### PR TITLE
[Extension] Change sign mode to Direct in Claim Commission tx on Evmos(cosmos)

### DIFF
--- a/i18next-scanner.config.js
+++ b/i18next-scanner.config.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const chalk = require('chalk');
 
 module.exports = {
   input: [
@@ -60,7 +59,7 @@ module.exports = {
     });
 
     if (count > 0) {
-      console.log(`i18next-scanner: count=${chalk.cyan(count)}, file=${chalk.yellow(JSON.stringify(file.relative))}`);
+      console.log(`i18next-scanner: count=${count}, file=${JSON.stringify(file.relative)}`);
     }
 
     done();

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -697,6 +697,12 @@
             "components": {
               "TxMessage": {
                 "messages": {
+                  "Commission": {
+                    "index": {
+                      "title": "Claim Commission",
+                      "validatorAddress": "Validator address"
+                    }
+                  },
                   "Send": {
                     "index": {
                       "amount": "Amount",
@@ -712,6 +718,7 @@
               "confirmButton": "Confirm",
               "dataTab": "Data",
               "detailTab": "Details",
+              "failedTransfer": "Failed to transfer",
               "insufficientFeeAmount": "Insufficient fee"
             }
           },

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -697,6 +697,12 @@
             "components": {
               "TxMessage": {
                 "messages": {
+                  "Commission": {
+                    "index": {
+                      "title": "커미션 받기",
+                      "validatorAddress": "검증자 주소"
+                    }
+                  },
                   "Send": {
                     "index": {
                       "amount": "수량",
@@ -712,6 +718,7 @@
               "confirmButton": "승인",
               "dataTab": "데이터",
               "detailTab": "상세 내역",
+              "failedTransfer": "보내기를 실패했습니다.",
               "insufficientFeeAmount": "수수료가 부족합니다."
             }
           },

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -242,10 +242,8 @@ export default function Entry({ queue, chain }: EntryProps) {
                     if (channel) {
                       try {
                         const url = cosmosURL(chain).postBroadcast();
-                        const pTx = protoTx(tx, pubKey);
-                        const pTxBytes = pTx
-                          ? protoTxBytes({ signature: base64Signature, txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
-                          : undefined;
+                        const pTx = protoTx(tx, base64Signature, pubKey);
+                        const pTxBytes = pTx ? protoTxBytes({ ...pTx }) : undefined;
 
                         const response = await broadcast(url, pTxBytes);
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -23,7 +23,7 @@ import { getAddress, getKeyPair } from '~/Popup/utils/common';
 import { cosmosURL, getPublicKeyType, signAmino } from '~/Popup/utils/cosmos';
 import CosmosApp from '~/Popup/utils/ledger/cosmos';
 import { responseToWeb } from '~/Popup/utils/message';
-import { broadcast, protoTx } from '~/Popup/utils/proto';
+import { broadcast, protoTx, protoTxBytes } from '~/Popup/utils/proto';
 import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { CosmosChain, GasRateKey } from '~/types/chain';
 import type { Queue } from '~/types/chromeStorage';
@@ -242,9 +242,12 @@ export default function Entry({ queue, chain }: EntryProps) {
                     if (channel) {
                       try {
                         const url = cosmosURL(chain).postBroadcast();
-                        const pTx = protoTx(tx, base64Signature, pubKey);
+                        const pTx = protoTx(tx, pubKey);
+                        const pTxBytes = pTx
+                          ? protoTxBytes({ signature: base64Signature, txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
+                          : undefined;
 
-                        const response = await broadcast(url, pTx);
+                        const response = await broadcast(url, pTxBytes);
 
                         const { code } = response.tx_response;
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/components/TxMessage/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/components/TxMessage/index.tsx
@@ -1,7 +1,8 @@
-import { isDirectCustom, isDirectSend } from '~/Popup/utils/proto';
+import { isDirectCommission, isDirectCustom, isDirectSend } from '~/Popup/utils/proto';
 import type { CosmosChain } from '~/types/chain';
 import type { Msg } from '~/types/cosmos/proto';
 
+import Commission from './messages/Commission';
 import Custom from './messages/Custom';
 import Send from './messages/Send';
 
@@ -10,6 +11,10 @@ type TxMessageProps = { chain: CosmosChain; msg: Msg; isMultipleMsgs: boolean };
 export default function TxMessage({ chain, msg, isMultipleMsgs }: TxMessageProps) {
   if (isDirectSend(msg)) {
     return <Send msg={msg} chain={chain} isMultipleMsgs={isMultipleMsgs} />;
+  }
+
+  if (isDirectCommission(msg)) {
+    return <Commission msg={msg} isMultipleMsgs={isMultipleMsgs} />;
   }
 
   if (isDirectCustom(msg)) {

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/components/TxMessage/messages/Commission/index.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/components/TxMessage/messages/Commission/index.tsx
@@ -1,0 +1,35 @@
+import { Typography } from '@mui/material';
+
+import Tooltip from '~/Popup/components/common/Tooltip';
+import { useTranslation } from '~/Popup/hooks/useTranslation';
+import { shorterAddress } from '~/Popup/utils/string';
+import type { Msg, MsgCommission } from '~/types/cosmos/proto';
+
+import { AddressContainer, ContentContainer, LabelContainer, ValueContainer } from './styled';
+import Container from '../../components/Container';
+
+type CommissionProps = {
+  msg: Msg<MsgCommission>;
+  isMultipleMsgs: boolean;
+};
+
+export default function Commission({ msg, isMultipleMsgs }: CommissionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Container title={t('pages.Popup.Cosmos.Sign.Direct.components.TxMessage.messages.Commission.index.title')} isMultipleMsgs={isMultipleMsgs}>
+      <ContentContainer>
+        <AddressContainer>
+          <LabelContainer>
+            <Typography variant="h5">{t('pages.Popup.Cosmos.Sign.Direct.components.TxMessage.messages.Commission.index.validatorAddress')}</Typography>
+          </LabelContainer>
+          <ValueContainer>
+            <Tooltip title={msg.value.validator_address} arrow placement="top">
+              <Typography variant="h5">{shorterAddress(msg.value.validator_address, 32)}</Typography>
+            </Tooltip>
+          </ValueContainer>
+        </AddressContainer>
+      </ContentContainer>
+    </Container>
+  );
+}

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/components/TxMessage/messages/Commission/styled.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/components/TxMessage/messages/Commission/styled.tsx
@@ -1,0 +1,33 @@
+import { styled } from '@mui/material/styles';
+
+export const ContentContainer = styled('div')(({ theme }) => ({
+  color: theme.colors.text01,
+
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+
+  overflow: 'auto',
+}));
+
+export const AddressContainer = styled('div')({});
+
+export const LabelContainer = styled('div')(({ theme }) => ({
+  color: theme.colors.text02,
+}));
+
+export const ValueContainer = styled('div')(({ theme }) => ({
+  color: theme.colors.text01,
+  marginTop: '0.4rem',
+}));
+
+export const RightValueContainer = styled('div')(({ theme }) => ({
+  marginTop: '0.2rem',
+
+  display: 'flex',
+  justifyContent: 'flex-end',
+
+  color: theme.colors.text02,
+}));

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -224,16 +224,10 @@ export default function Entry({ queue, chain }: EntryProps) {
 
                     const base64Signature = Buffer.from(signature).toString('base64');
 
-                    const base64PublicKey = Buffer.from(keyPair.publicKey).toString('base64');
-
-                    const publicKeyType = PUBLIC_KEY_TYPE.SECP256K1;
-
-                    const pubKey = { type: publicKeyType, value: base64PublicKey };
-
                     if (channel) {
                       try {
                         const url = cosmosURL(chain).postBroadcast();
-                        const pTx = protoDirectTx(doc, base64Signature);
+                        const pTx = protoDirectTx(signedDoc, base64Signature);
 
                         const response = await broadcast(url, pTx);
 
@@ -256,6 +250,12 @@ export default function Entry({ queue, chain }: EntryProps) {
                         await deQueue();
                       }
                     } else {
+                      const base64PublicKey = Buffer.from(keyPair.publicKey).toString('base64');
+
+                      const publicKeyType = PUBLIC_KEY_TYPE.SECP256K1;
+
+                      const pubKey = { type: publicKeyType, value: base64PublicKey };
+
                       const signedDocHex = {
                         ...doc,
                         body_bytes: Buffer.from(bodyBytes).toString('hex'),

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -2,7 +2,6 @@ import { useMemo, useState } from 'react';
 import { useSnackbar } from 'notistack';
 
 import { COSMOS_DEFAULT_GAS } from '~/constants/chain';
-import { PUBLIC_KEY_TYPE } from '~/constants/cosmos';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '~/constants/error';
 import Button from '~/Popup/components/common/Button';
 import OutlineButton from '~/Popup/components/common/OutlineButton';
@@ -17,7 +16,7 @@ import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
 import { ceil, gte, lt, times } from '~/Popup/utils/big';
 import { getAddress, getKeyPair } from '~/Popup/utils/common';
-import { cosmosURL, signDirect } from '~/Popup/utils/cosmos';
+import { cosmosURL, getPublicKeyType, signDirect } from '~/Popup/utils/cosmos';
 import { responseToWeb } from '~/Popup/utils/message';
 import { broadcast, decodeProtobufMessage, protoTxBytes } from '~/Popup/utils/proto';
 import { cosmos } from '~/proto/cosmos-v0.44.2.js';
@@ -256,7 +255,7 @@ export default function Entry({ queue, chain }: EntryProps) {
                     } else {
                       const base64PublicKey = Buffer.from(keyPair.publicKey).toString('base64');
 
-                      const publicKeyType = PUBLIC_KEY_TYPE.SECP256K1;
+                      const publicKeyType = getPublicKeyType(chain);
 
                       const pubKey = { type: publicKeyType, value: base64PublicKey };
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -19,7 +19,7 @@ import { ceil, gte, lt, times } from '~/Popup/utils/big';
 import { getAddress, getKeyPair } from '~/Popup/utils/common';
 import { cosmosURL, signDirect } from '~/Popup/utils/cosmos';
 import { responseToWeb } from '~/Popup/utils/message';
-import { broadcast, decodeProtobufMessage, protoDirectTx } from '~/Popup/utils/proto';
+import { broadcast, decodeProtobufMessage, protoTxBytes } from '~/Popup/utils/proto';
 import { cosmos } from '~/proto/cosmos-v0.44.2.js';
 import type { CosmosChain, GasRateKey } from '~/types/chain';
 import type { Queue } from '~/types/chromeStorage';
@@ -227,9 +227,13 @@ export default function Entry({ queue, chain }: EntryProps) {
                     if (channel) {
                       try {
                         const url = cosmosURL(chain).postBroadcast();
-                        const pTx = protoDirectTx(signedDoc, base64Signature);
+                        const pTxBytes = protoTxBytes({
+                          signature: base64Signature,
+                          txBodyBytes: signedDoc.body_bytes,
+                          authInfoBytes: signedDoc.auth_info_bytes,
+                        });
 
-                        const response = await broadcast(url, pTx);
+                        const response = await broadcast(url, pTxBytes);
 
                         const { code } = response.tx_response;
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Message/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Message/entry.tsx
@@ -19,7 +19,7 @@ import { getAddress, getKeyPair } from '~/Popup/utils/common';
 import { cosmosURL, getMsgSignData, getPublicKeyType, signAmino } from '~/Popup/utils/cosmos';
 import CosmosApp from '~/Popup/utils/ledger/cosmos';
 import { responseToWeb } from '~/Popup/utils/message';
-import { broadcast, protoTx } from '~/Popup/utils/proto';
+import { broadcast, protoTx, protoTxBytes } from '~/Popup/utils/proto';
 import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { CosmosChain } from '~/types/chain';
 import type { Queue } from '~/types/chromeStorage';
@@ -179,9 +179,12 @@ export default function Entry({ queue, chain }: EntryProps) {
                 if (channel) {
                   try {
                     const url = cosmosURL(chain).postBroadcast();
-                    const pTx = protoTx(tx, base64Signature, pubKey);
+                    const pTx = protoTx(tx, pubKey);
+                    const pTxBytes = pTx
+                      ? protoTxBytes({ signature: base64Signature, txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
+                      : undefined;
 
-                    const response = await broadcast(url, pTx);
+                    const response = await broadcast(url, pTxBytes);
 
                     const { code } = response.tx_response;
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Message/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Message/entry.tsx
@@ -179,10 +179,8 @@ export default function Entry({ queue, chain }: EntryProps) {
                 if (channel) {
                   try {
                     const url = cosmosURL(chain).postBroadcast();
-                    const pTx = protoTx(tx, pubKey);
-                    const pTxBytes = pTx
-                      ? protoTxBytes({ signature: base64Signature, txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
-                      : undefined;
+                    const pTx = protoTx(tx, base64Signature, pubKey);
+                    const pTxBytes = pTx ? protoTxBytes({ ...pTx }) : undefined;
 
                     const response = await broadcast(url, pTxBytes);
 

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -446,9 +446,9 @@ export default function IBCSend({ chain }: IBCSendProps) {
 
   const ibcSendProtoTx = useMemo(() => {
     if (ibcSendAminoTx) {
-      const pTx = protoTx(ibcSendAminoTx, { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(ibcSendAminoTx, '', { type: getPublicKeyType(chain), value: '' });
 
-      return pTx ? protoTxBytes({ signature: '', txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes }) : null;
+      return pTx ? protoTxBytes({ ...pTx }) : null;
     }
     return null;
   }, [chain, ibcSendAminoTx]);

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -32,7 +32,7 @@ import { ceil, gt, gte, isDecimal, minus, plus, times, toBaseDenomAmount, toDisp
 import { openWindow } from '~/Popup/utils/chromeWindows';
 import { getDisplayMaxDecimals } from '~/Popup/utils/common';
 import { convertAssetNameToCosmos, convertCosmosToAssetName, getDefaultAV, getPublicKeyType } from '~/Popup/utils/cosmos';
-import { protoTx } from '~/Popup/utils/proto';
+import { protoTx, protoTxBytes } from '~/Popup/utils/proto';
 import { getCosmosAddressRegex } from '~/Popup/utils/regex';
 import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { CosmosChain, CosmosToken as BaseCosmosToken, GasRateKey } from '~/types/chain';
@@ -446,7 +446,9 @@ export default function IBCSend({ chain }: IBCSendProps) {
 
   const ibcSendProtoTx = useMemo(() => {
     if (ibcSendAminoTx) {
-      return protoTx(ibcSendAminoTx, '', { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(ibcSendAminoTx, { type: getPublicKeyType(chain), value: '' });
+
+      return pTx ? protoTxBytes({ signature: '', txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes }) : null;
     }
     return null;
   }, [chain, ibcSendAminoTx]);

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
@@ -344,11 +344,9 @@ export default function Send({ chain }: CosmosProps) {
 
   const sendProtoTx = useMemo(() => {
     if (sendAminoTx) {
-      const pTx = protoTx(sendAminoTx, { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(sendAminoTx, Buffer.from(new Uint8Array(64)).toString('base64'), { type: getPublicKeyType(chain), value: '' });
 
-      return pTx
-        ? protoTxBytes({ signature: Buffer.from(new Uint8Array(64)).toString('base64'), txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
-        : null;
+      return pTx ? protoTxBytes({ ...pTx }) : null;
     }
     return null;
   }, [chain, sendAminoTx]);

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
@@ -30,7 +30,7 @@ import { ceil, gt, gte, isDecimal, minus, plus, times, toBaseDenomAmount, toDisp
 import { openWindow } from '~/Popup/utils/chromeWindows';
 import { getDisplayMaxDecimals } from '~/Popup/utils/common';
 import { getDefaultAV, getPublicKeyType } from '~/Popup/utils/cosmos';
-import { protoTx } from '~/Popup/utils/proto';
+import { protoTx, protoTxBytes } from '~/Popup/utils/proto';
 import { getCosmosAddressRegex } from '~/Popup/utils/regex';
 import type { CosmosChain, CosmosToken as BaseCosmosToken, GasRateKey } from '~/types/chain';
 
@@ -344,7 +344,11 @@ export default function Send({ chain }: CosmosProps) {
 
   const sendProtoTx = useMemo(() => {
     if (sendAminoTx) {
-      return protoTx(sendAminoTx, Buffer.from(new Uint8Array(64)).toString('base64'), { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(sendAminoTx, { type: getPublicKeyType(chain), value: '' });
+
+      return pTx
+        ? protoTxBytes({ signature: Buffer.from(new Uint8Array(64)).toString('base64'), txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
+        : null;
     }
     return null;
   }, [chain, sendAminoTx]);

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -382,11 +382,9 @@ export default function Entry({ chain }: EntryProps) {
 
   const swapProtoTx = useMemo(() => {
     if (swapAminoTx) {
-      const pTx = protoTx(swapAminoTx, { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(swapAminoTx, Buffer.from(new Uint8Array(64)).toString('base64'), { type: getPublicKeyType(chain), value: '' });
 
-      return pTx
-        ? protoTxBytes({ signature: Buffer.from(new Uint8Array(64)).toString('base64'), txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
-        : null;
+      return pTx ? protoTxBytes({ ...pTx }) : null;
     }
     return null;
   }, [chain, swapAminoTx]);

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -26,7 +26,7 @@ import { ceil, divide, fix, gt, gte, isDecimal, lt, minus, plus, times, toBaseDe
 import { getCapitalize, getDisplayMaxDecimals } from '~/Popup/utils/common';
 import { getDefaultAV, getPublicKeyType } from '~/Popup/utils/cosmos';
 import { calcOutGivenIn, calcSpotPrice, decimalScaling } from '~/Popup/utils/osmosis';
-import { protoTx } from '~/Popup/utils/proto';
+import { protoTx, protoTxBytes } from '~/Popup/utils/proto';
 import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { CosmosChain } from '~/types/chain';
 import type { AssetV3 } from '~/types/cosmos/asset';
@@ -382,7 +382,11 @@ export default function Entry({ chain }: EntryProps) {
 
   const swapProtoTx = useMemo(() => {
     if (swapAminoTx) {
-      return protoTx(swapAminoTx, Buffer.from(new Uint8Array(64)).toString('base64'), { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(swapAminoTx, { type: getPublicKeyType(chain), value: '' });
+
+      return pTx
+        ? protoTxBytes({ signature: Buffer.from(new Uint8Array(64)).toString('base64'), txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes })
+        : null;
     }
     return null;
   }, [chain, swapAminoTx]);

--- a/src/Popup/pages/Wallet/components/cosmos/NativeChainCard/index.tsx
+++ b/src/Popup/pages/Wallet/components/cosmos/NativeChainCard/index.tsx
@@ -286,10 +286,10 @@ export default function NativeChainCard({ chain, isCustom = false }: NativeChain
 
   const isPossibleClaimCommission = useMemo(
     () =>
-      commissionDirectTx
+      chain.id === EVMOS.id
         ? !!commissionDirectTx && gt(displayAvailableAmount, estimatedCommissionDisplayFeeAmount)
         : !!commissionAminoTx && !!commissionSimulate.data?.gas_info?.gas_used && gt(displayAvailableAmount, estimatedCommissionDisplayFeeAmount),
-    [commissionAminoTx, commissionDirectTx, commissionSimulate.data?.gas_info?.gas_used, displayAvailableAmount, estimatedCommissionDisplayFeeAmount],
+    [chain.id, commissionAminoTx, commissionDirectTx, commissionSimulate.data?.gas_info?.gas_used, displayAvailableAmount, estimatedCommissionDisplayFeeAmount],
   );
 
   return (

--- a/src/Popup/pages/Wallet/components/cosmos/NativeChainCard/index.tsx
+++ b/src/Popup/pages/Wallet/components/cosmos/NativeChainCard/index.tsx
@@ -156,9 +156,9 @@ export default function NativeChainCard({ chain, isCustom = false }: NativeChain
 
   const rewardProtoTx = useMemo(() => {
     if (rewardAminoTx) {
-      const pTx = protoTx(rewardAminoTx, { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(rewardAminoTx, '', { type: getPublicKeyType(chain), value: '' });
 
-      return pTx ? protoTxBytes({ signature: '', txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes }) : undefined;
+      return pTx ? protoTxBytes({ ...pTx }) : undefined;
     }
 
     return undefined;
@@ -190,9 +190,9 @@ export default function NativeChainCard({ chain, isCustom = false }: NativeChain
 
   const commissionProtoTx = useMemo(() => {
     if (commissionAminoTx) {
-      const pTx = protoTx(commissionAminoTx, { type: getPublicKeyType(chain), value: '' });
+      const pTx = protoTx(commissionAminoTx, '', { type: getPublicKeyType(chain), value: '' });
 
-      return pTx ? protoTxBytes({ signature: '', txBodyBytes: pTx.txBodyBytes, authInfoBytes: pTx.authInfoBytes }) : undefined;
+      return pTx ? protoTxBytes({ ...pTx }) : undefined;
     }
 
     return undefined;
@@ -231,7 +231,7 @@ export default function NativeChainCard({ chain, isCustom = false }: NativeChain
 
       const publicKeyType = getPublicKeyType(chain);
 
-      const pTx = protoTx(commissionSimulatedAminoTx, { type: publicKeyType, value: base64PublicKey }, cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT);
+      const pTx = protoTx(commissionSimulatedAminoTx, '', { type: publicKeyType, value: base64PublicKey }, cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_DIRECT);
 
       return pTx
         ? {

--- a/src/Popup/utils/proto.ts
+++ b/src/Popup/utils/proto.ts
@@ -182,7 +182,7 @@ export function getPubKey(pubKey: PubKey) {
   return publicKey;
 }
 
-export function protoTx(signed: SignAminoDoc, pubKey: PubKey, mode = cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_LEGACY_AMINO_JSON) {
+export function protoTx(signed: SignAminoDoc, signature: string, pubKey: PubKey, mode = cosmos.tx.signing.v1beta1.SignMode.SIGN_MODE_LEGACY_AMINO_JSON) {
   const txBodyBytes = getTxBodyBytes(signed);
 
   if (txBodyBytes === null) {
@@ -191,7 +191,7 @@ export function protoTx(signed: SignAminoDoc, pubKey: PubKey, mode = cosmos.tx.s
 
   const authInfoBytes = getAuthInfoBytes(signed, pubKey, mode);
 
-  return { txBodyBytes, authInfoBytes };
+  return { signature, txBodyBytes, authInfoBytes };
 }
 
 export function protoTxBytes({ signature, txBodyBytes, authInfoBytes }: ProtoTxBytesProps) {

--- a/src/types/cosmos/proto.ts
+++ b/src/types/cosmos/proto.ts
@@ -24,3 +24,9 @@ export type SignDirectDoc = {
   auth_info_bytes: Uint8Array;
   account_number: string;
 };
+
+export type ProtoTxBytesProps = {
+  signature: string;
+  txBodyBytes: Uint8Array;
+  authInfoBytes: Uint8Array;
+};

--- a/src/types/cosmos/proto.ts
+++ b/src/types/cosmos/proto.ts
@@ -14,6 +14,10 @@ export type MsgSend = {
   amount: Amount[];
 };
 
+export type MsgCommission = {
+  validator_address: string;
+};
+
 export type SignDirectDoc = {
   chain_id: string;
   body_bytes: Uint8Array;


### PR DESCRIPTION
기존 커미션을 받는 tx의 레거시 아미노 사인 방식에서 Evmos에서만 direct방식으로 변경하였습니다.
- 인앱에서 다이렉트 사인 메시지를 post할 수 있는 분기처리 코드가 추가되었습니다.
- evmos에서만 다이렉트 방식으로 사인을 합니다. 그 외 체인에서는 모두 레거시 아미노 방식으로 사인을 합니다.

<img width="435" alt="스크린샷 2023-03-07 오후 12 16 14" src="https://user-images.githubusercontent.com/87967564/223311493-d8afaa4a-27c2-42c8-a02f-9339f05acb34.png">
<img width="447" alt="스크린샷 2023-03-07 오후 12 16 02" src="https://user-images.githubusercontent.com/87967564/223311504-aab7ca06-5ec0-4530-923a-d1aedb97273f.png">
<img width="428" alt="스크린샷 2023-03-07 오후 12 15 52" src="https://user-images.githubusercontent.com/87967564/223311508-5f9a38c6-0604-4fee-bea5-734ed67134f2.png">
