### PR TITLE
[WEB-1396] Sui / Aptos 검색 시 testnet, devnet 노출

### DIFF
--- a/src/Popup/pages/Chain/Management/Use/entry.tsx
+++ b/src/Popup/pages/Chain/Management/Use/entry.tsx
@@ -78,15 +78,21 @@ export default function Entry() {
       : ETHEREUM_NETWORKS;
   }, [debouncedCloseSearch, debouncedOpenSearch]);
 
-  const filteredAptosNetworks = useMemo(
-    () => (APTOS.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : []),
-    [debouncedOpenSearch],
-  );
+  const filteredAptosNetworks = useMemo(() => {
+    if (debouncedOpenSearch) {
+      return APTOS.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : [];
+    }
 
-  const filteredSuiNetworks = useMemo(
-    () => (SUI.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? SUI_NETWORKS : []),
-    [debouncedOpenSearch],
-  );
+    return debouncedCloseSearch ? (APTOS.chainName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : []) : [];
+  }, [debouncedCloseSearch, debouncedOpenSearch]);
+
+  const filteredSuiNetworks = useMemo(() => {
+    if (debouncedOpenSearch) {
+      return SUI.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? SUI_NETWORKS : [];
+    }
+
+    return debouncedCloseSearch ? (SUI.chainName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1 ? SUI_NETWORKS : []) : [];
+  }, [debouncedCloseSearch, debouncedOpenSearch]);
 
   const filteredCosmosChains = useMemo(() => {
     if (debouncedOpenSearch) {

--- a/src/Popup/pages/Chain/Management/Use/entry.tsx
+++ b/src/Popup/pages/Chain/Management/Use/entry.tsx
@@ -78,25 +78,15 @@ export default function Entry() {
       : ETHEREUM_NETWORKS;
   }, [debouncedCloseSearch, debouncedOpenSearch]);
 
-  const filteredAptosNetworks = useMemo(() => {
-    if (debouncedOpenSearch) {
-      return APTOS_NETWORKS.filter((network) => network.networkName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1);
-    }
+  const filteredAptosNetworks = useMemo(
+    () => (APTOS.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : []),
+    [debouncedOpenSearch],
+  );
 
-    return debouncedCloseSearch
-      ? APTOS_NETWORKS.filter((network) => network.networkName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1)
-      : APTOS_NETWORKS;
-  }, [debouncedOpenSearch, debouncedCloseSearch]);
-
-  const filteredSuiNetworks = useMemo(() => {
-    if (debouncedOpenSearch) {
-      return SUI_NETWORKS.filter((network) => network.networkName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1);
-    }
-
-    return debouncedCloseSearch
-      ? SUI_NETWORKS.filter((network) => network.networkName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1)
-      : SUI_NETWORKS;
-  }, [debouncedOpenSearch, debouncedCloseSearch]);
+  const filteredSuiNetworks = useMemo(
+    () => (SUI.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? SUI_NETWORKS : []),
+    [debouncedOpenSearch],
+  );
 
   const filteredCosmosChains = useMemo(() => {
     if (debouncedOpenSearch) {


### PR DESCRIPTION
체인 관리 페이지에서 'aptos', 'sui' 키워드 검색시 해당하는 네트워크의 아이템을 모두 노출시키도록 필터링 로직을 수정했습니다.
<img width="468" alt="스크린샷 2023-02-09 오후 10 03 53" src="https://user-images.githubusercontent.com/87967564/217820521-28a9f2f7-7c22-4d84-8dba-4e91faed88ab.png">
<img width="493" alt="스크린샷 2023-02-09 오후 10 03 42" src="https://user-images.githubusercontent.com/87967564/217820530-6f626c4d-6955-4d85-bd58-f22f3800946f.png">
