### PR TITLE
[WEB-1861] 수이 테스트넷 rpc 주소 변경

### DIFF
--- a/src/constants/chain/sui/network/testnet.ts
+++ b/src/constants/chain/sui/network/testnet.ts
@@ -4,7 +4,7 @@ import type { SuiNetwork } from '~/types/chain';
 export const TESTNET: SuiNetwork = {
   id: '2f79310a-8621-49b6-b2d5-16b49f3605c1',
   networkName: 'Testnet',
-  rpcURL: 'https://rpc-sui-testnet.cosmostation.io/',
+  rpcURL: 'https://sui-testnet-kr-1.cosmostation.io',
   imageURL: suiImg,
   explorerURL: 'https://explorer.sui.io',
   displayDenom: 'SUI',


### PR DESCRIPTION
수이 테스트넷의 알피시 주소를 다음과 같이 변경했습니다.

https://rpc-sui-testnet.cosmostation.io/ -> https://sui-testnet-kr-1.cosmostation.io/