### PR TITLE
[WEB-2091] Skip swap price `swap_price_impact_percent`리스폰스 타입 지원

### DIFF
--- a/src/Popup/components/common/InformContainer/styled.tsx
+++ b/src/Popup/components/common/InformContainer/styled.tsx
@@ -11,6 +11,7 @@ export const Container = styled('div')<ContainerProps>(({ ...props }) => ({
   display: 'flex',
   backgroundColor: props['data-varient'] === 'info' ? 'rgba(39, 189, 105, 0.15)' : 'rgba(205, 26, 26, 0.15)',
   borderRadius: '0.8rem',
+  wordBreak: 'break-word',
 }));
 
 type TextContainerProps = {

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -1585,7 +1585,6 @@
           "insufficientFeeAmount": "Insufficient fee",
           "invalidAmount": "Invalid amount",
           "invalidOutputAmount": "Invalid output amount",
-          "invalidPriceImpact": "Too high Price Impact",
           "invalidSwapTx": "Invalid tx data",
           "lessThanFeeWarningDescription1": "You do not have enough balance to cover the estimated gas costs for this transaction. Make sure you have more than",
           "lessThanFeeWarningDescription2": "before trying again.",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -1585,7 +1585,6 @@
           "insufficientFeeAmount": "수수료가 부족합니다.",
           "invalidAmount": "수량을 입력하세요.",
           "invalidOutputAmount": "예상 교환치가 없습니다.",
-          "invalidPriceImpact": "가격 변동치가 지나치게 높습니다.",
           "invalidSwapTx": "Invalid tx data",
           "lessThanFeeWarningDescription1": "예상 가스비를 위한 잔액이 부족합니다. 잔액이",
           "lessThanFeeWarningDescription2": "이상인지 확인하세요.",

--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -962,12 +962,16 @@ export default function Entry() {
   }, [currentSwapAPI, estimatedToTokenDisplayAmount, inputDisplayAmount, squidSwap.squidRoute?.data?.route.estimate.exchangeRate]);
 
   const priceImpactPercent = useMemo(() => {
+    if (currentSwapAPI === 'skip' && skipRoute.data?.swap_price_impact_percent) {
+      return skipRoute.data.swap_price_impact_percent;
+    }
+
     if ((currentSwapAPI === 'squid_evm' || currentSwapAPI === 'squid_cosmos') && squidSwap.squidRoute?.data) {
       return squidSwap.squidRoute.data.route.estimate.aggregatePriceImpact;
     }
 
     return '0';
-  }, [currentSwapAPI, squidSwap.squidRoute?.data]);
+  }, [currentSwapAPI, skipRoute.data?.swap_price_impact_percent, squidSwap.squidRoute?.data]);
 
   const integratedEVMSwapTx = useMemo(() => {
     if (gt(integratedAllowance?.allowance || '0', currentInputBaseAmount)) {
@@ -1173,9 +1177,7 @@ export default function Entry() {
       if (gt(estimatedToTokenDisplayAmountPrice, '100000')) {
         return t('pages.Wallet.Swap.entry.oversizedSwap');
       }
-      if (gt(priceImpactPercent, '3')) {
-        return t('pages.Wallet.Swap.entry.invalidPriceImpact');
-      }
+
       if (currentSwapAPI === 'squid_evm') {
         if (!integratedEVMSwapTx) {
           return t('pages.Wallet.Swap.entry.invalidSwapTx');
@@ -1217,7 +1219,6 @@ export default function Entry() {
     skipSwapAminoTx,
     integratedEVMSwapTx,
     estimatedToTokenDisplayAmountPrice,
-    priceImpactPercent,
   ]);
 
   const swapInfoMessage = useMemo(() => {
@@ -1261,6 +1262,9 @@ export default function Entry() {
       }
 
       if (currentSwapAPI === 'skip') {
+        if (gt(priceImpactPercent, '3')) {
+          return t('pages.Wallet.Swap.entry.liquidityWarning');
+        }
         if (skipRoute.data?.txs_required && skipRoute.data?.txs_required > 1) {
           return t('pages.Wallet.Swap.entry.multiTxSwap');
         }
@@ -1665,7 +1669,7 @@ export default function Entry() {
                 </SwapInfoBodyRightContainer>
               </SwapInfoBodyTextContainer>
 
-              {(currentSwapAPI === 'squid_evm' || currentSwapAPI === 'squid_cosmos') && (
+              {currentSwapAPI !== '1inch' && (
                 <SwapInfoBodyTextContainer>
                   <SwapInfoBodyLeftContainer>
                     <Typography variant="h6">{t('pages.Wallet.Swap.entry.priceImpact')}</Typography>
@@ -1674,13 +1678,9 @@ export default function Entry() {
                     {isLoadingSwapData ? (
                       <Skeleton width="4rem" height="1.5rem" />
                     ) : priceImpactPercent !== '0' ? (
-                      <SwapInfoBodyRightTextContainer data-is-invalid={gt(priceImpactPercent, '5')}>
-                        <Typography variant="h6n">{` ${gt(priceImpactPercent, '0') ? `-` : ``} ${
-                          lt(priceImpactPercent.replace('-', ''), 0.01) ? `<` : ``
-                        }`}</Typography>
-                        &nbsp;
+                      <SwapInfoBodyRightTextContainer data-is-invalid={gt(priceImpactPercent, '3')}>
                         <NumberText typoOfIntegers="h6n" typoOfDecimals="h7n" fixed={2}>
-                          {priceImpactPercent.replace('-', '')}
+                          {priceImpactPercent}
                         </NumberText>
                         <Typography variant="h6n">%</Typography>
                       </SwapInfoBodyRightTextContainer>

--- a/src/Popup/utils/calculate.ts
+++ b/src/Popup/utils/calculate.ts
@@ -1,0 +1,7 @@
+import { divide, minus, times } from './big';
+
+export function calcPriceImpact(amountIn: string, amountOut: string): string {
+  if (amountIn === '0' || amountOut === '0') return '0';
+
+  return times(divide(minus(amountIn, amountOut), amountIn), '100');
+}

--- a/src/types/swap/skip.ts
+++ b/src/types/swap/skip.ts
@@ -41,6 +41,16 @@ export type Affiliates = {
   address: string;
 };
 
+export const WARNING_TYPE = {
+  BAD_PRICE_WARNING: 'BAD_PRICE_WARNING',
+  LOW_INFO_WARNING: 'LOW_INFO_WARNING',
+} as const;
+
+export type Warning = {
+  type: ValueOf<typeof WARNING_TYPE>;
+  message: string;
+};
+
 export type SkipRoutePayload = {
   source_asset_denom: string;
   source_asset_chain_id: string;
@@ -56,10 +66,7 @@ export type SkipRoutePayload = {
   txs_required: number;
   usd_amount_in: string;
   usd_amount_out: string;
-  warning?: {
-    type: 'BAD_PRICE_WARNING' | 'LOW_INFO_WARNING';
-    message: string;
-  };
+  warning?: Warning;
 };
 
 export type Msg = {

--- a/src/types/swap/skip.ts
+++ b/src/types/swap/skip.ts
@@ -54,6 +54,12 @@ export type SkipRoutePayload = {
   swap_price_impact_percent?: string;
   swap_venue?: SwapVenue;
   txs_required: number;
+  usd_amount_in: string;
+  usd_amount_out: string;
+  warning?: {
+    type: 'BAD_PRICE_WARNING' | 'LOW_INFO_WARNING';
+    message: string;
+  };
 };
 
 export type Msg = {

--- a/src/types/swap/skip.ts
+++ b/src/types/swap/skip.ts
@@ -51,6 +51,7 @@ export type SkipRoutePayload = {
   chain_ids: string[];
   does_swap: boolean;
   amount_out: string;
+  swap_price_impact_percent?: string;
   swap_venue?: SwapVenue;
   txs_required: number;
 };


### PR DESCRIPTION
Skip swap에서도 price impact값을 노출하도록 api리스폰스 타입을 추가했습니다.

+) Squid swap에서 price impact에 따른 스왑 제한 해제
+) Skip, Squid swap에서 price impact가 3% 이상일 때 경고문을 노출합니다.
