### PR TITLE
[Extension] edit kava api endpoint & response type

### DIFF
--- a/src/Popup/hooks/SWR/cosmos/useIncentiveSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useIncentiveSWR.ts
@@ -10,7 +10,7 @@ import { plus } from '~/Popup/utils/big';
 import { cosmosURL } from '~/Popup/utils/cosmos';
 import type { CosmosChain } from '~/types/chain';
 import type { Amount } from '~/types/cosmos/common';
-import type { IncentiveClaims, IncentiveHardClaims, IncentivePayload } from '~/types/cosmos/incentive';
+import type { IncentiveClaims, IncentiveHardLiquidityProviderClaims, IncentivePayload } from '~/types/cosmos/incentive';
 
 export function useIncentiveSWR(chain: CosmosChain, suspense?: boolean) {
   const accounts = useAccounts(suspense);
@@ -42,16 +42,17 @@ export function useIncentiveSWR(chain: CosmosChain, suspense?: boolean) {
   };
 
   const getClaimReward = useCallback(
-    (claims: IncentiveHardClaims[] | IncentiveClaims[] | null): Amount[] => claims?.map((claim) => parseReward(claim.base_claim.reward))?.flat() || [],
+    (claims: IncentiveHardLiquidityProviderClaims[] | IncentiveClaims[] | null): Amount[] =>
+      claims?.map((claim) => parseReward(claim.base_claim.reward))?.flat() || [],
     [],
   );
 
   const incentives = useMemo(() => {
     if (data) {
-      const hardClaimsReward = getClaimReward(data.result.hard_claims);
-      const usdxMintingReward = getClaimReward(data.result.usdx_minting_claims);
-      const delegationReward = getClaimReward(data.result.delegator_claims);
-      const swapRewards = getClaimReward(data.result.swap_claims);
+      const hardClaimsReward = getClaimReward(data.hard_liquidity_provider_claims);
+      const usdxMintingReward = getClaimReward(data.usdx_minting_claims);
+      const delegationReward = getClaimReward(data.delegator_claims);
+      const swapRewards = getClaimReward(data.swap_claims);
 
       return [...hardClaimsReward, ...usdxMintingReward, ...delegationReward, ...swapRewards];
     }

--- a/src/Popup/utils/cosmos.ts
+++ b/src/Popup/utils/cosmos.ts
@@ -54,7 +54,7 @@ export function cosmosURL(chain: CosmosChain) {
     getRewards: (address: string) => `${restURL}/cosmos/distribution/v1beta1/delegators/${address}/rewards`,
     getUndelegations: (address: string) => `${restURL}/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`,
     getAccount: (address: string) => `${restURL}/cosmos/auth/v1beta1/accounts/${address}`,
-    getIncentive: (address: string) => (chainName === KAVA.chainName ? `${restURL}/incentive/rewards?owner=${address}` : ''),
+    getIncentive: (address: string) => (chainName === KAVA.chainName ? `${restURL}/kava/incentive/v1beta1/rewards?owner=${address}` : ''),
     postBroadcast: () => `${restURL}/cosmos/tx/v1beta1/txs`,
     getCW20TokenInfo: (contractAddress: string) => `${restURL}/wasm/contract/${contractAddress}/smart/${toHex('{"token_info":{}}')}?encoding=utf-8`,
     getCW20Balance: (contractAddress: string, address: string) =>

--- a/src/types/cosmos/incentive.ts
+++ b/src/types/cosmos/incentive.ts
@@ -15,7 +15,7 @@ type IncentiveSupplyRewardIndex = {
   reward_indexes: IncentiveRewardIndex[];
 };
 
-export type IncentiveHardClaims = {
+export type IncentiveHardLiquidityProviderClaims = {
   base_claim: IncentiveBaseClaim;
   supply_reward_indexes: IncentiveSupplyRewardIndex[] | null;
   borrow_reward_indexes: IncentiveSupplyRewardIndex[] | null;
@@ -27,13 +27,10 @@ export type IncentiveClaims = {
 };
 
 export type Incentive = {
-  hard_claims: IncentiveHardClaims[] | null;
+  hard_liquidity_provider_claims: IncentiveHardLiquidityProviderClaims[] | null;
   usdx_minting_claims: IncentiveClaims[] | null;
   delegator_claims: IncentiveClaims[] | null;
   swap_claims: IncentiveClaims[] | null;
 };
 
-export type IncentivePayload = {
-  height: string;
-  result: Incentive;
-};
+export type IncentivePayload = Incentive;


### PR DESCRIPTION
Kava의 incentive api의 엔드포인트와 리스폰스의 타입명, 타입이 변경되었습니다.
이에 맞춰 코드를 수정했습니다.

속성명: hard_claims -> hard_liquidity_provider_claims

https://swagger.kava.io/#/Incentive/IncentiveRewards