### PR TITLE
[WEB-1315] 내 주소 버튼 hover사이즈 줄이기 & 모든 체인에 내 주소 버튼 추가 & Sui send페이지 오류수정

### DIFF
--- a/src/Popup/components/AccountAddressBookBottomSheet/index.tsx
+++ b/src/Popup/components/AccountAddressBookBottomSheet/index.tsx
@@ -5,20 +5,22 @@ import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useChromeStorage } from '~/Popup/hooks/useChromeStorage';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
-import type { CosmosChain } from '~/types/chain';
+import type { CommonChain, EthereumNetwork } from '~/types/chain';
 
 import { AddressList, Container, Header, HeaderTitle, StyledBottomSheet } from './styled';
 import AccountAddressBookItem from '../AccountAddressBookItem';
 
 type AccountAddressBookBottomSheetProps = Omit<React.ComponentProps<typeof StyledBottomSheet>, 'children'> & {
   onClickAddress?: (address: string) => void;
-  chain?: CosmosChain;
+  chain?: CommonChain;
+  token?: EthereumNetwork;
   hasCurrentAccount?: boolean;
 };
 
 export default function AccountAddressBookBottomSheet({
   hasCurrentAccount = true,
   chain,
+  token,
   onClickAddress,
   onClose,
   ...remainder
@@ -53,6 +55,7 @@ export default function AccountAddressBookBottomSheet({
               accountName={accountName[item.id]}
               address={chain ? item.address[chain.id] : ''}
               chain={chain}
+              token={token}
               onClick={(address) => {
                 onClickAddress?.(address);
                 onClose?.({}, 'backdropClick');

--- a/src/Popup/components/AccountAddressBookBottomSheet/index.tsx
+++ b/src/Popup/components/AccountAddressBookBottomSheet/index.tsx
@@ -5,7 +5,7 @@ import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useChromeStorage } from '~/Popup/hooks/useChromeStorage';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
-import type { CommonChain, EthereumNetwork } from '~/types/chain';
+import type { CommonChain } from '~/types/chain';
 
 import { AddressList, Container, Header, HeaderTitle, StyledBottomSheet } from './styled';
 import AccountAddressBookItem from '../AccountAddressBookItem';
@@ -13,14 +13,12 @@ import AccountAddressBookItem from '../AccountAddressBookItem';
 type AccountAddressBookBottomSheetProps = Omit<React.ComponentProps<typeof StyledBottomSheet>, 'children'> & {
   onClickAddress?: (address: string) => void;
   chain?: CommonChain;
-  token?: EthereumNetwork;
   hasCurrentAccount?: boolean;
 };
 
 export default function AccountAddressBookBottomSheet({
   hasCurrentAccount = true,
   chain,
-  token,
   onClickAddress,
   onClose,
   ...remainder
@@ -55,7 +53,6 @@ export default function AccountAddressBookBottomSheet({
               accountName={accountName[item.id]}
               address={chain ? item.address[chain.id] : ''}
               chain={chain}
-              token={token}
               onClick={(address) => {
                 onClickAddress?.(address);
                 onClose?.({}, 'backdropClick');

--- a/src/Popup/components/AccountAddressBookBottomSheet/index.tsx
+++ b/src/Popup/components/AccountAddressBookBottomSheet/index.tsx
@@ -52,7 +52,7 @@ export default function AccountAddressBookBottomSheet({
               key={item.id}
               accountName={accountName[item.id]}
               address={chain ? item.address[chain.id] : ''}
-              chain={chain}
+              accountId={item.id}
               onClick={(address) => {
                 onClickAddress?.(address);
                 onClose?.({}, 'backdropClick');

--- a/src/Popup/components/AccountAddressBookItem/index.tsx
+++ b/src/Popup/components/AccountAddressBookItem/index.tsx
@@ -2,24 +2,23 @@ import { Typography } from '@mui/material';
 
 import Tooltip from '~/Popup/components/common/Tooltip';
 import { shorterAddress } from '~/Popup/utils/string';
-import type { CommonChain, EthereumNetwork } from '~/types/chain';
+import type { CommonChain } from '~/types/chain';
 
 import { AddressContainer, Container, LabelContainer, LabelLeftContainer, StyledImage } from './styled';
 
 type AccountAddressBookItemProps = {
   accountName: string;
   chain?: CommonChain;
-  token?: EthereumNetwork;
   address: string;
   onClick?: (address: string) => void;
 };
 
-export default function AccountAddressBookItem({ onClick, address, chain, token, accountName }: AccountAddressBookItemProps) {
+export default function AccountAddressBookItem({ onClick, address, chain, accountName }: AccountAddressBookItemProps) {
   return (
     <Container onClick={() => onClick?.(address)} data-is-onclick={onClick ? 1 : 0}>
       <LabelContainer>
         <LabelLeftContainer>
-          <StyledImage src={token?.imageURL ?? chain?.imageURL} />
+          <StyledImage src={chain?.imageURL} />
           <Typography variant="h6">{accountName}</Typography>
         </LabelLeftContainer>
       </LabelContainer>

--- a/src/Popup/components/AccountAddressBookItem/index.tsx
+++ b/src/Popup/components/AccountAddressBookItem/index.tsx
@@ -1,24 +1,30 @@
+import stc from 'string-to-color';
 import { Typography } from '@mui/material';
 
 import Tooltip from '~/Popup/components/common/Tooltip';
 import { shorterAddress } from '~/Popup/utils/string';
-import type { CommonChain } from '~/types/chain';
 
-import { AddressContainer, Container, LabelContainer, LabelLeftContainer, StyledImage } from './styled';
+import { AccountIconContainer, AddressContainer, Container, LabelContainer, LabelLeftContainer } from './styled';
+
+import Account10Icon from '~/images/icons/Account10.svg';
 
 type AccountAddressBookItemProps = {
   accountName: string;
-  chain?: CommonChain;
   address: string;
+  accountId: string;
   onClick?: (address: string) => void;
 };
 
-export default function AccountAddressBookItem({ onClick, address, chain, accountName }: AccountAddressBookItemProps) {
+export default function AccountAddressBookItem({ onClick, address, accountName, accountId }: AccountAddressBookItemProps) {
+  const accountColor = stc(accountId);
+
   return (
     <Container onClick={() => onClick?.(address)} data-is-onclick={onClick ? 1 : 0}>
       <LabelContainer>
         <LabelLeftContainer>
-          <StyledImage src={chain?.imageURL} />
+          <AccountIconContainer data-account-color={accountColor}>
+            <Account10Icon />
+          </AccountIconContainer>
           <Typography variant="h6">{accountName}</Typography>
         </LabelLeftContainer>
       </LabelContainer>

--- a/src/Popup/components/AccountAddressBookItem/index.tsx
+++ b/src/Popup/components/AccountAddressBookItem/index.tsx
@@ -2,23 +2,24 @@ import { Typography } from '@mui/material';
 
 import Tooltip from '~/Popup/components/common/Tooltip';
 import { shorterAddress } from '~/Popup/utils/string';
-import type { Chain } from '~/types/chain';
+import type { CommonChain, EthereumNetwork } from '~/types/chain';
 
 import { AddressContainer, Container, LabelContainer, LabelLeftContainer, StyledImage } from './styled';
 
 type AccountAddressBookItemProps = {
   accountName: string;
-  chain?: Chain;
+  chain?: CommonChain;
+  token?: EthereumNetwork;
   address: string;
   onClick?: (address: string) => void;
 };
 
-export default function AccountAddressBookItem({ onClick, address, chain, accountName }: AccountAddressBookItemProps) {
+export default function AccountAddressBookItem({ onClick, address, chain, token, accountName }: AccountAddressBookItemProps) {
   return (
     <Container onClick={() => onClick?.(address)} data-is-onclick={onClick ? 1 : 0}>
       <LabelContainer>
         <LabelLeftContainer>
-          <StyledImage src={chain?.imageURL} />
+          <StyledImage src={token?.imageURL ?? chain?.imageURL} />
           <Typography variant="h6">{accountName}</Typography>
         </LabelLeftContainer>
       </LabelContainer>

--- a/src/Popup/components/AccountAddressBookItem/styled.tsx
+++ b/src/Popup/components/AccountAddressBookItem/styled.tsx
@@ -1,7 +1,5 @@
 import { styled } from '@mui/material/styles';
 
-import Image from '~/Popup/components/common/Image';
-
 type ContainerProps = {
   'data-is-onclick': number;
 };
@@ -30,12 +28,39 @@ export const LabelLeftContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 }));
 
-export const StyledImage = styled(Image)({
-  width: '2rem',
+type AccountIconContainerProps = {
+  'data-account-color'?: string;
+};
+
+export const AccountIconContainer = styled('div')<AccountIconContainerProps>(({ theme, ...props }) => ({
   height: '2rem',
+  width: '2rem',
+
+  borderRadius: '50%',
+
+  backgroundColor: props['data-account-color'] ? `${props['data-account-color']}66` : theme.colors.base03,
+  color: theme.accentColors.white,
+
+  padding: 0,
+
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
 
   marginRight: '0.8rem',
-});
+
+  '& > svg': {
+    fill: theme.colors.base06,
+
+    '& > path': {
+      fill: theme.colors.base06,
+    },
+
+    '& > circle': {
+      fill: theme.colors.base06,
+    },
+  },
+}));
 
 export const AddressContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,

--- a/src/Popup/components/InputAdornmentIconButton/index.tsx
+++ b/src/Popup/components/InputAdornmentIconButton/index.tsx
@@ -1,0 +1,7 @@
+import type { IconButtonProps } from '@mui/material';
+
+import { StyledIconButton } from './styled';
+
+export default function InputAdornmentIconButton({ ...remainder }: IconButtonProps) {
+  return <StyledIconButton type="button" {...remainder} />;
+}

--- a/src/Popup/components/InputAdornmentIconButton/styled.tsx
+++ b/src/Popup/components/InputAdornmentIconButton/styled.tsx
@@ -1,0 +1,9 @@
+import { styled } from '@mui/material/styles';
+
+import IconButton from '../common/IconButton';
+
+export const StyledIconButton = styled(IconButton)({
+  '&.MuiIconButton-root': {
+    padding: '0.4rem',
+  },
+});

--- a/src/Popup/hooks/SWR/sui/useGetObjectsSWR.ts
+++ b/src/Popup/hooks/SWR/sui/useGetObjectsSWR.ts
@@ -31,7 +31,7 @@ export function useGetObjectsSWR({ network, objectIds }: UseGetObjectsOwnedByAdd
   }));
 
   const fetcher = (params: FetchParams) => {
-    if (!params.payload.length) {
+    if (params.payload && !params.payload.length) {
       return null;
     }
 

--- a/src/Popup/pages/Wallet/Send/Entry/Aptos/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Aptos/index.tsx
@@ -2,10 +2,11 @@ import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { InputAdornment, Typography } from '@mui/material';
 
+import AccountAddressBookBottomSheet from '~/Popup/components/AccountAddressBookBottomSheet';
 import AddressBookBottomSheet from '~/Popup/components/AddressBookBottomSheet';
 import Button from '~/Popup/components/common/Button';
-import IconButton from '~/Popup/components/common/IconButton';
 import Tooltip from '~/Popup/components/common/Tooltip';
+import InputAdornmentIconButton from '~/Popup/components/InputAdornmentIconButton';
 import { useAccountResourceSWR } from '~/Popup/hooks/SWR/aptos/useAccountResourceSWR';
 import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
@@ -22,6 +23,7 @@ import CoinButton from './components/CoinButton';
 import CoinPopover from './components/CoinPopover';
 import { BottomContainer, Container, Div, MaxButton, StyledInput } from './styled';
 
+import AccountAddressIcon from '~/images/icons/AccountAddress.svg';
 import AddressBook24Icon from '~/images/icons/AddressBook24.svg';
 
 type AptosProps = {
@@ -53,6 +55,7 @@ export default function Aptos({ chain }: AptosProps) {
   const [currentAddress, setCurrentAddress] = useState('');
 
   const [isOpenedAddressBook, setIsOpenedAddressBook] = useState(false);
+  const [isOpenedMyAddressBook, setIsOpenedMyAddressBook] = useState(false);
 
   const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLButtonElement | null>(null);
   const isOpenPopover = Boolean(popoverAnchorEl);
@@ -97,11 +100,18 @@ export default function Aptos({ chain }: AptosProps) {
         <Div>
           <StyledInput
             endAdornment={
-              <InputAdornment position="end">
-                <IconButton edge="end" onClick={() => setIsOpenedAddressBook(true)}>
-                  <AddressBook24Icon />
-                </IconButton>
-              </InputAdornment>
+              <>
+                <InputAdornment position="end">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedMyAddressBook(true)}>
+                    <AccountAddressIcon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+                <InputAdornment position="start">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
+                    <AddressBook24Icon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+              </>
             }
             placeholder={t('pages.Wallet.Send.Entry.Aptos.index.recipientAddressPlaceholder')}
             onChange={(e) => setCurrentAddress(e.currentTarget.value)}
@@ -201,6 +211,16 @@ export default function Aptos({ chain }: AptosProps) {
           onClose={() => setIsOpenedAddressBook(false)}
           onClickAddress={(a) => {
             setCurrentAddress(a.address);
+          }}
+        />
+
+        <AccountAddressBookBottomSheet
+          open={isOpenedMyAddressBook}
+          hasCurrentAccount={false}
+          chain={chain}
+          onClose={() => setIsOpenedMyAddressBook(false)}
+          onClickAddress={(a) => {
+            setCurrentAddress(a);
           }}
         />
       </Container>

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -9,9 +9,9 @@ import AccountAddressBookBottomSheet from '~/Popup/components/AccountAddressBook
 import AddressBookBottomSheet from '~/Popup/components/AddressBookBottomSheet';
 import Button from '~/Popup/components/common/Button';
 import DropdownButton from '~/Popup/components/common/DropdownButton';
-import IconButton from '~/Popup/components/common/IconButton';
 import Tooltip from '~/Popup/components/common/Tooltip';
 import Fee from '~/Popup/components/Fee';
+import InputAdornmentIconButton from '~/Popup/components/InputAdornmentIconButton';
 import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useAccountSWR } from '~/Popup/hooks/SWR/cosmos/useAccountSWR';
 import { useAmountSWR } from '~/Popup/hooks/SWR/cosmos/useAmountSWR';
@@ -516,14 +516,18 @@ export default function IBCSend({ chain }: IBCSendProps) {
         <MarginTop8Div>
           <StyledInput
             endAdornment={
-              <InputAdornment position="end">
-                <IconButton onClick={() => setIsOpenedMyAddressBook(true)} edge="end">
-                  <AccountAddressIcon />
-                </IconButton>
-                <IconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
-                  <AddressBook24Icon />
-                </IconButton>
-              </InputAdornment>
+              <>
+                <InputAdornment position="end">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedMyAddressBook(true)}>
+                    <AccountAddressIcon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+                <InputAdornment position="start">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
+                    <AddressBook24Icon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+              </>
             }
             placeholder={t('pages.Wallet.Send.Entry.Cosmos.components.IBCSend.index.recipientAddressPlaceholder')}
             onChange={(e) => setCurrentAddress(e.currentTarget.value)}

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
@@ -9,9 +9,9 @@ import AccountAddressBookBottomSheet from '~/Popup/components/AccountAddressBook
 import AddressBookBottomSheet from '~/Popup/components/AddressBookBottomSheet';
 import Button from '~/Popup/components/common/Button';
 import DropdownButton from '~/Popup/components/common/DropdownButton';
-import IconButton from '~/Popup/components/common/IconButton';
 import Tooltip from '~/Popup/components/common/Tooltip';
 import Fee from '~/Popup/components/Fee';
+import InputAdornmentIconButton from '~/Popup/components/InputAdornmentIconButton';
 import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useAccountSWR } from '~/Popup/hooks/SWR/cosmos/useAccountSWR';
 import { useAmountSWR } from '~/Popup/hooks/SWR/cosmos/useAmountSWR';
@@ -379,14 +379,18 @@ export default function Send({ chain }: CosmosProps) {
       <div>
         <StyledInput
           endAdornment={
-            <InputAdornment position="end">
-              <IconButton onClick={() => setIsOpenedMyAddressBook(true)} edge="end">
-                <AccountAddressIcon />
-              </IconButton>
-              <IconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
-                <AddressBook24Icon />
-              </IconButton>
-            </InputAdornment>
+            <>
+              <InputAdornment position="end">
+                <InputAdornmentIconButton onClick={() => setIsOpenedMyAddressBook(true)}>
+                  <AccountAddressIcon />
+                </InputAdornmentIconButton>
+              </InputAdornment>
+              <InputAdornment position="start">
+                <InputAdornmentIconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
+                  <AddressBook24Icon />
+                </InputAdornmentIconButton>
+              </InputAdornment>
+            </>
           }
           placeholder={t('pages.Wallet.Send.Entry.Cosmos.components.Send.index.recipientAddressPlaceholder')}
           onChange={(e) => setCurrentAddress(e.currentTarget.value)}

--- a/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
@@ -281,7 +281,6 @@ export default function Ethereum({ chain }: EthereumProps) {
           open={isOpenedMyAddressBook}
           hasCurrentAccount={false}
           chain={chain}
-          token={currentEthereumNetwork}
           onClose={() => setIsOpenedMyAddressBook(false)}
           onClickAddress={(a) => {
             setCurrentAddress(a);

--- a/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
@@ -6,10 +6,11 @@ import type { AbiItem } from 'web3-utils';
 import { InputAdornment, Typography } from '@mui/material';
 
 import { ERC20_ABI } from '~/constants/abi';
+import AccountAddressBookBottomSheet from '~/Popup/components/AccountAddressBookBottomSheet';
 import AddressBookBottomSheet from '~/Popup/components/AddressBookBottomSheet';
 import Button from '~/Popup/components/common/Button';
-import IconButton from '~/Popup/components/common/IconButton';
 import Tooltip from '~/Popup/components/common/Tooltip';
+import InputAdornmentIconButton from '~/Popup/components/InputAdornmentIconButton';
 import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useBalanceSWR } from '~/Popup/hooks/SWR/ethereum/useBalanceSWR';
 import { useEstimateGasSWR } from '~/Popup/hooks/SWR/ethereum/useEstimateGasSWR';
@@ -32,6 +33,7 @@ import CoinButton from './components/CoinButton';
 import CoinPopover from './components/CoinPopover';
 import { BottomContainer, Container, Div, MaxButton, StyledInput } from './styled';
 
+import AccountAddressIcon from '~/images/icons/AccountAddress.svg';
 import AddressBook24Icon from '~/images/icons/AddressBook24.svg';
 
 type EthereumProps = {
@@ -62,6 +64,7 @@ export default function Ethereum({ chain }: EthereumProps) {
   const [currentAddress, setCurrentAddress] = useState('');
 
   const [isOpenedAddressBook, setIsOpenedAddressBook] = useState(false);
+  const [isOpenedMyAddressBook, setIsOpenedMyAddressBook] = useState(false);
 
   const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLButtonElement | null>(null);
   const isOpenPopover = Boolean(popoverAnchorEl);
@@ -180,11 +183,18 @@ export default function Ethereum({ chain }: EthereumProps) {
         <Div>
           <StyledInput
             endAdornment={
-              <InputAdornment position="end">
-                <IconButton edge="end" onClick={() => setIsOpenedAddressBook(true)}>
-                  <AddressBook24Icon />
-                </IconButton>
-              </InputAdornment>
+              <>
+                <InputAdornment position="end">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedMyAddressBook(true)}>
+                    <AccountAddressIcon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+                <InputAdornment position="start">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
+                    <AddressBook24Icon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+              </>
             }
             placeholder={t('pages.Wallet.Send.Entry.Ethereum.index.recipientAddressPlaceholder')}
             onChange={(e) => setCurrentAddress(e.currentTarget.value)}
@@ -264,6 +274,17 @@ export default function Ethereum({ chain }: EthereumProps) {
           onClose={() => setIsOpenedAddressBook(false)}
           onClickAddress={(a) => {
             setCurrentAddress(a.address);
+          }}
+        />
+
+        <AccountAddressBookBottomSheet
+          open={isOpenedMyAddressBook}
+          hasCurrentAccount={false}
+          chain={chain}
+          token={currentEthereumNetwork}
+          onClose={() => setIsOpenedMyAddressBook(false)}
+          onClickAddress={(a) => {
+            setCurrentAddress(a);
           }}
         />
       </Container>

--- a/src/Popup/pages/Wallet/Send/Entry/Sui/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Sui/index.tsx
@@ -6,10 +6,11 @@ import type { UnserializedSignableTransaction } from '@mysten/sui.js';
 import { Ed25519Keypair, JsonRpcProvider, RawSigner } from '@mysten/sui.js';
 
 import { SUI_COIN } from '~/constants/sui';
+import AccountAddressBookBottomSheet from '~/Popup/components/AccountAddressBookBottomSheet';
 import AddressBookBottomSheet from '~/Popup/components/AddressBookBottomSheet';
 import Button from '~/Popup/components/common/Button';
-import IconButton from '~/Popup/components/common/IconButton';
 import Tooltip from '~/Popup/components/common/Tooltip';
+import InputAdornmentIconButton from '~/Popup/components/InputAdornmentIconButton';
 import { useAccounts } from '~/Popup/hooks/SWR/cache/useAccounts';
 import { useDryRunTransactionSWR } from '~/Popup/hooks/SWR/sui/useDryRunTransactionSWR';
 import { useGetCoinMetadataSWR } from '~/Popup/hooks/SWR/sui/useGetCoinMetadataSWR';
@@ -30,6 +31,7 @@ import CoinButton from './components/CoinButton';
 import CoinPopover from './components/CoinPopover';
 import { BottomContainer, Container, Div, MaxButton, StyledInput } from './styled';
 
+import AccountAddressIcon from '~/images/icons/AccountAddress.svg';
 import AddressBook24Icon from '~/images/icons/AddressBook24.svg';
 
 type SuiProps = {
@@ -84,6 +86,7 @@ export default function Sui({ chain }: SuiProps) {
   const [currentAddress, setCurrentAddress] = useState('');
 
   const [isOpenedAddressBook, setIsOpenedAddressBook] = useState(false);
+  const [isOpenedMyAddressBook, setIsOpenedMyAddressBook] = useState(false);
 
   const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLButtonElement | null>(null);
   const isOpenPopover = Boolean(popoverAnchorEl);
@@ -208,11 +211,18 @@ export default function Sui({ chain }: SuiProps) {
         <Div>
           <StyledInput
             endAdornment={
-              <InputAdornment position="end">
-                <IconButton edge="end" onClick={() => setIsOpenedAddressBook(true)}>
-                  <AddressBook24Icon />
-                </IconButton>
-              </InputAdornment>
+              <>
+                <InputAdornment position="end">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedMyAddressBook(true)}>
+                    <AccountAddressIcon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+                <InputAdornment position="start">
+                  <InputAdornmentIconButton onClick={() => setIsOpenedAddressBook(true)} edge="end">
+                    <AddressBook24Icon />
+                  </InputAdornmentIconButton>
+                </InputAdornment>
+              </>
             }
             placeholder={t('pages.Wallet.Send.Entry.Sui.index.recipientAddressPlaceholder')}
             onChange={(e) => setCurrentAddress(e.currentTarget.value)}
@@ -287,6 +297,16 @@ export default function Sui({ chain }: SuiProps) {
           onClose={() => setIsOpenedAddressBook(false)}
           onClickAddress={(a) => {
             setCurrentAddress(a.address);
+          }}
+        />
+
+        <AccountAddressBookBottomSheet
+          open={isOpenedMyAddressBook}
+          hasCurrentAccount={false}
+          chain={chain}
+          onClose={() => setIsOpenedMyAddressBook(false)}
+          onClickAddress={(a) => {
+            setCurrentAddress(a);
           }}
         />
       </Container>


### PR DESCRIPTION
- 내 계정 내 주소, 등록한 주소록을 볼 수 있는 버튼의 hover, active 사이즈를 줄였습니다.

![스크린샷 2023-02-01 오후 3 22 31](https://user-images.githubusercontent.com/87967564/215967513-d8a5dfaf-3176-4f9a-ac67-bb58d3f56475.png)

- 이더리움, 앱토스, 수이 체인에서 send시 전체 계정, 주소록을 확인할 수 있는 버튼을 추가했습니다.

![스크린샷 2023-02-01 오후 3 24 44](https://user-images.githubusercontent.com/87967564/215967576-2eda3ad9-88c9-4161-8a5e-a7ae40358f16.png)

- Sui send 페이지에서 사용되는 훅에서 오류가 발생해 해당 훅의 코드를 수정했습니다.