### PR TITLE
[WEB-1328] 커스텀 가스 입력 오류 수정

### DIFF
--- a/src/Popup/components/Fee/components/GasSettingDialog/useSchema.ts
+++ b/src/Popup/components/Fee/components/GasSettingDialog/useSchema.ts
@@ -10,7 +10,7 @@ export function useSchema() {
   const gasForm = Joi.object<GasForm>({
     gas: Joi.number()
       .required()
-      .min(0)
+      .min(1)
       .messages({
         'any.required': t('schema.common.any.required'),
         'number.base': t('schema.common.number.base'),


### PR DESCRIPTION
커스텀 가스값 입력 시 0이 입력되면 fee 계산 로직에서 발생하는 오류를 방지하고자 1 이상의 값만 입력되도록 스키마를 수정했습니다.
<img width="478" alt="스크린샷 2023-02-06 오전 11 55 08" src="https://user-images.githubusercontent.com/87967564/216873200-cbb0d943-bbc4-480f-863a-8768cc9e3945.png">
