### PR TITLE
[WEB-1878] 체인 맵핑 메서드에 마스체인 추가

### DIFF
--- a/src/Popup/utils/cosmos.ts
+++ b/src/Popup/utils/cosmos.ts
@@ -17,6 +17,7 @@ import { INJECTIVE } from '~/constants/chain/cosmos/injective';
 import { IXO } from '~/constants/chain/cosmos/ixo';
 import { KAVA } from '~/constants/chain/cosmos/kava';
 import { KI } from '~/constants/chain/cosmos/ki';
+import { MARS } from '~/constants/chain/cosmos/mars';
 import { PROVENANCE } from '~/constants/chain/cosmos/provenance';
 import { SIF } from '~/constants/chain/cosmos/sif';
 import { STAFIHUB } from '~/constants/chain/cosmos/stafihub';
@@ -175,6 +176,7 @@ export function convertCosmosToAssetName(cosmosChain: CosmosChain) {
     [KI.id]: 'ki-chain',
     [STAFIHUB.id]: 'stafi',
     [FETCH_AI.id]: 'fetchai',
+    [MARS.id]: 'mars-protocol',
   };
   return nameMap[cosmosChain.id] || cosmosChain.chainName.toLowerCase();
 }
@@ -188,6 +190,7 @@ export function convertAssetNameToCosmos(assetName: string) {
     'ki-chain': KI,
     stafi: STAFIHUB,
     fetchai: FETCH_AI,
+    'mars-protocol': MARS,
   } as Record<string, CosmosChain | undefined>;
 
   return nameMap[assetName] || COSMOS_CHAINS.find((item) => item.chainName.toLowerCase() === assetName);


### PR DESCRIPTION
코스모스 계열 체인 네임 매핑 메서드에 마스 체인을 추가했습니다.

→ 마스 체인에서 에셋을 못가져오는 이슈가 해결됩니다.