### PR TITLE
[WEB-2062] Add ONOMY protocol to Cosmos asset name map

### DIFF
--- a/src/Popup/utils/cosmos.ts
+++ b/src/Popup/utils/cosmos.ts
@@ -18,6 +18,7 @@ import { IXO } from '~/constants/chain/cosmos/ixo';
 import { KAVA } from '~/constants/chain/cosmos/kava';
 import { KI } from '~/constants/chain/cosmos/ki';
 import { MARS } from '~/constants/chain/cosmos/mars';
+import { ONOMY } from '~/constants/chain/cosmos/onomy';
 import { PROVENANCE } from '~/constants/chain/cosmos/provenance';
 import { SEI } from '~/constants/chain/cosmos/sei';
 import { STAFIHUB } from '~/constants/chain/cosmos/stafihub';
@@ -185,6 +186,7 @@ export function convertCosmosToAssetName(cosmosChain: CosmosChain) {
     [STAFIHUB.id]: 'stafi',
     [FETCH_AI.id]: 'fetchai',
     [MARS.id]: 'mars-protocol',
+    [ONOMY.id]: 'onomy-protocol',
   };
   return nameMap[cosmosChain.id] || cosmosChain.chainName.toLowerCase();
 }
@@ -198,6 +200,7 @@ export function convertAssetNameToCosmos(assetName: string) {
     stafi: STAFIHUB,
     fetchai: FETCH_AI,
     'mars-protocol': MARS,
+    'onomy-protocol': ONOMY,
   } as Record<string, CosmosChain | undefined>;
 
   return nameMap[assetName] || COSMOS_CHAINS.find((item) => item.chainName.toLowerCase() === assetName);

--- a/src/constants/chain/cosmos/dydx.ts
+++ b/src/constants/chain/cosmos/dydx.ts
@@ -21,6 +21,7 @@ export const DYDX: CosmosChain = {
   },
   bech32Prefix: { address: 'dydx' },
   explorerURL: `${MINTSCAN_URL}/dydx`,
+  coinGeckoId: 'dydx-chain',
   gasRate: {
     tiny: '12500000000',
     low: '12500000000',


### PR DESCRIPTION
Onomy체인에서 chain list 데이터를 사용할 수 있도록 `onomy-protocol`을 네임 맵핑에 추가했습니다