### PR TITLE
[WEB-1131] 체인 활성화 여부 체크 제거

### DIFF
--- a/src/Popup/background/messageProcessor.ts
+++ b/src/Popup/background/messageProcessor.ts
@@ -221,7 +221,6 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
 
           if (
             chain.id &&
-            [...currentAllowedChains, ...additionalChains].map((item) => item.id).includes(chain.id) &&
             currentAccountAllowedOrigins.includes(origin) &&
             currentPassword &&
             (currentAccount.type !== 'LEDGER' || (currentAccount.type === 'LEDGER' && currentAccount.cosmosPublicKey))
@@ -344,12 +343,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
 
             const chain = getChain(chainName)!;
 
-            if (
-              chain.id &&
-              [...currentAllowedChains, ...additionalChains].map((item) => item.id).includes(chain.id) &&
-              currentAccountAllowedOrigins.includes(origin) &&
-              currentPassword
-            ) {
+            if (chain.id && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
               const currentTime = new Date().getTime();
               const autoSign = autoSigns.find(
                 (item) =>
@@ -396,12 +390,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
 
             const chain = getChain(chainName)!;
 
-            if (
-              chain.id &&
-              [...currentAllowedChains, ...additionalChains].map((item) => item.id).includes(chain.id) &&
-              currentAccountAllowedOrigins.includes(origin) &&
-              currentPassword
-            ) {
+            if (chain.id && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
               const newAutoSigns = autoSigns.filter((item) => !(item.accountId === currentAccount.id && item.chainId === chain.id && item.origin === origin));
 
               await setStorage('autoSigns', newAutoSigns);
@@ -453,13 +442,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
                 item.accountId === currentAccount.id && item.chainId === chain?.id && item.origin === origin && item.startTime + item.duration > currentTime,
             );
 
-            if (
-              chain?.id &&
-              [...currentAllowedChains, ...additionalChains].map((item) => item.id).includes(chain.id) &&
-              currentAccountAllowedOrigins.includes(origin) &&
-              currentPassword &&
-              isAutoSign
-            ) {
+            if (chain?.id && currentAccountAllowedOrigins.includes(origin) && currentPassword && isAutoSign) {
               const keyPair = getKeyPair(currentAccount, chain, currentPassword);
 
               if (!keyPair?.privateKey) {
@@ -524,13 +507,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
                 item.accountId === currentAccount.id && item.chainId === chain?.id && item.origin === origin && item.startTime + item.duration > currentTime,
             );
 
-            if (
-              chain?.id &&
-              [...currentAllowedChains, ...additionalChains].map((item) => item.id).includes(chain.id) &&
-              currentAccountAllowedOrigins.includes(origin) &&
-              currentPassword &&
-              isAutoSign
-            ) {
+            if (chain?.id && currentAccountAllowedOrigins.includes(origin) && currentPassword && isAutoSign) {
               const keyPair = getKeyPair(currentAccount, chain, currentPassword);
 
               if (!keyPair?.privateKey) {
@@ -736,12 +713,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
             throw new CosmosRPCError(RPC_ERROR.LEDGER_UNSUPPORTED_CHAIN, COSMOS_RPC_ERROR_MESSAGE[RPC_ERROR.LEDGER_UNSUPPORTED_CHAIN]);
           }
 
-          if (
-            chain?.id &&
-            [...currentAllowedChains, ...additionalChains].map((item) => item.id).includes(chain?.id) &&
-            currentAccountAllowedOrigins.includes(origin) &&
-            currentPassword
-          ) {
+          if (chain?.id && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
             const keyPair = getKeyPair(currentAccount, chain, currentPassword);
             const address = getAddress(chain, keyPair?.publicKey);
 
@@ -1019,7 +991,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
     const ethereumPopupMethods = Object.values(ETHEREUM_POPUP_METHOD_TYPE) as string[];
     const ethereumNoPopupMethods = Object.values(ETHEREUM_NO_POPUP_METHOD_TYPE) as string[];
 
-    const { additionalEthereumNetworks, currentEthereumNetwork, currentAccountAllowedOrigins, currentAllowedChains, currentAccount } = await chromeStorage();
+    const { additionalEthereumNetworks, currentEthereumNetwork, currentAccountAllowedOrigins, currentAccount } = await chromeStorage();
 
     const { currentPassword } = await chromeSessionStorage();
 
@@ -1041,7 +1013,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
           try {
             const validatedParams = (await schema.validateAsync(params)) as EthSign['params'];
 
-            if (currentAllowedChains.find((item) => item.id === chain.id) && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
+            if (currentAccountAllowedOrigins.includes(origin) && currentPassword) {
               const keyPair = getKeyPair(currentAccount, chain, currentPassword);
               const address = getAddress(chain, keyPair?.publicKey);
 
@@ -1074,7 +1046,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
           try {
             const validatedParams = (await schema.validateAsync(params)) as EthSignTypedData['params'];
 
-            if (currentAllowedChains.find((item) => item.id === chain.id) && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
+            if (currentAccountAllowedOrigins.includes(origin) && currentPassword) {
               const keyPair = getKeyPair(currentAccount, chain, currentPassword);
               const address = getAddress(chain, keyPair?.publicKey);
               if ((currentAccount.type === 'LEDGER' && currentAccount.ethereumPublicKey) || currentAccount.type !== 'LEDGER') {
@@ -1128,7 +1100,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
           try {
             const validatedParams = (await schema.validateAsync(params)) as PersonalSign['params'];
 
-            if (currentAllowedChains.find((item) => item.id === chain.id) && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
+            if (currentAccountAllowedOrigins.includes(origin) && currentPassword) {
               const keyPair = getKeyPair(currentAccount, chain, currentPassword);
               const address = getAddress(chain, keyPair?.publicKey);
 
@@ -1161,7 +1133,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
           try {
             const validatedParams = (await schema.validateAsync(params)) as EthSignTransaction['params'];
 
-            if (currentAllowedChains.find((item) => item.id === chain.id) && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
+            if (currentAccountAllowedOrigins.includes(origin) && currentPassword) {
               const keyPair = getKeyPair(currentAccount, chain, currentPassword);
 
               const address = getAddress(chain, keyPair?.publicKey);
@@ -1211,7 +1183,6 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
 
         if (method === 'eth_requestAccounts' || method === 'wallet_requestPermissions') {
           if (
-            currentAllowedChains.find((item) => item.id === chain.id) &&
             currentAccountAllowedOrigins.includes(origin) &&
             currentPassword &&
             (currentAccount.type !== 'LEDGER' || (currentAccount.type === 'LEDGER' && currentAccount.ethereumPublicKey))
@@ -1474,7 +1445,6 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
       } else if (ethereumNoPopupMethods.includes(method)) {
         if (method === 'eth_accounts') {
           if (
-            currentAllowedChains.find((item) => item.id === chain.id) &&
             currentAccountAllowedOrigins.includes(origin) &&
             currentPassword &&
             (currentAccount.type !== 'LEDGER' || (currentAccount.type === 'LEDGER' && currentAccount.ethereumPublicKey))
@@ -1505,7 +1475,6 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
           }
         } else if (method === 'eth_coinbase') {
           if (
-            currentAllowedChains.find((item) => item.id === chain.id) &&
             currentAccountAllowedOrigins.includes(origin) &&
             currentPassword &&
             (currentAccount.type !== 'LEDGER' || (currentAccount.type === 'LEDGER' && currentAccount.ethereumPublicKey))
@@ -1585,7 +1554,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
     const aptosPopupMethods = Object.values(APTOS_POPUP_METHOD_TYPE) as string[];
     const aptosNoPopupMethods = Object.values(APTOS_NO_POPUP_METHOD_TYPE) as string[];
 
-    const { currentAccountAllowedOrigins, currentAllowedChains, currentAccount, allowedOrigins, currentAptosNetwork } = await chromeStorage();
+    const { currentAccountAllowedOrigins, currentAccount, allowedOrigins, currentAptosNetwork } = await chromeStorage();
 
     const { currentPassword } = await chromeSessionStorage();
 
@@ -1604,7 +1573,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
 
       if (aptosPopupMethods.includes(method)) {
         if (method === 'aptos_connect' || method === 'aptos_account') {
-          if (currentAllowedChains.find((item) => item.id === chain.id) && currentAccountAllowedOrigins.includes(origin) && currentPassword) {
+          if (currentAccountAllowedOrigins.includes(origin) && currentPassword) {
             const keyPair = getKeyPair(currentAccount, chain, currentPassword);
             const address = getAddress(chain, keyPair?.publicKey);
 

--- a/src/Popup/pages/Popup/Aptos/SignMessage/index.tsx
+++ b/src/Popup/pages/Popup/Aptos/SignMessage/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,11 +16,9 @@ export default function SignMessage() {
       <Lock>
         <LedgerPublicKeyRequest>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} />
+            </Layout>
           </AccessRequest>
         </LedgerPublicKeyRequest>
       </Lock>

--- a/src/Popup/pages/Popup/Aptos/Transaction/index.tsx
+++ b/src/Popup/pages/Popup/Aptos/Transaction/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,11 +16,9 @@ export default function Transaction() {
       <Lock>
         <LedgerPublicKeyRequest>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} />
+            </Layout>
           </AccessRequest>
         </LedgerPublicKeyRequest>
       </Lock>

--- a/src/Popup/pages/Popup/Cosmos/AddTokens/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AddTokens/index.tsx
@@ -1,7 +1,6 @@
 import { COSMOS_CHAINS } from '~/constants/chain';
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentAdditionalChains } from '~/Popup/hooks/useCurrent/useCurrentAdditionalChains';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -15,17 +14,15 @@ export default function AddTokens() {
   const { currentCosmosAdditionalChains } = useCurrentAdditionalChains();
 
   if (currentQueue && isCosAddTokensCW20Internal(currentQueue)) {
-    const selecteChain = [...COSMOS_CHAINS, ...currentCosmosAdditionalChains].find((item) => item.chainName === currentQueue.message.params.chainName);
+    const selectedChain = [...COSMOS_CHAINS, ...currentCosmosAdditionalChains].find((item) => item.chainName === currentQueue.message.params.chainName);
 
-    if (selecteChain) {
+    if (selectedChain) {
       return (
         <Lock>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} chain={selecteChain} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} chain={selectedChain} />
+            </Layout>
           </AccessRequest>
         </Lock>
       );

--- a/src/Popup/pages/Popup/Cosmos/AutoSign/Delete/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AutoSign/Delete/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
 import type { CosDeleteAutoSign } from '~/types/message/cosmos';
@@ -15,11 +14,9 @@ export default function Delete() {
     return (
       <Lock>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry queue={currentQueue} />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry queue={currentQueue} />
+          </Layout>
         </AccessRequest>
       </Lock>
     );

--- a/src/Popup/pages/Popup/Cosmos/AutoSign/Get/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AutoSign/Get/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
 import type { CosGetAutoSign } from '~/types/message/cosmos';
@@ -15,11 +14,9 @@ export default function Get() {
     return (
       <Lock>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry queue={currentQueue} />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry queue={currentQueue} />
+          </Layout>
         </AccessRequest>
       </Lock>
     );

--- a/src/Popup/pages/Popup/Cosmos/AutoSign/Set/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AutoSign/Set/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
 import type { CosSetAutoSign } from '~/types/message/cosmos';
@@ -15,11 +14,9 @@ export default function Set() {
     return (
       <Lock>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry queue={currentQueue} />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry queue={currentQueue} />
+          </Layout>
         </AccessRequest>
       </Lock>
     );

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/index.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react';
 import { COSMOS_CHAINS } from '~/constants/chain';
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentAdditionalChains } from '~/Popup/hooks/useCurrent/useCurrentAdditionalChains';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
@@ -18,20 +17,18 @@ export default function AddChain() {
   const { currentCosmosAdditionalChains } = useCurrentAdditionalChains();
 
   if (currentQueue && isCosSignAmino(currentQueue)) {
-    const selecteChain = [...COSMOS_CHAINS, ...currentCosmosAdditionalChains].find((item) => item.chainName === currentQueue.message.params.chainName);
+    const selectedChain = [...COSMOS_CHAINS, ...currentCosmosAdditionalChains].find((item) => item.chainName === currentQueue.message.params.chainName);
 
-    if (selecteChain) {
+    if (selectedChain) {
       return (
         <Lock>
           <LedgerPublicKeyRequest>
             <AccessRequest>
-              <ActivateChainRequest>
-                <Layout>
-                  <Suspense fallback={null}>
-                    <Entry queue={currentQueue} chain={selecteChain} />
-                  </Suspense>
-                </Layout>
-              </ActivateChainRequest>
+              <Layout>
+                <Suspense fallback={null}>
+                  <Entry queue={currentQueue} chain={selectedChain} />
+                </Suspense>
+              </Layout>
             </AccessRequest>
           </LedgerPublicKeyRequest>
         </Lock>

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/index.tsx
@@ -3,7 +3,6 @@ import { Suspense } from 'react';
 import { COSMOS_CHAINS } from '~/constants/chain';
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentAdditionalChains } from '~/Popup/hooks/useCurrent/useCurrentAdditionalChains';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,7 +16,7 @@ export default function AddChain() {
   const { currentCosmosAdditionalChains } = useCurrentAdditionalChains();
 
   if (currentQueue && isCosSignDirect(currentQueue)) {
-    const selecteChain = [...COSMOS_CHAINS, ...currentCosmosAdditionalChains].find((item) => item.chainName === currentQueue.message.params.chainName);
+    const selectedChain = [...COSMOS_CHAINS, ...currentCosmosAdditionalChains].find((item) => item.chainName === currentQueue.message.params.chainName);
 
     const { message } = currentQueue;
     const { params } = message;
@@ -31,17 +30,15 @@ export default function AddChain() {
 
     const newCurrentQueue = { ...currentQueue, message: { ...message, params: { ...params, doc: newDoc } } };
 
-    if (selecteChain) {
+    if (selectedChain) {
       return (
         <Lock>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Suspense fallback={null}>
-                  <Entry queue={newCurrentQueue} chain={selecteChain} />
-                </Suspense>
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Suspense fallback={null}>
+                <Entry queue={newCurrentQueue} chain={selectedChain} />
+              </Suspense>
+            </Layout>
           </AccessRequest>
         </Lock>
       );

--- a/src/Popup/pages/Popup/Ethereum/AddNetwork/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/AddNetwork/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
 import type { EthcAddNetwork } from '~/types/message/ethereum';
@@ -15,11 +14,9 @@ export default function AddNetwork() {
     return (
       <Lock>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry queue={currentQueue} />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry queue={currentQueue} />
+          </Layout>
         </AccessRequest>
       </Lock>
     );

--- a/src/Popup/pages/Popup/Ethereum/AddTokens/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/AddTokens/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
 import type { EthcAddTokens } from '~/types/message/ethereum';
@@ -15,11 +14,9 @@ export default function AddTokens() {
     return (
       <Lock>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry queue={currentQueue} />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry queue={currentQueue} />
+          </Layout>
         </AccessRequest>
       </Lock>
     );

--- a/src/Popup/pages/Popup/Ethereum/PersonalSign/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/PersonalSign/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,11 +16,9 @@ export default function PersonalSign() {
       <Lock>
         <LedgerPublicKeyRequest>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} />
+            </Layout>
           </AccessRequest>
         </LedgerPublicKeyRequest>
       </Lock>

--- a/src/Popup/pages/Popup/Ethereum/Sign/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Sign/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,11 +16,9 @@ export default function Sign() {
       <Lock>
         <LedgerPublicKeyRequest>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} />
+            </Layout>
           </AccessRequest>
         </LedgerPublicKeyRequest>
       </Lock>

--- a/src/Popup/pages/Popup/Ethereum/SignTypedData/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/SignTypedData/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,11 +16,9 @@ export default function SignTypedData() {
       <Lock>
         <LedgerPublicKeyRequest>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} />
+            </Layout>
           </AccessRequest>
         </LedgerPublicKeyRequest>
       </Lock>

--- a/src/Popup/pages/Popup/Ethereum/SwitchNetwork/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/SwitchNetwork/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
 import type { EthcSwitchNetwork } from '~/types/message/ethereum';
@@ -15,11 +14,9 @@ export default function SwitchNetwork() {
     return (
       <Lock>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry queue={currentQueue} />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry queue={currentQueue} />
+          </Layout>
         </AccessRequest>
       </Lock>
     );

--- a/src/Popup/pages/Popup/Ethereum/Transaction/index.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import type { Queue } from '~/types/chromeStorage';
@@ -17,11 +16,9 @@ export default function Transaction() {
       <Lock>
         <LedgerPublicKeyRequest>
           <AccessRequest>
-            <ActivateChainRequest>
-              <Layout>
-                <Entry queue={currentQueue} />
-              </Layout>
-            </ActivateChainRequest>
+            <Layout>
+              <Entry queue={currentQueue} />
+            </Layout>
           </AccessRequest>
         </LedgerPublicKeyRequest>
       </Lock>

--- a/src/Popup/pages/Popup/RequestAccount/index.tsx
+++ b/src/Popup/pages/Popup/RequestAccount/index.tsx
@@ -1,6 +1,5 @@
 import Lock from '~/Popup/components/Lock';
 import AccessRequest from '~/Popup/components/requests/AccessRequest';
-import ActivateChainRequest from '~/Popup/components/requests/ActivateChainRequest';
 import LedgerPublicKeyRequest from '~/Popup/components/requests/LedgerPublicKeyRequest';
 
 import Entry from './entry';
@@ -11,11 +10,9 @@ export default function RequestAccount() {
     <Lock>
       <LedgerPublicKeyRequest>
         <AccessRequest>
-          <ActivateChainRequest>
-            <Layout>
-              <Entry />
-            </Layout>
-          </ActivateChainRequest>
+          <Layout>
+            <Entry />
+          </Layout>
         </AccessRequest>
       </LedgerPublicKeyRequest>
     </Lock>


### PR DESCRIPTION
account 요청이 한꺼번에 들어오면 요청이 들어온 모든 체인에 대한 활성화 confirm 해줘야 한다.

체인 활성화는 익스텐션 내의 기능으로만 사용하고 dapp 요청에서는 체인 활성화의 여부를 체크하지 않도록 변경