### PR TITLE
[WEB-2027] 1inch api v5.2 버젼 업그레이드 반영

### DIFF
--- a/.env.chrome
+++ b/.env.chrome
@@ -1,3 +1,4 @@
 BROWSER=chrome
 RUN_MODE=production
 VERSION=0.7.4
+ONEINCH_API_KEY=djFmxTIuhIwZYX5bcNMSqnUme6OTUXtX

--- a/.env.chrome.development
+++ b/.env.chrome.development
@@ -1,3 +1,4 @@
 BROWSER=chrome
 RUN_MODE=development
 VERSION=0.7.4
+ONEINCH_API_KEY=djFmxTIuhIwZYX5bcNMSqnUme6OTUXtX

--- a/.env.firefox
+++ b/.env.firefox
@@ -1,3 +1,4 @@
 BROWSER=firefox
 RUN_MODE=production
 VERSION=0.7.4
+ONEINCH_API_KEY=djFmxTIuhIwZYX5bcNMSqnUme6OTUXtX

--- a/.env.firefox.development
+++ b/.env.firefox.development
@@ -1,3 +1,4 @@
 BROWSER=firefox
 RUN_MODE=development
 VERSION=0.7.4
+ONEINCH_API_KEY=djFmxTIuhIwZYX5bcNMSqnUme6OTUXtX

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
@@ -2,7 +2,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
-import { ONEINCH_BASE_URL } from '~/constants/1inch';
+import { ONEINCH_SWAP_BASE_URL } from '~/constants/1inch';
 import { ETHEREUM } from '~/constants/chain/ethereum/ethereum';
 import { useCurrentChain } from '~/Popup/hooks/useCurrent/useCurrentChain';
 import { get } from '~/Popup/utils/axios';
