### PR TITLE
[WEB-1893] 체인 관리 페이지 개편

### DIFF
--- a/src/Popup/components/ChainPopover/index.tsx
+++ b/src/Popup/components/ChainPopover/index.tsx
@@ -68,7 +68,7 @@ export default function ChainPopover({ onClose, currentChain, onClickChain, isOn
             <Typography variant="h5">{t('pages.Wallet.components.Header.ChainPopover.index.title')}</Typography>
           </HeaderLeftContainer>
           <HeaderRightContainer>
-            <StyledIconButton onClick={() => navigate('/chain/management')}>
+            <StyledIconButton onClick={() => navigate('/chain/management/use')}>
               <SettingIcon24 />
             </StyledIconButton>
           </HeaderRightContainer>

--- a/src/Popup/components/Header/Drawer/index.tsx
+++ b/src/Popup/components/Header/Drawer/index.tsx
@@ -145,12 +145,12 @@ export default function Drawer({ onClose, ...remainder }: DrawerProps) {
               {t('components.Header.Drawer.index.guide')}
             </ItemButton>
 
-            <ItemButton Icon={HelpIcon} onClick={() => window.open('https://cosmostation.io/contact')}>
-              {t('components.Header.Drawer.index.helpSupport')}
+            <ItemButton Icon={SettingIcon24} onClick={() => navigate('/chain/management', { isDuplicateCheck: true })}>
+              {t('components.Header.Drawer.index.customChain')}
             </ItemButton>
 
-            <ItemButton Icon={SettingIcon24} onClick={() => navigate('/chain/management', { isDuplicateCheck: true })}>
-              {t('components.Header.Drawer.index.chainManagement')}
+            <ItemButton Icon={HelpIcon} onClick={() => window.open('https://cosmostation.io/contact')}>
+              {t('components.Header.Drawer.index.helpSupport')}
             </ItemButton>
           </ItemContainer>
         </UpContainer>

--- a/src/Popup/components/Header/Drawer/index.tsx
+++ b/src/Popup/components/Header/Drawer/index.tsx
@@ -146,7 +146,7 @@ export default function Drawer({ onClose, ...remainder }: DrawerProps) {
             </ItemButton>
 
             <ItemButton Icon={SettingIcon24} onClick={() => navigate('/chain/management', { isDuplicateCheck: true })}>
-              {t('components.Header.Drawer.index.customChain')}
+              {t('components.Header.Drawer.index.addCustomChain')}
             </ItemButton>
 
             <ItemButton Icon={HelpIcon} onClick={() => window.open('https://cosmostation.io/contact')}>

--- a/src/Popup/components/Header/Drawer/index.tsx
+++ b/src/Popup/components/Header/Drawer/index.tsx
@@ -48,6 +48,7 @@ import Lock16 from '~/images/icons/Lock16.svg';
 import Logo24Icon from '~/images/icons/Logo28.svg';
 import PasswordChangeIcon from '~/images/icons/PasswordChange.svg';
 import Provider24Icon from '~/images/icons/Provider24.svg';
+import SettingIcon24 from '~/images/icons/Setting24.svg';
 
 type DrawerProps = Omit<BaseDrawerProps, 'children'>;
 
@@ -146,6 +147,10 @@ export default function Drawer({ onClose, ...remainder }: DrawerProps) {
 
             <ItemButton Icon={HelpIcon} onClick={() => window.open('https://cosmostation.io/contact')}>
               {t('components.Header.Drawer.index.helpSupport')}
+            </ItemButton>
+
+            <ItemButton Icon={SettingIcon24} onClick={() => navigate('/chain/management', { isDuplicateCheck: true })}>
+              {t('components.Header.Drawer.index.chainManagement')}
             </ItemButton>
           </ItemContainer>
         </UpContainer>

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -56,7 +56,7 @@
         "index": {
           "addressBook": "Address book",
           "autoSign": "Auto sign",
-          "customChain": "Custom chain",
+          "addCustomChain": "Add Custom Chain",
           "changePassword": "Change password",
           "connectedSites": "Connected sites",
           "currency": "Currency",

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -56,7 +56,7 @@
         "index": {
           "addressBook": "Address book",
           "autoSign": "Auto sign",
-          "chainManagement": "Chain management",
+          "customChain": "Custom chain",
           "changePassword": "Change password",
           "connectedSites": "Connected sites",
           "currency": "Currency",

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -56,6 +56,7 @@
         "index": {
           "addressBook": "Address book",
           "autoSign": "Auto sign",
+          "chainManagement": "Chain management",
           "changePassword": "Change password",
           "connectedSites": "Connected sites",
           "currency": "Currency",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -56,6 +56,7 @@
         "index": {
           "addressBook": "주소록",
           "autoSign": "자동 서명",
+          "chainManagement": "체인 관리",
           "changePassword": "비밀번호 변경",
           "connectedSites": "연결 된 사이트",
           "currency": "통화",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -56,7 +56,7 @@
         "index": {
           "addressBook": "주소록",
           "autoSign": "자동 서명",
-          "customChain": "커스텀 체인",
+          "addCustomChain": "커스텀 체인 추가",
           "changePassword": "비밀번호 변경",
           "connectedSites": "연결 된 사이트",
           "currency": "통화",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -56,7 +56,7 @@
         "index": {
           "addressBook": "주소록",
           "autoSign": "자동 서명",
-          "chainManagement": "체인 관리",
+          "customChain": "커스텀 체인",
           "changePassword": "비밀번호 변경",
           "connectedSites": "연결 된 사이트",
           "currency": "통화",

--- a/src/Popup/pages/Chain/Management/entry.tsx
+++ b/src/Popup/pages/Chain/Management/entry.tsx
@@ -11,10 +11,6 @@ export default function Entry() {
   return (
     <Container>
       <ListContainer>
-        <MenuButton onClick={() => navigate('/chain/management/use', { isDuplicateCheck: true })}>
-          {t('pages.Chain.Management.entry.chainManagement')}
-        </MenuButton>
-
         <MenuButton onClick={() => navigate('/chain/ethereum/network/add', { isDuplicateCheck: true })}>
           {t('pages.Chain.Management.entry.addEthereumNetwork')}
         </MenuButton>


### PR DESCRIPTION
기존 체인 팝오버에서 진입 가능했던 체인 관리 페이지가 다음과 같이 변경되었습니다.

- 커스텀 체인 페이지 진입 버튼 제거
  - drawer로 이동
- 바로 체인 선택 페이지로 이동 

<img width="236" alt="스크린샷 2023-08-02 오전 11 57 23" src="https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/bf3fd1ab-a639-4258-9dfa-7efa76aff3d3">
<img width="439" alt="스크린샷 2023-08-02 오전 11 57 12" src="https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/3adeceef-45a8-4c33-9295-62bb0d996cef">
