### PR TITLE
[WEB-1869] EVM 체인 익스플로러 링크 수정 

### DIFF
--- a/src/Popup/pages/Wallet/components/ethereum/NativeChainCard/index.tsx
+++ b/src/Popup/pages/Wallet/components/ethereum/NativeChainCard/index.tsx
@@ -86,6 +86,12 @@ export default function NativeChainCard({ chain, isCustom }: NativeChainCardProp
     }
   };
 
+  const explorerAccountURL = useMemo(
+    () =>
+      explorerURL ? (explorerURL.includes('mintscan') ? `${explorerURL}/accounts/${currentAddress}` : `${explorerURL}/address/${currentAddress}`) : undefined,
+    [currentAddress, explorerURL],
+  );
+
   return (
     <Container>
       <FirstLineContainer>
@@ -93,10 +99,10 @@ export default function NativeChainCard({ chain, isCustom }: NativeChainCardProp
           <AddressButton onClick={handleOnClickCopy}>{currentAddress}</AddressButton>
         </FirstLineLeftContainer>
         <FirstLineRightContainer>
-          {explorerURL && (
+          {explorerAccountURL && (
             <StyledIconButton
               onClick={() => {
-                window.open(`${explorerURL}/address/${currentAddress}`);
+                window.open(explorerAccountURL);
               }}
             >
               <ExplorerIcon />


### PR DESCRIPTION
민트스캔을 익스플로러로 사용하는 칸토,이브이모스,카바 체인의 익스플로러 링크를 수정했습니다.