### PR TITLE
[WEB-2015] bridge 토큰 수신 체인 리스팅 로직 수정

### DIFF
--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -241,14 +241,20 @@ export default function IBCSend({ chain }: IBCSendProps) {
   );
 
   const receiverIBCList = useMemo(() => {
-    if (currentCoinOrToken.type === 'coin' && (currentCoinOrToken.coinType === 'native' || currentCoinOrToken.coinType === 'staking')) {
+    if (
+      currentCoinOrToken.type === 'coin' &&
+      (currentCoinOrToken.coinType === 'native' || currentCoinOrToken.coinType === 'staking' || currentCoinOrToken.coinType === 'bridge')
+    ) {
       const assets = filteredCosmosChainAssets.filter(
-        (asset) => isEqualsIgnoringCase(asset.counter_party?.denom, currentCoinOrToken.baseDenom) && cosmosAssetNames.includes(asset.origin_chain),
+        (asset) =>
+          isEqualsIgnoringCase(asset.counter_party?.denom, currentCoinOrToken.baseDenom) &&
+          isEqualsIgnoringCase(convertAssetNameToCosmos(asset.prevChain || '')?.baseDenom, chain.baseDenom) &&
+          cosmosAssetNames.includes(asset.prevChain || ''),
       );
       return assets.map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }));
     }
 
-    if (currentCoinOrToken.type === 'coin' && (currentCoinOrToken.coinType === 'ibc' || currentCoinOrToken.coinType === 'bridge')) {
+    if (currentCoinOrToken.type === 'coin' && currentCoinOrToken.coinType === 'ibc') {
       const assets = filteredCurrentChainAssets.filter(
         (asset) => isEqualsIgnoringCase(asset.denom, currentCoinOrToken.baseDenom) && asset.channel && asset.port,
       );

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -241,17 +241,14 @@ export default function IBCSend({ chain }: IBCSendProps) {
   );
 
   const receiverIBCList = useMemo(() => {
-    if (
-      currentCoinOrToken.type === 'coin' &&
-      (currentCoinOrToken.coinType === 'native' || currentCoinOrToken.coinType === 'staking' || currentCoinOrToken.coinType === 'bridge')
-    ) {
+    if (currentCoinOrToken.type === 'coin' && (currentCoinOrToken.coinType === 'native' || currentCoinOrToken.coinType === 'staking')) {
       const assets = filteredCosmosChainAssets.filter(
         (asset) => isEqualsIgnoringCase(asset.counter_party?.denom, currentCoinOrToken.baseDenom) && cosmosAssetNames.includes(asset.origin_chain),
       );
       return assets.map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }));
     }
 
-    if (currentCoinOrToken.type === 'coin' && currentCoinOrToken.coinType === 'ibc') {
+    if (currentCoinOrToken.type === 'coin' && (currentCoinOrToken.coinType === 'ibc' || currentCoinOrToken.coinType === 'bridge')) {
       const assets = filteredCurrentChainAssets.filter(
         (asset) => isEqualsIgnoringCase(asset.denom, currentCoinOrToken.baseDenom) && asset.channel && asset.port,
       );

--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -248,7 +248,7 @@ export default function IBCSend({ chain }: IBCSendProps) {
       const assets = filteredCosmosChainAssets.filter(
         (asset) =>
           isEqualsIgnoringCase(asset.counter_party?.denom, currentCoinOrToken.baseDenom) &&
-          isEqualsIgnoringCase(convertAssetNameToCosmos(asset.prevChain || '')?.baseDenom, chain.baseDenom) &&
+          isEqualsIgnoringCase(convertAssetNameToCosmos(asset.prevChain || '')?.id, chain.id) &&
           cosmosAssetNames.includes(asset.prevChain || ''),
       );
       return assets.map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }));
@@ -262,7 +262,7 @@ export default function IBCSend({ chain }: IBCSendProps) {
       const counterPartyAssets = filteredCosmosChainAssets.filter(
         (asset) =>
           isEqualsIgnoringCase(asset.counter_party?.denom, currentCoinOrToken.baseDenom) &&
-          isEqualsIgnoringCase(convertAssetNameToCosmos(asset.prevChain || '')?.baseDenom, chain.baseDenom),
+          isEqualsIgnoringCase(convertAssetNameToCosmos(asset.prevChain || '')?.id, chain.id),
       );
 
       return [
@@ -277,7 +277,7 @@ export default function IBCSend({ chain }: IBCSendProps) {
     }
 
     return [];
-  }, [currentCoinOrToken, filteredCosmosChainAssets, filteredCurrentChainAssets, chain.baseDenom]);
+  }, [currentCoinOrToken, filteredCosmosChainAssets, chain.id, filteredCurrentChainAssets]);
 
   const [selectedReceiverIBC, setReceiverIBC] = useState(receiverIBCList.length ? receiverIBCList[0] : undefined);
 


### PR DESCRIPTION
토큰 타입이 브릿지(악셀레에서 axlUSDC)인 토큰의 리스팅 로직을 IBC 토큰과 동일하도록 수정했습니다.

<img width="426" alt="스크린샷 2023-09-15 오후 11 43 47" src="https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/8f66ea3b-18f7-4351-b512-dff4e3b40428">
