### PR TITLE
[WEB-2087] 스왑 가능한 토큰 리스팅 로직 수정

### DIFF
--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -440,7 +440,7 @@ export default function Entry() {
       }));
     }
 
-    if (currentSwapAPI === 'squid_cosmos') {
+    if (currentSwapAPI === 'squid_cosmos' && currentFromChain.line === COSMOS.line) {
       const squidTokens = filterSquidTokens(currentFromChain?.chainId);
 
       const filteredTokens = cosmosFromTokenAssets.data
@@ -467,7 +467,7 @@ export default function Entry() {
       ].sort((a) => (currentFromChain?.displayDenom === a.displayDenom && a.origin_type === 'staking' ? -1 : 1));
     }
 
-    if (currentSwapAPI === 'squid_evm') {
+    if (currentSwapAPI === 'squid_evm' && currentFromChain.line === ETHEREUM.line) {
       const filteredTokens = filterSquidTokens(currentFromChain?.chainId);
 
       return [
@@ -500,6 +500,7 @@ export default function Entry() {
     coinGeckoPrice.data,
     extensionStorage.currency,
     cosmosFromChainBalance.data?.balance,
+    currentFromChain.line,
     currentFromEVMNativeBalance.data?.result,
     currentEthereumNetwork.coinGeckoId,
     currentFromEthereumTokens,


### PR DESCRIPTION
스퀴드 api로 코스모스 체인간 스왑을 지원하면서 생긴 부수적인 문제들을 수정했습니다.

문제점
- 선택된 api가 스퀴드 에서 스킵으로 변경되는 타이밍에 스퀴드(코스모스) 토큰 리스트와 스킵의 토큰 리스트 중 겹치는 토큰이 자동 선택될 경우 스킵의 토큰 리스트가 아닌 스퀴드의 리스트를 사용합니다.

케이스 재현
1. 오스모(오스모시스 토큰) - > 오스모(토큰 상관없음) 선택
2. 송신 체인을 이더리움 체인으로 변경하여 스퀴드 스왑으로 api를 변경시킴
3. 다시 오스모시스 체인으로 변경
4. 이 상태에서 스왑 input값을 아무리 입력해도 api요청을 하지 않음