### PR TITLE
[WEB-1410] 체인 관리 페이지 sui,aptos 미노출 오류 수정

### DIFF
--- a/src/Popup/pages/Chain/Management/Use/entry.tsx
+++ b/src/Popup/pages/Chain/Management/Use/entry.tsx
@@ -83,7 +83,7 @@ export default function Entry() {
       return APTOS.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : [];
     }
 
-    return debouncedCloseSearch ? (APTOS.chainName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : []) : [];
+    return debouncedCloseSearch ? (APTOS.chainName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1 ? APTOS_NETWORKS : []) : APTOS_NETWORKS;
   }, [debouncedCloseSearch, debouncedOpenSearch]);
 
   const filteredSuiNetworks = useMemo(() => {
@@ -91,7 +91,7 @@ export default function Entry() {
       return SUI.chainName.toLowerCase().indexOf(debouncedOpenSearch.toLowerCase()) > -1 ? SUI_NETWORKS : [];
     }
 
-    return debouncedCloseSearch ? (SUI.chainName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1 ? SUI_NETWORKS : []) : [];
+    return debouncedCloseSearch ? (SUI.chainName.toLowerCase().indexOf(debouncedCloseSearch.toLowerCase()) > -1 ? SUI_NETWORKS : []) : SUI_NETWORKS;
   }, [debouncedCloseSearch, debouncedOpenSearch]);
 
   const filteredCosmosChains = useMemo(() => {


### PR DESCRIPTION
체인 관리 페이지에서 aptos,sui를 검색하지 않을 시 해당 체인의 아이템이 없는 것으로 나오는 오류를 수정했습니다.

<img width="440" alt="스크린샷 2023-02-13 오후 5 45 16" src="https://user-images.githubusercontent.com/87967564/218411352-c4584a78-d9da-4ec6-a31b-41631084b848.png">
<img width="452" alt="스크린샷 2023-02-13 오후 5 45 07" src="https://user-images.githubusercontent.com/87967564/218411358-c69a8c0c-4697-4ea8-a101-8404a2ee4a46.png">

