### PR TITLE
[WEB-1910] 중복 사인 요청 막기(+ tx메세지 오버플로우 영역 조절)

### DIFF
--- a/src/Popup/pages/Popup/Aptos/Transaction/components/TxMessage/components/Container/styled.tsx
+++ b/src/Popup/pages/Popup/Aptos/Transaction/components/TxMessage/components/Container/styled.tsx
@@ -9,7 +9,9 @@ export const StyledContainer = styled('div')(({ theme }) => ({
   borderRadius: '0.8rem',
 
   height: '18.7rem',
-  overflow: 'auto',
+
+  display: 'flex',
+  flexDirection: 'column',
 }));
 
 export const TitleContainer = styled('div')(({ theme }) => ({
@@ -18,5 +20,4 @@ export const TitleContainer = styled('div')(({ theme }) => ({
 
 export const StyledDivider = styled(Divider)({
   marginTop: '1.6rem',
-  marginBottom: '1.2rem',
 });

--- a/src/Popup/pages/Popup/Aptos/Transaction/components/TxMessage/messages/Transaction/styled.tsx
+++ b/src/Popup/pages/Popup/Aptos/Transaction/components/TxMessage/messages/Transaction/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -211,6 +211,7 @@ export default function Entry({ queue, chain }: EntryProps) {
                 onClick={async () => {
                   try {
                     handleButtonDisabled();
+
                     if (!keyPair) {
                       throw new Error('key pair does not exist');
                     }

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -64,7 +64,7 @@ export default function Entry({ queue, chain }: EntryProps) {
     params: { doc, isEditFee, isEditMemo, isCheckBalance, gasRate },
   } = message;
 
-  const { fee, msgs } = useMemo(() => doc, [doc]);
+  const { fee, msgs } = doc;
 
   const keyPair = useMemo(() => getKeyPair(currentAccount, chain, currentPassword), [chain, currentAccount, currentPassword]);
   const address = useMemo(() => getAddress(chain, keyPair?.publicKey), [chain, keyPair?.publicKey]);

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -54,15 +54,15 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const { t } = useTranslation();
 
-  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const [isProgress, setIsProgress] = useState(false);
 
   const { feeCoins } = useCurrentFeesSWR(chain, { suspense: true });
 
-  const { message, messageId, origin, channel } = useMemo(() => queue, [queue]);
+  const { message, messageId, origin, channel } = queue;
 
   const {
     params: { doc, isEditFee, isEditMemo, isCheckBalance, gasRate },
-  } = useMemo(() => message, [message]);
+  } = message;
 
   const { fee, msgs } = useMemo(() => doc, [doc]);
 
@@ -120,10 +120,6 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const handleChange = useCallback((_: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
-  }, []);
-
-  const handleButtonDisabled = useCallback(() => {
-    setButtonDisabled(true);
   }, []);
 
   const errorMessage = useMemo(() => {
@@ -207,10 +203,11 @@ export default function Entry({ queue, chain }: EntryProps) {
           <Tooltip varient="error" title={errorMessage} placement="top" arrow>
             <div>
               <Button
-                disabled={!!errorMessage || buttonDisabled}
+                disabled={!!errorMessage}
+                isProgress={isProgress}
                 onClick={async () => {
                   try {
-                    handleButtonDisabled();
+                    setIsProgress(true);
 
                     if (!keyPair) {
                       throw new Error('key pair does not exist');
@@ -315,6 +312,7 @@ export default function Entry({ queue, chain }: EntryProps) {
                     enqueueSnackbar((e as { message: string }).message, { variant: 'error' });
                   } finally {
                     setLoadingLedgerSigning(false);
+                    setIsProgress(false);
                     await closeTransport();
                   }
                 }}

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -61,7 +61,7 @@ export default function Entry({ queue, chain }: EntryProps) {
   const decodedBodyBytes = useMemo(() => cosmos.tx.v1beta1.TxBody.decode(body_bytes), [body_bytes]);
   const decodedAuthInfoBytes = useMemo(() => cosmos.tx.v1beta1.AuthInfo.decode(auth_info_bytes), [auth_info_bytes]);
 
-  const { fee } = useMemo(() => decodedAuthInfoBytes, [decodedAuthInfoBytes]);
+  const { fee } = decodedAuthInfoBytes;
 
   const keyPair = useMemo(() => getKeyPair(currentAccount, chain, currentPassword), [chain, currentAccount, currentPassword]);
   const address = useMemo(() => getAddress(chain, keyPair?.publicKey), [chain, keyPair?.publicKey]);
@@ -127,7 +127,7 @@ export default function Entry({ queue, chain }: EntryProps) {
   const decodedChangedBodyBytes = useMemo(() => cosmos.tx.v1beta1.TxBody.decode(bodyBytes), [bodyBytes]);
   const decodedChangedAuthInfoBytes = useMemo(() => cosmos.tx.v1beta1.AuthInfo.decode(authInfoBytes), [authInfoBytes]);
 
-  const { messages } = useMemo(() => decodedChangedBodyBytes, [decodedChangedBodyBytes]);
+  const { messages } = decodedChangedBodyBytes;
   const msgs = useMemo(() => messages.map((item) => decodeProtobufMessage(item)), [messages]);
 
   const tx = useMemo(

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useSnackbar } from 'notistack';
 
 import { COSMOS_DEFAULT_GAS } from '~/constants/chain';
@@ -45,26 +45,28 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const { t } = useTranslation();
 
+  const [buttonDisabled, setButtonDisabled] = useState(false);
+
   const { feeCoins } = useCurrentFeesSWR(chain, { suspense: true });
 
-  const { message, messageId, origin, channel } = queue;
+  const { message, messageId, origin, channel } = useMemo(() => queue, [queue]);
 
   const {
     params: { doc, isEditFee, isEditMemo, isCheckBalance, gasRate },
-  } = message;
+  } = useMemo(() => message, [message]);
 
-  const auth_info_bytes = new Uint8Array(doc.auth_info_bytes);
-  const body_bytes = new Uint8Array(doc.body_bytes);
+  const auth_info_bytes = useMemo(() => new Uint8Array(doc.auth_info_bytes), [doc.auth_info_bytes]);
+  const body_bytes = useMemo(() => new Uint8Array(doc.body_bytes), [doc.body_bytes]);
 
-  const decodedBodyBytes = cosmos.tx.v1beta1.TxBody.decode(body_bytes);
-  const decodedAuthInfoBytes = cosmos.tx.v1beta1.AuthInfo.decode(auth_info_bytes);
+  const decodedBodyBytes = useMemo(() => cosmos.tx.v1beta1.TxBody.decode(body_bytes), [body_bytes]);
+  const decodedAuthInfoBytes = useMemo(() => cosmos.tx.v1beta1.AuthInfo.decode(auth_info_bytes), [auth_info_bytes]);
 
-  const { fee } = decodedAuthInfoBytes;
+  const { fee } = useMemo(() => decodedAuthInfoBytes, [decodedAuthInfoBytes]);
 
-  const keyPair = getKeyPair(currentAccount, chain, currentPassword);
-  const address = getAddress(chain, keyPair?.publicKey);
+  const keyPair = useMemo(() => getKeyPair(currentAccount, chain, currentPassword), [chain, currentAccount, currentPassword]);
+  const address = useMemo(() => getAddress(chain, keyPair?.publicKey), [chain, keyPair?.publicKey]);
 
-  const inputGas = fee?.gas_limit ? String(fee.gas_limit) : COSMOS_DEFAULT_GAS;
+  const inputGas = useMemo(() => (fee?.gas_limit ? String(fee.gas_limit) : COSMOS_DEFAULT_GAS), [fee?.gas_limit]);
 
   const inputFee = useMemo(() => {
     const foundFee = fee?.amount?.find((item) => item?.denom && item?.amount && feeCoins.map((feeCoin) => feeCoin.baseDenom).includes(item?.denom || ''));
@@ -81,7 +83,7 @@ export default function Entry({ queue, chain }: EntryProps) {
     };
   }, [chain.baseDenom, fee?.amount, feeCoins]);
 
-  const inputFeeAmount = inputFee.amount || '0';
+  const inputFeeAmount = useMemo(() => inputFee.amount || '0', [inputFee.amount]);
 
   const [currentFeeBaseDenom, setCurrentFeeBaseDenom] = useState(
     feeCoins.find((item) => item.baseDenom === inputFee.denom)?.baseDenom ?? feeCoins[0].baseDenom,
@@ -91,13 +93,16 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const currentFeeGasRate = useMemo(() => currentFeeCoin.gasRate || gasRate || chain.gasRate, [chain.gasRate, currentFeeCoin.gasRate, gasRate]);
 
-  const tinyFee = times(inputGas, currentFeeGasRate.tiny);
-  const lowFee = times(inputGas, currentFeeGasRate.low);
-  const averageFee = times(inputGas, currentFeeGasRate.average);
+  const tinyFee = useMemo(() => times(inputGas, currentFeeGasRate.tiny), [currentFeeGasRate.tiny, inputGas]);
+  const lowFee = useMemo(() => times(inputGas, currentFeeGasRate.low), [currentFeeGasRate.low, inputGas]);
+  const averageFee = useMemo(() => times(inputGas, currentFeeGasRate.average), [currentFeeGasRate.average, inputGas]);
 
-  const isExistZeroFee = tinyFee === '0' || lowFee === '0' || averageFee === '0';
+  const isExistZeroFee = useMemo(() => tinyFee === '0' || lowFee === '0' || averageFee === '0', [averageFee, lowFee, tinyFee]);
 
-  const initBaseFee = isEditFee && !isExistZeroFee && lt(inputFeeAmount, '1') ? lowFee : inputFeeAmount;
+  const initBaseFee = useMemo(
+    () => (isEditFee && !isExistZeroFee && lt(inputFeeAmount, '1') ? lowFee : inputFeeAmount),
+    [inputFeeAmount, isEditFee, isExistZeroFee, lowFee],
+  );
 
   const [gas, setGas] = useState(inputGas);
   const [currentGasRateKey, setCurrentGasRateKey] = useState<GasRateKey>('low');
@@ -106,30 +111,41 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const ceilBaseFee = useMemo(() => ceil(baseFee), [baseFee]);
 
-  const encodedBodyBytes = cosmos.tx.v1beta1.TxBody.encode({ ...decodedBodyBytes, memo }).finish();
-  const encodedAuthInfoBytes = cosmos.tx.v1beta1.AuthInfo.encode({
-    ...decodedAuthInfoBytes,
-    fee: { ...fee, amount: [{ denom: currentFeeBaseDenom, amount: ceilBaseFee }], gas_limit: Number(gas) },
-  }).finish();
+  const encodedBodyBytes = useMemo(() => cosmos.tx.v1beta1.TxBody.encode({ ...decodedBodyBytes, memo }).finish(), [decodedBodyBytes, memo]);
+  const encodedAuthInfoBytes = useMemo(
+    () =>
+      cosmos.tx.v1beta1.AuthInfo.encode({
+        ...decodedAuthInfoBytes,
+        fee: { ...fee, amount: [{ denom: currentFeeBaseDenom, amount: ceilBaseFee }], gas_limit: Number(gas) },
+      }).finish(),
+    [ceilBaseFee, currentFeeBaseDenom, decodedAuthInfoBytes, fee, gas],
+  );
 
-  const bodyBytes = isEditMemo ? encodedBodyBytes : body_bytes;
-  const authInfoBytes = isEditFee ? encodedAuthInfoBytes : auth_info_bytes;
+  const bodyBytes = useMemo(() => (isEditMemo ? encodedBodyBytes : body_bytes), [body_bytes, encodedBodyBytes, isEditMemo]);
+  const authInfoBytes = useMemo(() => (isEditFee ? encodedAuthInfoBytes : auth_info_bytes), [auth_info_bytes, encodedAuthInfoBytes, isEditFee]);
 
-  const decodedChangedBodyBytes = cosmos.tx.v1beta1.TxBody.decode(bodyBytes);
-  const decodedChangedAuthInfoBytes = cosmos.tx.v1beta1.AuthInfo.decode(authInfoBytes);
+  const decodedChangedBodyBytes = useMemo(() => cosmos.tx.v1beta1.TxBody.decode(bodyBytes), [bodyBytes]);
+  const decodedChangedAuthInfoBytes = useMemo(() => cosmos.tx.v1beta1.AuthInfo.decode(authInfoBytes), [authInfoBytes]);
 
-  const { messages } = decodedChangedBodyBytes;
-  const msgs = messages.map((item) => decodeProtobufMessage(item));
+  const { messages } = useMemo(() => decodedChangedBodyBytes, [decodedChangedBodyBytes]);
+  const msgs = useMemo(() => messages.map((item) => decodeProtobufMessage(item)), [messages]);
 
-  const tx = {
-    ...doc,
-    body_bytes: { ...decodedChangedBodyBytes, messages: msgs },
-    auth_info_bytes: decodedChangedAuthInfoBytes,
-  };
+  const tx = useMemo(
+    () => ({
+      ...doc,
+      body_bytes: { ...decodedChangedBodyBytes, messages: msgs },
+      auth_info_bytes: decodedChangedAuthInfoBytes,
+    }),
+    [decodedChangedAuthInfoBytes, decodedChangedBodyBytes, doc, msgs],
+  );
 
-  const handleChange = (_: React.SyntheticEvent, newValue: number) => {
+  const handleChange = useCallback((_: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
-  };
+  }, []);
+
+  const handleButtonDisabled = useCallback(() => {
+    setButtonDisabled(true);
+  }, []);
 
   const errorMessage = useMemo(() => {
     if (!gte(currentFeeCoin.availableAmount, baseFee) && isCheckBalance && !fee?.granter && !fee?.payer) {
@@ -215,9 +231,11 @@ export default function Entry({ queue, chain }: EntryProps) {
           <Tooltip varient="error" title={errorMessage} placement="top" arrow>
             <div>
               <Button
-                disabled={!!errorMessage}
+                disabled={!!errorMessage || buttonDisabled}
                 onClick={async () => {
                   try {
+                    handleButtonDisabled();
+
                     if (!keyPair?.privateKey) {
                       throw new Error('Unknown Error');
                     }

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -45,15 +45,15 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const { t } = useTranslation();
 
-  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const [isProgress, setIsProgress] = useState(false);
 
   const { feeCoins } = useCurrentFeesSWR(chain, { suspense: true });
 
-  const { message, messageId, origin, channel } = useMemo(() => queue, [queue]);
+  const { message, messageId, origin, channel } = queue;
 
   const {
     params: { doc, isEditFee, isEditMemo, isCheckBalance, gasRate },
-  } = useMemo(() => message, [message]);
+  } = message;
 
   const auth_info_bytes = useMemo(() => new Uint8Array(doc.auth_info_bytes), [doc.auth_info_bytes]);
   const body_bytes = useMemo(() => new Uint8Array(doc.body_bytes), [doc.body_bytes]);
@@ -143,10 +143,6 @@ export default function Entry({ queue, chain }: EntryProps) {
     setValue(newValue);
   }, []);
 
-  const handleButtonDisabled = useCallback(() => {
-    setButtonDisabled(true);
-  }, []);
-
   const errorMessage = useMemo(() => {
     if (!gte(currentFeeCoin.availableAmount, baseFee) && isCheckBalance && !fee?.granter && !fee?.payer) {
       return t('pages.Popup.Cosmos.Sign.Direct.entry.insufficientFeeAmount');
@@ -231,10 +227,11 @@ export default function Entry({ queue, chain }: EntryProps) {
           <Tooltip varient="error" title={errorMessage} placement="top" arrow>
             <div>
               <Button
-                disabled={!!errorMessage || buttonDisabled}
+                disabled={!!errorMessage}
+                isProgress={isProgress}
                 onClick={async () => {
                   try {
-                    handleButtonDisabled();
+                    setIsProgress(true);
 
                     if (!keyPair?.privateKey) {
                       throw new Error('Unknown Error');
@@ -305,6 +302,8 @@ export default function Entry({ queue, chain }: EntryProps) {
                     }
                   } catch (e) {
                     enqueueSnackbar((e as { message: string }).message, { variant: 'error' });
+                  } finally {
+                    setIsProgress(false);
                   }
                 }}
               >

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/components/Container/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/components/Container/styled.tsx
@@ -9,7 +9,9 @@ export const StyledContainer = styled('div')(({ theme }) => ({
   borderRadius: '0.8rem',
 
   height: '18.7rem',
-  overflow: 'auto',
+
+  display: 'flex',
+  flexDirection: 'column',
 }));
 
 export const TitleContainer = styled('div')(({ theme }) => ({
@@ -18,5 +20,4 @@ export const TitleContainer = styled('div')(({ theme }) => ({
 
 export const StyledDivider = styled(Divider)({
   marginTop: '1.6rem',
-  marginBottom: '1.2rem',
 });

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Approve/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Approve/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Deploy/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Deploy/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Interact/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Interact/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/NFT/ERC11155/SafeTransferFrom/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/NFT/ERC11155/SafeTransferFrom/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/NFT/ERC721/TransferFrom/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/NFT/ERC721/TransferFrom/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Send/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Send/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Transfer/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/Transfer/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/TransferFrom/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/components/TxMessage/messages/TransferFrom/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -90,7 +90,7 @@ export default function Entry({ queue }: EntryProps) {
   const { extensionStorage } = useExtensionStorage();
   const coinGeckoPrice = useCoinGeckoPriceSWR();
 
-  const [buttonDisabled, setButtonDisabled] = useState(false);
+  const [isProgress, setIsProgress] = useState(false);
 
   const { setLoadingLedgerSigning } = useLoading();
 
@@ -143,8 +143,8 @@ export default function Entry({ queue }: EntryProps) {
   const address = useMemo(() => getAddress(chain, keyPair?.publicKey), [chain, keyPair?.publicKey]);
   const transactionCount = useTransactionCountSWR([address, 'latest']);
 
-  const { message, messageId, origin } = useMemo(() => queue, [queue]);
-  const { params } = useMemo(() => message, [message]);
+  const { message, messageId, origin } = queue;
+  const { params } = message;
 
   const [isSigningLedger, setIsSigningLedger] = useState(false);
 
@@ -333,10 +333,6 @@ export default function Entry({ queue }: EntryProps) {
     setTabValue(newTabValue);
   }, []);
 
-  const handleButtonDisabled = useCallback(() => {
-    setButtonDisabled(true);
-  }, []);
-
   useEffect(() => {
     void (async () => {
       const from = toHex(params[0].from, { addPrefix: true });
@@ -509,10 +505,11 @@ export default function Entry({ queue }: EntryProps) {
             <Tooltip title={errorMessage} varient="error" placement="top">
               <div>
                 <Button
-                  disabled={isLoadingFee || !!errorMessage || buttonDisabled}
+                  disabled={isLoadingFee || !!errorMessage}
+                  isProgress={isProgress}
                   onClick={async () => {
                     try {
-                      handleButtonDisabled();
+                      setIsProgress(true);
 
                       const signedRawTx = await (async () => {
                         const dataToSign = {
@@ -639,6 +636,7 @@ export default function Entry({ queue }: EntryProps) {
                       await closeTransport();
                       setLoadingLedgerSigning(false);
                       setIsSigningLedger(false);
+                      setIsProgress(false);
                     }
                   }}
                 >

--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -130,7 +130,7 @@ export default function Entry({ queue }: EntryProps) {
 
   const netVersion = useNetVersionSWR();
 
-  const { displayDenom, coinGeckoId, decimals } = useMemo(() => currentEthereumNetwork, [currentEthereumNetwork]);
+  const { displayDenom, coinGeckoId, decimals } = currentEthereumNetwork;
 
   const { t } = useTranslation();
 

--- a/src/Popup/pages/Popup/Sui/Transaction/components/TxMessage/components/Container/styled.tsx
+++ b/src/Popup/pages/Popup/Sui/Transaction/components/TxMessage/components/Container/styled.tsx
@@ -9,7 +9,9 @@ export const StyledContainer = styled('div')(({ theme }) => ({
   borderRadius: '0.8rem',
 
   height: '18.7rem',
-  overflow: 'auto',
+
+  display: 'flex',
+  flexDirection: 'column',
 }));
 
 export const TitleContainer = styled('div')(({ theme }) => ({
@@ -18,5 +20,4 @@ export const TitleContainer = styled('div')(({ theme }) => ({
 
 export const StyledDivider = styled(Divider)({
   marginTop: '1.6rem',
-  marginBottom: '1.2rem',
 });

--- a/src/Popup/pages/Popup/Sui/Transaction/components/TxMessage/messages/Transaction/styled.tsx
+++ b/src/Popup/pages/Popup/Sui/Transaction/components/TxMessage/messages/Transaction/styled.tsx
@@ -3,8 +3,13 @@ import { styled } from '@mui/material/styles';
 export const ContentContainer = styled('div')(({ theme }) => ({
   color: theme.colors.text01,
 
+  margin: '0 -1.6rem',
+  padding: '1.2rem 1.6rem 0',
+
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+
+  overflow: 'auto',
 }));
 
 export const AddressContainer = styled('div')({});

--- a/src/Popup/pages/Popup/Sui/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Sui/Transaction/entry.tsx
@@ -85,7 +85,7 @@ export default function Entry({ queue }: EntryProps) {
 
   const { currentSuiNetwork } = useCurrentSuiNetwork();
 
-  const { coinGeckoId } = useMemo(() => currentSuiNetwork, [currentSuiNetwork]);
+  const { coinGeckoId } = currentSuiNetwork;
 
   const price = useMemo(() => (coinGeckoId && coinGeckoPrice.data?.[coinGeckoId]?.[currency]) || 0, [coinGeckoId, coinGeckoPrice.data, currency]);
 


### PR DESCRIPTION
- tx 사인 페이지에서 `sign`버튼 클릭 시 버튼을 다시 클릭하지 못하도록 disable처리했습니다.
- tx 메시지 영역의 오버플로우 영역을 수정했습니다.
  - tx 타입 밑으로 오버 플로우 영역을 잡도록 수정했습니다.
  - ![스크린샷 2023-08-08 오후 3 37 51](https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/d14928fe-95c3-45b0-b9c2-1163893b598e)

- 각 체인의 변수 할당식에 useMemo를 사용하는 방식으로 변경했습니다.