### PR TITLE
[WEB-2016] Swap 후 Tx Receipt진입 로직 수정

### DIFF
--- a/src/Popup/Routes/index.tsx
+++ b/src/Popup/Routes/index.tsx
@@ -171,7 +171,8 @@ export default function Routes() {
           <Route path={PATH.POPUP__SUI__TRANSACTION} element={<PopupSuiTransaction />} />
 
           <Route path={PATH.POPUP__TX_RECEIPT} element={<PopupTxReceipt />}>
-            <Route path=":id" element={<PopupTxReceipt />} />
+            <Route path=":txhash" element={<PopupTxReceipt />} />
+            <Route path=":txhash/:chainId" element={<PopupTxReceipt />} />
           </Route>
         </>
       )}

--- a/src/Popup/hooks/useCurrent/useCurrentAllowedChains.ts
+++ b/src/Popup/hooks/useCurrent/useCurrentAllowedChains.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { CHAINS } from '~/constants/chain';
 import { useExtensionStorage } from '~/Popup/hooks/useExtensionStorage';
 import type { Chain } from '~/types/chain';
@@ -7,9 +9,11 @@ export function useCurrentAllowedChains() {
 
   const { allowedChainIds } = extensionStorage;
 
-  const allChains = [...CHAINS];
+  const currentAllowedChains = useMemo(() => {
+    const allChains = [...CHAINS];
 
-  const currentAllowedChains = allChains.filter((chain) => allowedChainIds.includes(chain.id));
+    return allChains.filter((chain) => allowedChainIds.includes(chain.id));
+  }, [allowedChainIds]);
 
   const addAllowedChainId = async (chain: Chain) => {
     if (allowedChainIds.find((allowedChainId) => allowedChainId === chain.id)) {

--- a/src/Popup/hooks/useCurrent/useCurrentChain.ts
+++ b/src/Popup/hooks/useCurrent/useCurrentChain.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import { CHAINS } from '~/constants/chain';
 import { useExtensionStorage } from '~/Popup/hooks/useExtensionStorage';
 import type { Chain } from '~/types/chain';
@@ -10,15 +12,18 @@ export function useCurrentChain() {
   const { currentAllowedChains } = useCurrentAllowedChains();
 
   const { additionalChains, selectedChainId } = extensionStorage;
-  const additionalChainIds = additionalChains.map((item) => item.id);
+  const additionalChainIds = useMemo(() => additionalChains.map((item) => item.id), [additionalChains]);
 
-  const allowedChainIds = currentAllowedChains.map((item) => item.id);
+  const allowedChainIds = useMemo(() => currentAllowedChains.map((item) => item.id), [currentAllowedChains]);
 
-  const allChains = [...CHAINS, ...additionalChains];
+  const allChains = useMemo(() => [...CHAINS, ...additionalChains], [additionalChains]);
 
-  const currentAccountSelectedChainId = [...allowedChainIds, ...additionalChainIds].includes(selectedChainId) ? selectedChainId : allowedChainIds[0];
+  const currentAccountSelectedChainId = useMemo(
+    () => ([...allowedChainIds, ...additionalChainIds].includes(selectedChainId) ? selectedChainId : allowedChainIds[0]),
+    [additionalChainIds, allowedChainIds, selectedChainId],
+  );
 
-  const currentChain = allChains.find((chain) => chain.id === currentAccountSelectedChainId)!;
+  const currentChain = useMemo(() => allChains.find((chain) => chain.id === currentAccountSelectedChainId)!, [allChains, currentAccountSelectedChainId]);
 
   const setCurrentChain = async (chain: Chain) => {
     if (![...allowedChainIds, ...additionalChainIds].includes(chain.id)) {

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -272,7 +272,7 @@ export default function Entry({ queue, chain }: EntryProps) {
 
                         if (code === 0) {
                           if (txhash) {
-                            void deQueue(`/popup/tx-receipt/${txhash}` as unknown as Path);
+                            void deQueue(`/popup/tx-receipt/${txhash}/${chain.id}` as unknown as Path);
                           } else {
                             void deQueue();
                           }

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -258,7 +258,7 @@ export default function Entry({ queue, chain }: EntryProps) {
 
                         if (code === 0) {
                           if (txhash) {
-                            void deQueue(`/popup/tx-receipt/${txhash}` as unknown as Path);
+                            void deQueue(`/popup/tx-receipt/${txhash}/${chain.id}` as unknown as Path);
                           } else {
                             void deQueue();
                           }

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Aptos/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Aptos/entry.tsx
@@ -81,7 +81,7 @@ export default function Aptos() {
 
   const params = useParams();
 
-  const txHash = useMemo(() => params.id || '', [params.id]);
+  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txDetailExplorerURL = useMemo(
     () => (explorerURL ? `${explorerURL}/txn/${txHash}?network=${networkName.toLowerCase()}` : ''),

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Aptos/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Aptos/entry.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import copy from 'copy-to-clipboard';
 import { useSnackbar } from 'notistack';
 import { Typography } from '@mui/material';
@@ -59,7 +58,11 @@ import Copy16Icon from '~/images/icons/Copy16.svg';
 import Explorer16Icon from '~/images/icons/Explorer16.svg';
 import Warning50Icon from '~/images/icons/Warning50.svg';
 
-export default function Aptos() {
+type AptosProps = {
+  txHash: string;
+};
+
+export default function Aptos({ txHash }: AptosProps) {
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
   const { navigate } = useNavigate();
@@ -78,10 +81,6 @@ export default function Aptos() {
   const { currency, language } = extensionStorage;
 
   const price = useMemo(() => (coinGeckoId && coinGeckoPrice.data?.[coinGeckoId]?.[currency]) || 0, [coinGeckoId, coinGeckoPrice.data, currency]);
-
-  const params = useParams();
-
-  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txDetailExplorerURL = useMemo(
     () => (explorerURL ? `${explorerURL}/txn/${txHash}?network=${networkName.toLowerCase()}` : ''),

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Cosmos/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Cosmos/entry.tsx
@@ -69,7 +69,7 @@ export default function Cosmos({ chain }: CosmosProps) {
 
   const params = useParams();
 
-  const txHash = useMemo(() => params.id || '', [params.id]);
+  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txInfo = useTxInfoSWR(chain, txHash);
 

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Cosmos/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Cosmos/entry.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import copy from 'copy-to-clipboard';
 import { useSnackbar } from 'notistack';
 import { Typography } from '@mui/material';
@@ -56,9 +55,10 @@ import Warning50Icon from '~/images/icons/Warning50.svg';
 
 type CosmosProps = {
   chain: CosmosChain;
+  txHash: string;
 };
 
-export default function Cosmos({ chain }: CosmosProps) {
+export default function Cosmos({ chain, txHash }: CosmosProps) {
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
   const { navigate } = useNavigate();
@@ -66,10 +66,6 @@ export default function Cosmos({ chain }: CosmosProps) {
   const { extensionStorage } = useExtensionStorage();
   const coinGeckoPrice = useCoinGeckoPriceSWR();
   const { currency, language } = extensionStorage;
-
-  const params = useParams();
-
-  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txInfo = useTxInfoSWR(chain, txHash);
 

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Ethereum/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Ethereum/entry.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import copy from 'copy-to-clipboard';
 import { useSnackbar } from 'notistack';
 import { Typography } from '@mui/material';
@@ -56,7 +55,11 @@ import Copy16Icon from '~/images/icons/Copy16.svg';
 import Explorer16Icon from '~/images/icons/Explorer16.svg';
 import Warning50Icon from '~/images/icons/Warning50.svg';
 
-export default function Ethereum() {
+type EthereumProps = {
+  txHash: string;
+};
+
+export default function Ethereum({ txHash }: EthereumProps) {
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
   const { navigate } = useNavigate();
@@ -66,10 +69,6 @@ export default function Ethereum() {
   const { extensionStorage } = useExtensionStorage();
   const coinGeckoPrice = useCoinGeckoPriceSWR();
   const { currency, language } = extensionStorage;
-
-  const params = useParams();
-
-  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txInfo = useTxInfoSWR(txHash);
 

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Ethereum/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Ethereum/entry.tsx
@@ -69,7 +69,7 @@ export default function Ethereum() {
 
   const params = useParams();
 
-  const txHash = useMemo(() => params.id || '', [params.id]);
+  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txInfo = useTxInfoSWR(txHash);
 

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Sui/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Sui/entry.tsx
@@ -70,11 +70,14 @@ export default function Sui() {
 
   const params = useParams();
 
-  const txDigest = useMemo(() => params.id || '', [params.id]);
+  const txDigest = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txInfo = useTxInfoSWR({ digest: txDigest, network: currentSuiNetwork });
 
-  const txDetailExplorerURL = useMemo(() => (explorerURL ? `${explorerURL}/txblock/${txDigest}?network=${currentSuiNetwork.networkName.toLowerCase()}` : ''), [explorerURL, txDigest]);
+  const txDetailExplorerURL = useMemo(
+    () => (explorerURL ? `${explorerURL}/txblock/${txDigest}?network=${currentSuiNetwork.networkName.toLowerCase()}` : ''),
+    [currentSuiNetwork.networkName, explorerURL, txDigest],
+  );
 
   const formattedTimestamp = useMemo(() => {
     if (txInfo.data?.result?.timestampMs) {

--- a/src/Popup/pages/Popup/TxReceipt/Entry/Sui/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Sui/entry.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useParams } from 'react-router-dom';
 import copy from 'copy-to-clipboard';
 import { useSnackbar } from 'notistack';
 import { Typography } from '@mui/material';
@@ -55,7 +54,11 @@ import Copy16Icon from '~/images/icons/Copy16.svg';
 import Explorer16Icon from '~/images/icons/Explorer16.svg';
 import Warning50Icon from '~/images/icons/Warning50.svg';
 
-export default function Sui() {
+type SuiProps = {
+  txDigest: string;
+};
+
+export default function Sui({ txDigest }: SuiProps) {
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
   const { navigate } = useNavigate();
@@ -67,10 +70,6 @@ export default function Sui() {
   const { currency, language } = extensionStorage;
 
   const price = useMemo(() => (coinGeckoId && coinGeckoPrice.data?.[coinGeckoId]?.[currency]) || 0, [coinGeckoId, coinGeckoPrice.data, currency]);
-
-  const params = useParams();
-
-  const txDigest = useMemo(() => params.txhash || '', [params.txhash]);
 
   const txInfo = useTxInfoSWR({ digest: txDigest, network: currentSuiNetwork });
 

--- a/src/Popup/pages/Popup/TxReceipt/Entry/index.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/index.tsx
@@ -19,20 +19,22 @@ export default function Entry() {
     [currentChain, params.chainId],
   );
 
+  const txHash = useMemo(() => params.txhash || '', [params.txhash]);
+
   if (chain.line === 'COSMOS') {
-    return <Cosmos chain={chain} />;
+    return <Cosmos chain={chain} txHash={txHash} />;
   }
 
   if (chain.line === 'ETHEREUM') {
-    return <Ethereum />;
+    return <Ethereum txHash={txHash} />;
   }
 
   if (chain.line === 'APTOS') {
-    return <Aptos />;
+    return <Aptos txHash={txHash} />;
   }
 
   if (chain.line === 'SUI') {
-    return <Sui />;
+    return <Sui txDigest={txHash} />;
   }
 
   return null;

--- a/src/Popup/pages/Popup/TxReceipt/Entry/index.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/index.tsx
@@ -1,4 +1,9 @@
+import { useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { CHAINS } from '~/constants/chain';
 import { useCurrentChain } from '~/Popup/hooks/useCurrent/useCurrentChain';
+import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 
 import Aptos from './Aptos/entry';
 import Cosmos from './Cosmos/entry';
@@ -6,21 +11,27 @@ import Ethereum from './Ethereum/entry';
 import Sui from './Sui/entry';
 
 export default function Entry() {
+  const params = useParams();
   const { currentChain } = useCurrentChain();
 
-  if (currentChain.line === 'COSMOS') {
-    return <Cosmos chain={currentChain} />;
+  const chain = useMemo(
+    () => (params?.chainId ? CHAINS.find((item) => isEqualsIgnoringCase(item.id, params.chainId)) || currentChain : currentChain),
+    [currentChain, params.chainId],
+  );
+
+  if (chain.line === 'COSMOS') {
+    return <Cosmos chain={chain} />;
   }
 
-  if (currentChain.line === 'ETHEREUM') {
+  if (chain.line === 'ETHEREUM') {
     return <Ethereum />;
   }
 
-  if (currentChain.line === 'APTOS') {
+  if (chain.line === 'APTOS') {
     return <Aptos />;
   }
 
-  if (currentChain.line === 'SUI') {
+  if (chain.line === 'SUI') {
     return <Sui />;
   }
 

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -117,7 +117,7 @@ export default function Entry() {
   const coinGeckoPrice = useCoinGeckoPriceSWR();
 
   const { currentChain, setCurrentChain } = useCurrentChain();
-  const { addAllowedChainId, currentAllowedChains } = useCurrentAllowedChains();
+  const { currentAllowedChains, addAllowedChainId } = useCurrentAllowedChains();
 
   const { currentEthereumNetwork, setCurrentEthereumNetwork } = useCurrentEthereumNetwork();
 
@@ -395,7 +395,7 @@ export default function Entry() {
       return [
         ...filteredTokens.filter((item) => gt(item.balance, '0')).sort((a, b) => (gt(a.price, b.price) ? -1 : 1)),
         ...filteredTokens.filter((item) => !gt(item.balance, '0')),
-      ].sort((a) => (currentFromChain?.displayDenom === a.displayDenom ? -1 : 1));
+      ].sort((a) => (currentFromChain?.displayDenom === a.displayDenom && a.origin_type === 'staking' ? -1 : 1));
     }
 
     if (currentSwapAPI === '1inch' && oneInchTokens.data) {
@@ -515,7 +515,7 @@ export default function Entry() {
       return [
         ...filteredTokens.filter((item) => gt(item.balance, '0')).sort((a, b) => (gt(a.price, b.price) ? -1 : 1)),
         ...filteredTokens.filter((item) => !gt(item.balance, '0')),
-      ].sort((a) => (currentToChain?.displayDenom === a.displayDenom ? -1 : 1));
+      ].sort((a) => (currentToChain?.displayDenom === a.displayDenom && a.origin_type === 'staking' ? -1 : 1));
     }
 
     if (currentSwapAPI === '1inch' && oneInchTokens.data) {
@@ -1290,12 +1290,6 @@ export default function Entry() {
       if (currentChain.line !== ETHEREUM.line) {
         void setCurrentChain(ETHEREUM);
       }
-    }
-    if (currentFromChain.line === COSMOS.line && !isEqualsIgnoringCase(currentChain.id, currentFromChain.id)) {
-      if (!currentAllowedChains.find((item) => isEqualsIgnoringCase(item.id, currentFromChain.id))) {
-        void addAllowedChainId(currentFromChain);
-      }
-      void setCurrentChain(currentFromChain);
     }
   }, [addAllowedChainId, currentAllowedChains, currentChain.id, currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
 

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -33,7 +33,6 @@ import { useSquidSwap } from '~/Popup/hooks/SWR/integratedSwap/squid/useSquidSwa
 import { useSupportSwapChainsSWR } from '~/Popup/hooks/SWR/integratedSwap/useSupportSwapChainsSWR';
 import { useCoinGeckoPriceSWR } from '~/Popup/hooks/SWR/useCoinGeckoPriceSWR';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
-import { useCurrentAllowedChains } from '~/Popup/hooks/useCurrent/useCurrentAllowedChains';
 import { useCurrentChain } from '~/Popup/hooks/useCurrent/useCurrentChain';
 import { useCurrentEthereumNetwork } from '~/Popup/hooks/useCurrent/useCurrentEthereumNetwork';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
@@ -117,8 +116,6 @@ export default function Entry() {
   const coinGeckoPrice = useCoinGeckoPriceSWR();
 
   const { currentChain, setCurrentChain } = useCurrentChain();
-  const { currentAllowedChains, addAllowedChainId } = useCurrentAllowedChains();
-
   const { currentEthereumNetwork, setCurrentEthereumNetwork } = useCurrentEthereumNetwork();
 
   const [isOpenSlippageDialog, setIsOpenSlippageDialog] = useState(false);
@@ -1291,7 +1288,7 @@ export default function Entry() {
         void setCurrentChain(ETHEREUM);
       }
     }
-  }, [addAllowedChainId, currentAllowedChains, currentChain.id, currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
+  }, [currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
 
   return (
     <>

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -33,6 +33,7 @@ import { useSquidSwap } from '~/Popup/hooks/SWR/integratedSwap/squid/useSquidSwa
 import { useSupportSwapChainsSWR } from '~/Popup/hooks/SWR/integratedSwap/useSupportSwapChainsSWR';
 import { useCoinGeckoPriceSWR } from '~/Popup/hooks/SWR/useCoinGeckoPriceSWR';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
+import { useCurrentAllowedChains } from '~/Popup/hooks/useCurrent/useCurrentAllowedChains';
 import { useCurrentChain } from '~/Popup/hooks/useCurrent/useCurrentChain';
 import { useCurrentEthereumNetwork } from '~/Popup/hooks/useCurrent/useCurrentEthereumNetwork';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
@@ -116,6 +117,8 @@ export default function Entry() {
   const coinGeckoPrice = useCoinGeckoPriceSWR();
 
   const { currentChain, setCurrentChain } = useCurrentChain();
+  const { addAllowedChainId, currentAllowedChains } = useCurrentAllowedChains();
+
   const { currentEthereumNetwork, setCurrentEthereumNetwork } = useCurrentEthereumNetwork();
 
   const [isOpenSlippageDialog, setIsOpenSlippageDialog] = useState(false);
@@ -1288,7 +1291,13 @@ export default function Entry() {
         void setCurrentChain(ETHEREUM);
       }
     }
-  }, [currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
+    if (currentFromChain.line === COSMOS.line && !isEqualsIgnoringCase(currentChain.id, currentFromChain.id)) {
+      if (!currentAllowedChains.find((item) => isEqualsIgnoringCase(item.id, currentFromChain.id))) {
+        void addAllowedChainId(currentFromChain);
+      }
+      void setCurrentChain(currentFromChain);
+    }
+  }, [addAllowedChainId, currentAllowedChains, currentChain.id, currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
 
   return (
     <>

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -33,7 +33,6 @@ import { useSquidSwap } from '~/Popup/hooks/SWR/integratedSwap/squid/useSquidSwa
 import { useSupportSwapChainsSWR } from '~/Popup/hooks/SWR/integratedSwap/useSupportSwapChainsSWR';
 import { useCoinGeckoPriceSWR } from '~/Popup/hooks/SWR/useCoinGeckoPriceSWR';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
-import { useCurrentAllowedChains } from '~/Popup/hooks/useCurrent/useCurrentAllowedChains';
 import { useCurrentChain } from '~/Popup/hooks/useCurrent/useCurrentChain';
 import { useCurrentEthereumNetwork } from '~/Popup/hooks/useCurrent/useCurrentEthereumNetwork';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
@@ -117,7 +116,6 @@ export default function Entry() {
   const coinGeckoPrice = useCoinGeckoPriceSWR();
 
   const { currentChain, setCurrentChain } = useCurrentChain();
-  const { currentAllowedChains, addAllowedChainId } = useCurrentAllowedChains();
 
   const { currentEthereumNetwork, setCurrentEthereumNetwork } = useCurrentEthereumNetwork();
 
@@ -1291,7 +1289,7 @@ export default function Entry() {
         void setCurrentChain(ETHEREUM);
       }
     }
-  }, [addAllowedChainId, currentAllowedChains, currentChain.id, currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
+  }, [currentChain.id, currentChain.line, currentFromChain, setCurrentChain, setCurrentEthereumNetwork]);
 
   return (
     <>


### PR DESCRIPTION
Swap 페이지 진입 전 체인과 실제 스왑을 진행 한(Tx를 전송 한) 체인이 다를 때 Tx receipt페이지에 실제 스왑을 진행한 체인이 아닌 Swap페이지 진입 전 선택 체인으로 설정되어 있는 이슈를 수정합니다.

- 통합 스왑 페이지에서 코스모스 체인들의 토큰 리스팅 로직을 수정했습니다
 - 'staking'타입의 코인을 최우선 정렬했습니다.
- receipt 페이지 라우팅 파라미터에 chain id(옵셔널)를 추가했습니다 
- currentAllowed. currentChain 훅에서 선언된 변수들을 useMemo로 선언하도록 수정했습니다.