### PR TITLE
[WEB-1111] add Crypto.org name mapping

### DIFF
--- a/src/Popup/hooks/SWR/cosmos/useAssetsSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useAssetsSWR.ts
@@ -4,6 +4,7 @@ import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
 import { CRESCENT } from '~/constants/chain/cosmos/crescent';
+import { CRYPTO_ORG } from '~/constants/chain/cosmos/cryptoOrg';
 import { EMONEY } from '~/constants/chain/cosmos/emoney';
 import { GRAVITY_BRIDGE } from '~/constants/chain/cosmos/gravityBridge';
 import { INJECTIVE } from '~/constants/chain/cosmos/injective';
@@ -22,6 +23,7 @@ const nameMap = {
   [CRESCENT.id]: 'crescent',
   [EMONEY.id]: 'emoney',
   [STAFIHUB.id]: 'stafi',
+  [CRYPTO_ORG.id]: 'crypto-org',
 };
 
 export function useAssetsSWR(chain?: CosmosChain, config?: SWRConfiguration) {


### PR DESCRIPTION
익스텐션에서 Crypto.org체인의 지갑의 asset이 로드가 안되는 현상을 발견하여 다음과 같이 코드를 작성했습니다.

- 해당 체인이 asset을 정상적으로 불러올 수 있도록 Crypto.org의 id를 name Mapping에 추가했습니다
- 
<img width="358" alt="스크린샷 2022-11-08 오후 4 48 29" src="https://user-images.githubusercontent.com/87967564/200505890-7917e327-38fe-4cf4-bd6c-8e745b78c895.png">
