### PR TITLE
[WEB-1113] 체인 에섯 로드 로직 수정(AssetMantle,Ki,Fetch.ai)

### DIFF
--- a/src/Popup/hooks/SWR/cosmos/useAssetsSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useAssetsSWR.ts
@@ -3,12 +3,15 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
+import { ASSET_MANTLE } from '~/constants/chain/cosmos/assetMantle';
 import { CRESCENT } from '~/constants/chain/cosmos/crescent';
 import { CRYPTO_ORG } from '~/constants/chain/cosmos/cryptoOrg';
 import { EMONEY } from '~/constants/chain/cosmos/emoney';
+import { FETCH_AI } from '~/constants/chain/cosmos/fetchAi';
 import { GRAVITY_BRIDGE } from '~/constants/chain/cosmos/gravityBridge';
 import { INJECTIVE } from '~/constants/chain/cosmos/injective';
 import { KAVA } from '~/constants/chain/cosmos/kava';
+import { KI } from '~/constants/chain/cosmos/ki';
 import { SIF } from '~/constants/chain/cosmos/sif';
 import { STAFIHUB } from '~/constants/chain/cosmos/stafihub';
 import { get } from '~/Popup/utils/axios';
@@ -24,6 +27,9 @@ const nameMap = {
   [EMONEY.id]: 'emoney',
   [STAFIHUB.id]: 'stafi',
   [CRYPTO_ORG.id]: 'crypto-org',
+  [KI.id]: 'ki-chain',
+  [ASSET_MANTLE.id]: 'asset-mantle',
+  [FETCH_AI.id]: 'fetchai',
 };
 
 export function useAssetsSWR(chain?: CosmosChain, config?: SWRConfiguration) {


### PR DESCRIPTION
AssetMantle,Ki,Fetch.ai 해당 세개의 체인 지갑에서 asset을 불러오지 못하는 현상을 발견하여 다음과 같이 코드를 수정했습니다
- 기존의 name mapping에 위 세개의 체인의 id를 추가했습니다.

### 확인하지 못한점
Asset Mantle, Ki 체인의 asset로드 여부는 확인했지만 Fetch.ai는 native외 확인된 ibc토큰이 없어 로드 여부를 확인하지 못했습니다

![스크린샷 2022-11-09 오전 11 26 05](https://user-images.githubusercontent.com/87967564/200722065-972721e6-d56a-4be4-b198-d3a7a0962263.png)
![스크린샷 2022-11-09 오전 11 25 55](https://user-images.githubusercontent.com/87967564/200722068-01a7f1c9-7230-489e-ae73-cc2b73bde6d6.png)
