### PR TITLE
[WEB-2080] Add default revisionHeight in skip swap ibc tx

### DIFF
--- a/src/Popup/hooks/SWR/integratedSwap/skip/useSkipSwap.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/skip/useSkipSwap.ts
@@ -168,7 +168,10 @@ export function useSkipSwap(skipSwapProps?: UseSkipSwapProps) {
 
   const channelChainLatestBlock = useBlockLatestSWR(channelChain);
 
-  const latestHeight = useMemo(() => channelChainLatestBlock.data?.block?.header?.height, [channelChainLatestBlock.data?.block?.header?.height]);
+  const latestHeight = useMemo(
+    () => channelChainLatestBlock.data?.block?.header?.height || clientState.data?.identified_client_state?.client_state?.latest_height?.revision_height,
+    [channelChainLatestBlock.data?.block?.header?.height, clientState.data?.identified_client_state?.client_state?.latest_height?.revision_height],
+  );
 
   const revisionHeight = useMemo(() => (latestHeight ? String(100 + parseInt(latestHeight, 10)) : undefined), [latestHeight]);
 
@@ -180,7 +183,7 @@ export function useSkipSwap(skipSwapProps?: UseSkipSwapProps) {
   const skipSwapAminoTxMsgs = useMemo(
     () =>
       skipSwapParsedTx.map((item) => {
-        if (item?.msg_type_url === 'cosmos-sdk/MsgTransfer' && revisionHeight && revisionNumber) {
+        if (item?.msg_type_url === 'cosmos-sdk/MsgTransfer' && !!revisionHeight && !!revisionNumber) {
           return {
             ...item,
             msg: {

--- a/src/Popup/utils/cosmos.ts
+++ b/src/Popup/utils/cosmos.ts
@@ -205,6 +205,22 @@ export function convertAssetNameToCosmos(assetName: string) {
   return nameMap[assetName] || COSMOS_CHAINS.find((item) => item.chainName.toLowerCase() === assetName);
 }
 
+export function findCosmosChainByAddress(address?: string) {
+  if (!address || !isValidCosmosAddress(address)) {
+    return undefined;
+  }
+
+  return COSMOS_CHAINS.find((item) => bech32.decode(address).prefix === item.bech32Prefix.address);
+}
+
+export function isValidCosmosAddress(address: string): boolean {
+  try {
+    return COSMOS_CHAINS.some((chain) => chain.bech32Prefix.address === bech32.decode(address).prefix);
+  } catch (e) {
+    return false;
+  }
+}
+
 export function getMsgSignData(signer: string, message: string) {
   return {
     account_number: '0',


### PR DESCRIPTION
v 0.7.5 버전에서 변경된 `revisionHeight`을 구하는 로직이 skip 스왑에서 문제가 생기는 케이스가 있어 ~~기존 방식으로 구한 revisionHeight 값을 디폴트 값으로 추가합니다.~~
수신 주소의 prefix를 파싱해서 얻은 값으로 체인을 특정하는 방식으로 수정했습니다.


문제 상황: dydx(DYDX) → dydx(USDC) 케이스에서 dydx → osmosis로 ibc전송을 하게 되는데 dydx의 chainlist에는 osmosis가 정의되어 있지 않아서 revisionHeight를 구할 수 없는 상황입니다.