### PR TITLE
[WEB-2035] IBC 수신 체인 리스트 중복 제거

### DIFF
--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -251,7 +251,12 @@ export default function IBCSend({ chain }: IBCSendProps) {
           isEqualsIgnoringCase(convertAssetNameToCosmos(asset.prevChain || '')?.id, chain.id) &&
           cosmosAssetNames.includes(asset.prevChain || ''),
       );
-      return assets.map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }));
+      return assets
+        .map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }))
+        .filter(
+          (receiverIBC, idx, arr) =>
+            arr.findIndex((item) => item.chain.id === receiverIBC.chain.id && item.channel === receiverIBC.channel && item.port === receiverIBC.port) === idx,
+        );
     }
 
     if (currentCoinOrToken.type === 'coin' && currentCoinOrToken.coinType === 'ibc') {
@@ -268,12 +273,20 @@ export default function IBCSend({ chain }: IBCSendProps) {
       return [
         ...assets.map((item) => ({ chain: convertAssetNameToCosmos(item.prevChain || '')!, channel: item.channel!, port: item.port! })),
         ...counterPartyAssets.map((item) => ({ chain: convertAssetNameToCosmos(item.chain || '')!, channel: item.counter_party!.channel, port: item.port! })),
-      ];
+      ].filter(
+        (receiverIBC, idx, arr) =>
+          arr.findIndex((item) => item.chain.id === receiverIBC.chain.id && item.channel === receiverIBC.channel && item.port === receiverIBC.port) === idx,
+      );
     }
 
     if (currentCoinOrToken.type === 'token') {
       const assets = filteredCosmosChainAssets.filter((asset) => isEqualsIgnoringCase(asset.counter_party?.denom, currentCoinOrToken.address));
-      return assets.map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }));
+      return assets
+        .map((item) => ({ chain: convertAssetNameToCosmos(item.chain)!, channel: item.counter_party!.channel, port: item.counter_party!.port }))
+        .filter(
+          (receiverIBC, idx, arr) =>
+            arr.findIndex((item) => item.chain.id === receiverIBC.chain.id && item.channel === receiverIBC.channel && item.port === receiverIBC.port) === idx,
+        );
     }
 
     return [];


### PR DESCRIPTION
 IBC send 페이지에서 수신 체인의 중복값을 필터링했습니다.
<img width="525" alt="스크린샷 2023-10-19 오후 6 03 00" src="https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/84484409-0237-41ca-a9e1-36bade5ba004">
![image_480-1](https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/c126de08-f7c7-43ce-a7b2-b2f20d82b4fd)