@@ -17,11 +17,18 @@ type UseAllowanceSWRProps = {
 export function useAllowanceSWR(allowanceParam?: UseAllowanceSWRProps, config?: SWRConfiguration) {
   const { currentChain } = useCurrentChain();
 
-  const requestURL = `${ONEINCH_BASE_URL}/${allowanceParam?.chainId || ''}/approve/allowance?tokenAddress=${allowanceParam?.tokenAddress || ''}&walletAddress=${
-    allowanceParam?.walletAddress || ''
-  }`;
+  const requestURL = `${ONEINCH_SWAP_BASE_URL}/${allowanceParam?.chainId || ''}/approve/allowance?tokenAddress=${
+    allowanceParam?.tokenAddress || ''
+  }&walletAddress=${allowanceParam?.walletAddress || ''}`;
 
-  const fetcher = (fetchUrl: string) => get<AllowancePayload>(fetchUrl, { headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache', Expires: '0' } });
+  const fetcher = (fetchUrl: string) =>
+    get<AllowancePayload>(
+      fetchUrl,
+      { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` },
+      // {
+      //   headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache', Expires: '0' },
+      // },
+    );
 
   const { data, error, mutate } = useSWR<AllowancePayload, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
@@ -22,13 +22,9 @@ export function useAllowanceSWR(allowanceParam?: UseAllowanceSWRProps, config?: 
   }&walletAddress=${allowanceParam?.walletAddress || ''}`;
 
   const fetcher = (fetchUrl: string) =>
-    get<AllowancePayload>(
-      fetchUrl,
-      { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` },
-      {
-        headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache', Expires: '0' },
-      },
-    );
+    get<AllowancePayload>(fetchUrl, {
+      headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache', Expires: '0', Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` },
+    });
 
   const { data, error, mutate } = useSWR<AllowancePayload, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
@@ -25,16 +25,22 @@ export function useAllowanceSWR(allowanceParam?: UseAllowanceSWRProps, config?: 
     get<AllowancePayload>(
       fetchUrl,
       { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` },
-      // {
-      //   headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache', Expires: '0' },
-      // },
+      {
+        headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache', Expires: '0' },
+      },
     );
 
   const { data, error, mutate } = useSWR<AllowancePayload, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,
     dedupingInterval: 11000,
     refreshInterval: 12000,
-    errorRetryCount: 0,
+    onErrorRetry: (_, __, ___, revalidate, { retryCount }) => {
+      if (retryCount >= 6) return;
+
+      setTimeout(() => {
+        void revalidate({ retryCount });
+      }, 3000);
+    },
     isPaused: () => currentChain.id !== ETHEREUM.id || !allowanceParam,
     ...config,
   });

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceSWR.ts
@@ -34,13 +34,8 @@ export function useAllowanceSWR(allowanceParam?: UseAllowanceSWRProps, config?: 
     revalidateOnFocus: false,
     dedupingInterval: 11000,
     refreshInterval: 12000,
-    onErrorRetry: (_, __, ___, revalidate, { retryCount }) => {
-      if (retryCount >= 6) return;
-
-      setTimeout(() => {
-        void revalidate({ retryCount });
-      }, 3000);
-    },
+    errorRetryCount: 3,
+    errorRetryInterval: 2000,
     isPaused: () => currentChain.id !== ETHEREUM.id || !allowanceParam,
     ...config,
   });

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
@@ -20,13 +20,8 @@ export function useAllowanceTxSWR(allowanceTxParam?: UseAllowanceTxSWRProps, con
     revalidateOnFocus: false,
     revalidateIfStale: false,
     revalidateOnReconnect: false,
-    onErrorRetry: (_, __, ___, revalidate, { retryCount }) => {
-      if (retryCount >= 6) return;
-
-      setTimeout(() => {
-        void revalidate({ retryCount });
-      }, 3000);
-    },
+    errorRetryCount: 3,
+    errorRetryInterval: 2000,
     isPaused: () => !allowanceTxParam,
     ...config,
   });

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
@@ -20,6 +20,13 @@ export function useAllowanceTxSWR(allowanceTxParam?: UseAllowanceTxSWRProps, con
     revalidateOnFocus: false,
     revalidateIfStale: false,
     revalidateOnReconnect: false,
+    onErrorRetry: (_, __, ___, revalidate, { retryCount }) => {
+      if (retryCount >= 6) return;
+
+      setTimeout(() => {
+        void revalidate({ retryCount });
+      }, 3000);
+    },
     isPaused: () => !allowanceTxParam,
     ...config,
   });

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
@@ -2,7 +2,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
-import { ONEINCH_BASE_URL } from '~/constants/1inch';
+import { ONEINCH_SWAP_BASE_URL } from '~/constants/1inch';
 import { get } from '~/Popup/utils/axios';
 import type { AllowanceTxPayload } from '~/types/1inch/allowance';
 
@@ -12,9 +12,9 @@ type UseAllowanceTxSWRProps = {
 };
 
 export function useAllowanceTxSWR(allowanceTxParam?: UseAllowanceTxSWRProps, config?: SWRConfiguration) {
-  const requestURL = `${ONEINCH_BASE_URL}/${allowanceTxParam?.chainId || ''}/approve/transaction?tokenAddress=${allowanceTxParam?.tokenAddress || ''}`;
+  const requestURL = `${ONEINCH_SWAP_BASE_URL}/${allowanceTxParam?.chainId || ''}/approve/transaction?tokenAddress=${allowanceTxParam?.tokenAddress || ''}`;
 
-  const fetcher = (fetchUrl: string) => get<AllowanceTxPayload>(fetchUrl);
+  const fetcher = (fetchUrl: string) => get<AllowanceTxPayload>(fetchUrl, { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` });
 
   const { data, error, mutate } = useSWR<AllowanceTxPayload, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useAllowanceTxSWR.ts
@@ -14,7 +14,7 @@ type UseAllowanceTxSWRProps = {
 export function useAllowanceTxSWR(allowanceTxParam?: UseAllowanceTxSWRProps, config?: SWRConfiguration) {
   const requestURL = `${ONEINCH_SWAP_BASE_URL}/${allowanceTxParam?.chainId || ''}/approve/transaction?tokenAddress=${allowanceTxParam?.tokenAddress || ''}`;
 
-  const fetcher = (fetchUrl: string) => get<AllowanceTxPayload>(fetchUrl, { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` });
+  const fetcher = (fetchUrl: string) => get<AllowanceTxPayload>(fetchUrl, { headers: { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` } });
 
   const { data, error, mutate } = useSWR<AllowanceTxPayload, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
@@ -41,7 +41,13 @@ export function useOneInchSwapTxSWR(swapParam?: UseOneInchSwapSWRProps, config?:
     revalidateOnFocus: false,
     dedupingInterval: 14000,
     refreshInterval: 15000,
-    errorRetryCount: 0,
+    onErrorRetry: (_, __, ___, revalidate, { retryCount }) => {
+      if (retryCount >= 6) return;
+
+      setTimeout(() => {
+        void revalidate({ retryCount });
+      }, 3000);
+    },
     isPaused: () => !swapParam,
     ...config,
   });

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
@@ -2,7 +2,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
-import { FEE_RATIO, ONEINCH_BASE_URL, REFERRER_ADDRESS } from '~/constants/1inch';
+import { FEE_RATIO, ONEINCH_SWAP_BASE_URL, REFERRER_ADDRESS } from '~/constants/1inch';
 import { get } from '~/Popup/utils/axios';
 import type { OneInchSwapPayload } from '~/types/1inch/swap';
 
@@ -29,14 +29,13 @@ export type UseOneInchSwapSWRProps = {
 };
 
 export function useOneInchSwapTxSWR(swapParam?: UseOneInchSwapSWRProps, config?: SWRConfiguration) {
-  const requestURL = `${ONEINCH_BASE_URL}/${swapParam?.chainId || ''}/swap?fromTokenAddress=${swapParam?.fromTokenAddress || ''}&toTokenAddress=${
+  const requestURL = `${ONEINCH_SWAP_BASE_URL}/${swapParam?.chainId || ''}/swap?src=${swapParam?.fromTokenAddress || ''}&dst=${
     swapParam?.toTokenAddress || ''
-  }&amount=${swapParam?.amount || ''}&fromAddress=${swapParam?.fromAddress || ''}&slippage=${swapParam?.slippage || ''}&referrerAddress=${
-    REFERRER_ADDRESS || ''
-  }&fee=${FEE_RATIO || ''}
-  `;
+  }&amount=${swapParam?.amount || ''}&from=${swapParam?.fromAddress || ''}&slippage=${swapParam?.slippage || ''}&referrer=${REFERRER_ADDRESS || ''}&fee=${
+    FEE_RATIO || ''
+  }`;
 
-  const fetcher = (fetchUrl: string) => get<OneInchSwapPayload>(fetchUrl);
+  const fetcher = (fetchUrl: string) => get<OneInchSwapPayload>(fetchUrl, { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` });
 
   const { data, isValidating, error, mutate } = useSWR<OneInchSwapPayload, AxiosError<OneInchSwapError>>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
@@ -35,7 +35,7 @@ export function useOneInchSwapTxSWR(swapParam?: UseOneInchSwapSWRProps, config?:
     FEE_RATIO || ''
   }`;
 
-  const fetcher = (fetchUrl: string) => get<OneInchSwapPayload>(fetchUrl, { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` });
+  const fetcher = (fetchUrl: string) => get<OneInchSwapPayload>(fetchUrl, { headers: { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` } });
 
   const { data, isValidating, error, mutate } = useSWR<OneInchSwapPayload, AxiosError<OneInchSwapError>>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchSwapTxSWR.ts
@@ -41,13 +41,8 @@ export function useOneInchSwapTxSWR(swapParam?: UseOneInchSwapSWRProps, config?:
     revalidateOnFocus: false,
     dedupingInterval: 14000,
     refreshInterval: 15000,
-    onErrorRetry: (_, __, ___, revalidate, { retryCount }) => {
-      if (retryCount >= 6) return;
-
-      setTimeout(() => {
-        void revalidate({ retryCount });
-      }, 3000);
-    },
+    errorRetryCount: 3,
+    errorRetryInterval: 2000,
     isPaused: () => !swapParam,
     ...config,
   });

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchTokensSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchTokensSWR.ts
@@ -9,7 +9,7 @@ import type { Assets } from '~/types/1inch/swap';
 export function useOneInchTokensSWR(chainId?: string, config?: SWRConfiguration) {
   const requestURL = `${ONEINCH_SWAP_BASE_URL}/${chainId || ''}/tokens`;
 
-  const fetcher = (fetchUrl: string) => get<Assets>(fetchUrl, { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` });
+  const fetcher = (fetchUrl: string) => get<Assets>(fetchUrl, { headers: { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` } });
 
   const { data, error, mutate } = useSWR<Assets, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchTokensSWR.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/SWR/useOneInchTokensSWR.ts
@@ -2,14 +2,14 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
-import { ONEINCH_BASE_URL } from '~/constants/1inch';
+import { ONEINCH_SWAP_BASE_URL } from '~/constants/1inch';
 import { get } from '~/Popup/utils/axios';
 import type { Assets } from '~/types/1inch/swap';
 
 export function useOneInchTokensSWR(chainId?: string, config?: SWRConfiguration) {
-  const requestURL = `${ONEINCH_BASE_URL}/${chainId || ''}/tokens`;
+  const requestURL = `${ONEINCH_SWAP_BASE_URL}/${chainId || ''}/tokens`;
 
-  const fetcher = (fetchUrl: string) => get<Assets>(fetchUrl);
+  const fetcher = (fetchUrl: string) => get<Assets>(fetchUrl, { Authorization: `Bearer ${String(process.env.ONEINCH_API_KEY)}` });
 
   const { data, error, mutate } = useSWR<Assets, AxiosError>(requestURL, fetcher, {
     revalidateOnFocus: false,

--- a/src/Popup/hooks/SWR/integratedSwap/oneInch/useOneInchSwap.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/oneInch/useOneInchSwap.ts
@@ -39,7 +39,7 @@ export function useOneInchSwap(oneInchSwapProps?: UseOneInchSwapProps) {
   );
 
   const allowanceTxData = useAllowanceTxSWR(
-    !gt(allowance.data?.allowance || '0', inputBaseAmount) && fromToken?.address && fromChain?.chainId
+    allowance.data && !gt(allowance.data.allowance, inputBaseAmount) && fromToken?.address && fromChain?.chainId
       ? {
           tokenAddress: fromToken.address,
           chainId: fromChain.chainId,

--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -612,11 +612,11 @@ export default function Entry({ queue }: EntryProps) {
                           origin,
                         });
 
+                        // FIXME approve tx전송 후 스왑 페이지가 아닌 receipt페이지로 이동하는 현상 발견
                         if (queue.channel === 'inApp') {
                           if (txType.data?.contractKind === 'erc20' && txType.data?.type === 'approve') {
                             await deQueue(`/wallet/swap/${currentEthereumNetwork.id}` as unknown as Path);
-                          }
-                          if (result) {
+                          } else if (result) {
                             await deQueue(`/popup/tx-receipt/${result}` as unknown as Path);
                           } else {
                             await deQueue();

--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -612,11 +612,8 @@ export default function Entry({ queue }: EntryProps) {
                           origin,
                         });
 
-                        // FIXME approve tx전송 후 스왑 페이지가 아닌 receipt페이지로 이동하는 현상 발견
                         if (queue.channel === 'inApp') {
-                          if (txType.data?.contractKind === 'erc20' && txType.data?.type === 'approve') {
-                            await deQueue(`/wallet/swap/${currentEthereumNetwork.id}` as unknown as Path);
-                          } else if (result) {
+                          if (result) {
                             await deQueue(`/popup/tx-receipt/${result}` as unknown as Path);
                           } else {
                             await deQueue();

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -1271,9 +1271,6 @@ export default function Entry() {
 
   useEffect(() => {
     if (currentFromToken) {
-      if (currentSwapAPI === '1inch') {
-        void oneInchAllowance.mutate();
-      }
       if (currentSwapAPI === 'squid') {
         void squidAllowance.mutate();
       }

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -779,8 +779,8 @@ export default function Entry() {
       return skipRoute.data?.amount_out;
     }
 
-    if (currentSwapAPI === '1inch' && oneInchRoute.data?.toTokenAmount) {
-      return oneInchRoute.data.toTokenAmount;
+    if (currentSwapAPI === '1inch' && oneInchRoute.data?.toAmount) {
+      return oneInchRoute.data?.toAmount;
     }
 
     if (currentSwapAPI === 'squid' && squidRoute.data?.route.estimate.toAmount) {
@@ -788,7 +788,7 @@ export default function Entry() {
     }
 
     return '0';
-  }, [currentSwapAPI, oneInchRoute.data?.toTokenAmount, skipRoute.data?.amount_out, squidRoute.data?.route.estimate.toAmount]);
+  }, [currentSwapAPI, oneInchRoute.data?.toAmount, skipRoute.data?.amount_out, squidRoute.data?.route.estimate.toAmount]);
 
   const estimatedToTokenDisplayAmount = useMemo(
     () => toDisplayDenomAmount(estimatedToTokenBaseAmount, currentToToken?.decimals || 0),

--- a/src/Popup/utils/axios.ts
+++ b/src/Popup/utils/axios.ts
@@ -1,11 +1,12 @@
-import type { AxiosError, AxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosRequestHeaders } from 'axios';
 import axios from 'axios';
 
-export async function get<T>(path: string, config?: AxiosRequestConfig): Promise<T> {
+export async function get<T>(path: string, customHeaders?: AxiosRequestHeaders, config?: AxiosRequestConfig): Promise<T> {
   const { data } = await axios.get<T>(path, {
     ...config,
     headers: {
       Cosmostation: `extension/${String(process.env.VERSION)}`,
+      ...customHeaders,
       ...config?.headers,
     },
   });

--- a/src/Popup/utils/axios.ts
+++ b/src/Popup/utils/axios.ts
@@ -1,12 +1,11 @@
-import type { AxiosError, AxiosRequestConfig, AxiosRequestHeaders } from 'axios';
+import type { AxiosError, AxiosRequestConfig } from 'axios';
 import axios from 'axios';
 
-export async function get<T>(path: string, customHeaders?: AxiosRequestHeaders, config?: AxiosRequestConfig): Promise<T> {
+export async function get<T>(path: string, config?: AxiosRequestConfig): Promise<T> {
   const { data } = await axios.get<T>(path, {
     ...config,
     headers: {
       Cosmostation: `extension/${String(process.env.VERSION)}`,
-      ...customHeaders,
       ...config?.headers,
     },
   });

--- a/src/constants/1inch.ts
+++ b/src/constants/1inch.ts
@@ -1,4 +1,4 @@
-export const ONEINCH_BASE_URL = 'https://api-cosmostation.1inch.io/v5.0';
+export const ONEINCH_SWAP_BASE_URL = 'https://api.1inch.dev/swap/v5.2';
 
 export const REFERRER_ADDRESS = undefined;
 

--- a/src/types/1inch/swap.ts
+++ b/src/types/1inch/swap.ts
@@ -1,9 +1,5 @@
 export type OneInchSwapPayload = {
-  // fromToken: Token;
-  // toToken: Token;
   toAmount: string;
-  // fromTokenAmount: string;
-  // protocols: Array<Array<Protocol[]>>;
   tx: Tx;
 };
 

--- a/src/types/1inch/swap.ts
+++ b/src/types/1inch/swap.ts
@@ -1,9 +1,9 @@
 export type OneInchSwapPayload = {
-  fromToken: Token;
-  toToken: Token;
-  toTokenAmount: string;
-  fromTokenAmount: string;
-  protocols: Array<Array<Protocol[]>>;
+  // fromToken: Token;
+  // toToken: Token;
+  toAmount: string;
+  // fromTokenAmount: string;
+  // protocols: Array<Array<Protocol[]>>;
   tx: Tx;
 };
 


### PR DESCRIPTION
1inch api의 버젼이 올라가면서 변경된 부분들을 수정했습니다.

- 불필요한 mutate선언을 삭제했습니다.
- apporve설정 후 tx receipt페이지로 이동할 수 있도록 수정했습니다.
- 현재 두 요청간 간격이 짧으면 두번째 요청에서 429에러를 리턴합니다. 임시방편으로 재시도 간격을 3초로 설정하여 기능상 문제가 없도록 작업했습니다.