### PR TITLE
[WEB-1820] 컨트랙트 토큰 기본 노출

### DIFF
--- a/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
@@ -48,7 +48,7 @@ export function useTokensSWR(config?: SWRConfiguration) {
       displayDenom: item.symbol,
       imageURL: item.image ? `https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/${item.image}` : undefined,
       coinGeckoId: item.coinGeckoId,
-      default: item.default,
+      default: item.default ?? false,
     })) || [];
 
   return { data: returnData, error, mutate };

--- a/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
@@ -48,6 +48,7 @@ export function useTokensSWR(config?: SWRConfiguration) {
       displayDenom: item.symbol,
       imageURL: item.image ? `https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/${item.image}` : undefined,
       coinGeckoId: item.coinGeckoId,
+      default: item.default,
     })) || [];
 
   return { data: returnData, error, mutate };

--- a/src/Popup/hooks/useCurrent/useCurrentEthereumTokens.ts
+++ b/src/Popup/hooks/useCurrent/useCurrentEthereumTokens.ts
@@ -35,8 +35,12 @@ export function useCurrentEthereumTokens() {
 
   const { ethereumTokens } = extensionStorage;
 
-  const currentEthereumTokens = [...defaultTokens, ...ethereumTokens.filter((item) => item.ethereumNetworkId === currentEthereumNetwork.id)].filter(
-    (token, idx, self) => self.findIndex((item) => item.address.toLowerCase() === token.address.toLowerCase()) === idx,
+  const currentEthereumTokens = useMemo(
+    () =>
+      [...defaultTokens, ...ethereumTokens.filter((item) => item.ethereumNetworkId === currentEthereumNetwork.id)].filter(
+        (token, idx, self) => self.findIndex((item) => item.address.toLowerCase() === token.address.toLowerCase()) === idx,
+      ),
+    [currentEthereumNetwork.id, defaultTokens, ethereumTokens],
   );
 
   const addEthereumToken = async (token: AddEthereumTokenParams) => {

--- a/src/Popup/pages/Chain/Cosmos/Token/Add/CW20/Search/entry.tsx
+++ b/src/Popup/pages/Chain/Cosmos/Token/Add/CW20/Search/entry.tsx
@@ -49,7 +49,7 @@ export default function Entry({ chain }: EntryProps) {
   const [selectedTokens, setSelectedTokens] = useState<CosmosTokenParams[]>([]);
   const { currentChain } = useCurrentChain();
 
-  const { addCosmosTokens, currentCosmosTokens } = useCurrentCosmosTokens();
+  const { addCosmosTokens, currentCosmosTokens } = useCurrentCosmosTokens(chain);
 
   const { t } = useTranslation();
   const { navigate } = useNavigate();

--- a/src/Popup/pages/Chain/Cosmos/Token/Add/CW20/entry.tsx
+++ b/src/Popup/pages/Chain/Cosmos/Token/Add/CW20/entry.tsx
@@ -29,7 +29,7 @@ export default function Entry({ chain }: EntryProps) {
   const tokens = useTokensSWR(chain);
 
   const { importTokenForm } = useSchema({ chain });
-  const { addCosmosToken } = useCurrentCosmosTokens();
+  const { addCosmosToken } = useCurrentCosmosTokens(chain);
   const { t } = useTranslation();
 
   const tokenInfo = useTokenInfoSWR(chain, contractAddress);

--- a/src/Popup/pages/Popup/Cosmos/AddTokens/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AddTokens/entry.tsx
@@ -40,7 +40,7 @@ type EntryProps = {
 export default function Entry({ queue, chain }: EntryProps) {
   const { deQueue } = useCurrentQueue();
 
-  const { addCosmosTokens } = useCurrentCosmosTokens();
+  const { addCosmosTokens } = useCurrentCosmosTokens(chain);
 
   const { currentAccount } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -94,7 +94,7 @@ export default function IBCSend({ chain }: IBCSendProps) {
   const [isDisabled, setIsDisabled] = useState(false);
 
   const { t } = useTranslation();
-  const { currentCosmosTokens } = useCurrentCosmosTokens();
+  const { currentCosmosTokens } = useCurrentCosmosTokens(chain);
 
   const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [recipientPopoverAnchorEl, setReceiverIBCPopoverAnchorEl] = useState<HTMLButtonElement | null>(null);

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
@@ -81,7 +81,7 @@ export default function Send({ chain }: CosmosProps) {
 
   const { t } = useTranslation();
 
-  const { currentCosmosTokens } = useCurrentCosmosTokens();
+  const { currentCosmosTokens } = useCurrentCosmosTokens(chain);
 
   const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLButtonElement | null>(null);
   const isOpenPopover = Boolean(popoverAnchorEl);

--- a/src/Popup/pages/Wallet/components/cosmos/CoinList/components/TokenItem/index.tsx
+++ b/src/Popup/pages/Wallet/components/cosmos/CoinList/components/TokenItem/index.tsx
@@ -35,12 +35,11 @@ type TokenItemProps = {
   chain: CosmosChain;
   token: CosmosToken;
   address: string;
-  isDefault: boolean;
   onClick?: () => void;
   onClickDelete?: () => void;
 };
 
-export default function TokenItem({ chain, token, address, isDefault, onClick, onClickDelete }: TokenItemProps) {
+export default function TokenItem({ chain, token, address, onClick, onClickDelete }: TokenItemProps) {
   const { extensionStorage } = useExtensionStorage();
 
   const { currency } = extensionStorage;
@@ -82,7 +81,7 @@ export default function TokenItem({ chain, token, address, isDefault, onClick, o
             </Number>
           </RightTextChangeRateContainer>
         </RightTextContainer>
-        {!isDefault && (
+        {!token.default && (
           <DeleteButton
             id="deleteButton"
             onClick={(e) => {

--- a/src/Popup/pages/Wallet/components/cosmos/CoinList/components/TokenItem/index.tsx
+++ b/src/Popup/pages/Wallet/components/cosmos/CoinList/components/TokenItem/index.tsx
@@ -35,11 +35,12 @@ type TokenItemProps = {
   chain: CosmosChain;
   token: CosmosToken;
   address: string;
+  isDefault: boolean;
   onClick?: () => void;
   onClickDelete?: () => void;
 };
 
-export default function TokenItem({ chain, token, address, onClick, onClickDelete }: TokenItemProps) {
+export default function TokenItem({ chain, token, address, isDefault, onClick, onClickDelete }: TokenItemProps) {
   const { extensionStorage } = useExtensionStorage();
 
   const { currency } = extensionStorage;
@@ -81,15 +82,17 @@ export default function TokenItem({ chain, token, address, onClick, onClickDelet
             </Number>
           </RightTextChangeRateContainer>
         </RightTextContainer>
-        <DeleteButton
-          id="deleteButton"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClickDelete?.();
-          }}
-        >
-          <Close16Icon />
-        </DeleteButton>
+        {!isDefault && (
+          <DeleteButton
+            id="deleteButton"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClickDelete?.();
+            }}
+          >
+            <Close16Icon />
+          </DeleteButton>
+        )}
       </RightContainer>
     </StyledButton>
   );

--- a/src/Popup/pages/Wallet/components/ethereum/TokenList/components/TokenItem/index.tsx
+++ b/src/Popup/pages/Wallet/components/ethereum/TokenList/components/TokenItem/index.tsx
@@ -33,14 +33,13 @@ import Close16Icon from '~/images/icons/Close16.svg';
 import RetryIcon from '~/images/icons/Retry.svg';
 
 type TokenItemProps = {
-  isDefault: boolean;
   token: EthereumToken;
   onClick?: () => void;
   onClickDelete?: () => void;
   disabled?: boolean;
 };
 
-export default function TokenItem({ isDefault, token, disabled, onClick, onClickDelete }: TokenItemProps) {
+export default function TokenItem({ token, disabled, onClick, onClickDelete }: TokenItemProps) {
   const { extensionStorage } = useExtensionStorage();
   const coinGeckoPrice = useCoinGeckoPriceSWR();
   const tokenBalance = useTokenBalanceSWR({ token }, { suspense: true });
@@ -77,7 +76,7 @@ export default function TokenItem({ isDefault, token, disabled, onClick, onClick
             </Number>
           </RightTextChangeRateContainer>
         </RightTextContainer>
-        {!isDefault && (
+        {!token.default && (
           <DeleteButton
             id="deleteButton"
             onClick={(e) => {

--- a/src/Popup/pages/Wallet/components/ethereum/TokenList/components/TokenItem/index.tsx
+++ b/src/Popup/pages/Wallet/components/ethereum/TokenList/components/TokenItem/index.tsx
@@ -33,13 +33,14 @@ import Close16Icon from '~/images/icons/Close16.svg';
 import RetryIcon from '~/images/icons/Retry.svg';
 
 type TokenItemProps = {
+  isDefault: boolean;
   token: EthereumToken;
   onClick?: () => void;
   onClickDelete?: () => void;
   disabled?: boolean;
 };
 
-export default function TokenItem({ token, disabled, onClick, onClickDelete }: TokenItemProps) {
+export default function TokenItem({ isDefault, token, disabled, onClick, onClickDelete }: TokenItemProps) {
   const { extensionStorage } = useExtensionStorage();
   const coinGeckoPrice = useCoinGeckoPriceSWR();
   const tokenBalance = useTokenBalanceSWR({ token }, { suspense: true });
@@ -76,15 +77,17 @@ export default function TokenItem({ token, disabled, onClick, onClickDelete }: T
             </Number>
           </RightTextChangeRateContainer>
         </RightTextContainer>
-        <DeleteButton
-          id="deleteButton"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClickDelete?.();
-          }}
-        >
-          <Close16Icon />
-        </DeleteButton>
+        {!isDefault && (
+          <DeleteButton
+            id="deleteButton"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClickDelete?.();
+            }}
+          >
+            <Close16Icon />
+          </DeleteButton>
+        )}
       </RightContainer>
     </StyledButton>
   );

--- a/src/Popup/pages/Wallet/components/ethereum/TokenList/index.tsx
+++ b/src/Popup/pages/Wallet/components/ethereum/TokenList/index.tsx
@@ -7,6 +7,7 @@ import { useTokensSWR } from '~/Popup/hooks/SWR/ethereum/useTokensSWR';
 import { useCurrentEthereumTokens } from '~/Popup/hooks/useCurrent/useCurrentEthereumTokens';
 import { useNavigate } from '~/Popup/hooks/useNavigate';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
+import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { Path } from '~/types/route';
 
 import TokenItem, { TokenItemError, TokenItemSkeleton } from './components/TokenItem';
@@ -62,6 +63,8 @@ export default function TokenList() {
               await removeEthereumToken(token);
             };
 
+            const isDefault = !!data.find((item) => item.default && isEqualsIgnoringCase(item.address, token.address));
+
             return (
               <ErrorBoundary
                 key={token.id}
@@ -71,7 +74,12 @@ export default function TokenList() {
                 }
               >
                 <Suspense fallback={<TokenItemSkeleton token={token} />}>
-                  <TokenItem token={token} onClickDelete={handleOnClickDelete} onClick={() => navigate(`/wallet/send/${token.id}` as unknown as Path)} />
+                  <TokenItem
+                    isDefault={isDefault}
+                    token={token}
+                    onClickDelete={handleOnClickDelete}
+                    onClick={() => navigate(`/wallet/send/${token.id}` as unknown as Path)}
+                  />
                 </Suspense>
               </ErrorBoundary>
             );

--- a/src/Popup/pages/Wallet/components/ethereum/TokenList/index.tsx
+++ b/src/Popup/pages/Wallet/components/ethereum/TokenList/index.tsx
@@ -7,7 +7,6 @@ import { useTokensSWR } from '~/Popup/hooks/SWR/ethereum/useTokensSWR';
 import { useCurrentEthereumTokens } from '~/Popup/hooks/useCurrent/useCurrentEthereumTokens';
 import { useNavigate } from '~/Popup/hooks/useNavigate';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
-import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { Path } from '~/types/route';
 
 import TokenItem, { TokenItemError, TokenItemSkeleton } from './components/TokenItem';
@@ -63,8 +62,6 @@ export default function TokenList() {
               await removeEthereumToken(token);
             };
 
-            const isDefault = !!data.find((item) => item.default && isEqualsIgnoringCase(item.address, token.address));
-
             return (
               <ErrorBoundary
                 key={token.id}
@@ -74,12 +71,7 @@ export default function TokenList() {
                 }
               >
                 <Suspense fallback={<TokenItemSkeleton token={token} />}>
-                  <TokenItem
-                    isDefault={isDefault}
-                    token={token}
-                    onClickDelete={handleOnClickDelete}
-                    onClick={() => navigate(`/wallet/send/${token.id}` as unknown as Path)}
-                  />
+                  <TokenItem token={token} onClickDelete={handleOnClickDelete} onClick={() => navigate(`/wallet/send/${token.id}` as unknown as Path)} />
                 </Suspense>
               </ErrorBoundary>
             );

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -66,6 +66,7 @@ export type CosmosCW20Token = {
   decimals: number;
   imageURL?: string;
   coinGeckoId?: string;
+  default?: boolean;
 };
 
 export type CosmosToken = CosmosCW20Token;
@@ -163,6 +164,7 @@ export type EthereumERC20Token = {
   decimals: number;
   imageURL?: string;
   coinGeckoId?: string;
+  default?: boolean;
 };
 
 export type Chain = CosmosChain | EthereumChain | AptosChain | SuiChain;

--- a/src/types/ethereum/asset.ts
+++ b/src/types/ethereum/asset.ts
@@ -7,7 +7,7 @@ export type Asset = {
   decimals: number;
   image?: string;
   coinGeckoId?: string;
-  default: boolean;
+  default?: boolean;
 };
 
 export type AssetPayload = {

--- a/src/types/ethereum/asset.ts
+++ b/src/types/ethereum/asset.ts
@@ -7,6 +7,7 @@ export type Asset = {
   decimals: number;
   image?: string;
   coinGeckoId?: string;
+  default: boolean;
 };
 
 export type AssetPayload = {
@@ -21,4 +22,5 @@ export type ModifiedAsset = {
   decimals: number;
   imageURL?: string;
   coinGeckoId?: string;
+  default: boolean;
 };


### PR DESCRIPTION
사전에 정의된 컨트랙트 토큰은 보유 수량이 없어도 기본으로 노출되도록 코드를 수정했습니다.

- 기본 토큰들의 정렬은 사전 정의된 순서에 맞춰 정렬했습니다.
- 기존에 기본 토큰(이더리움의 weth, usdc 등)들이 추가되어 있어도 문제없이 기본 토큰들이 노출이 됩니다.


<img width="444" alt="스크린샷 2023-06-19 오후 6 49 03" src="https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/f93fcc17-5a36-4351-a440-9869f4e0d9f1">
