### PR TITLE
[APIS-151] 코인타입 임의 변경 롤백

### DIFF
--- a/src/Popup/background/joiSchema.ts
+++ b/src/Popup/background/joiSchema.ts
@@ -58,7 +58,7 @@ export const cosAddChainParamsSchema = (chainNames: string[], officialChainIds: 
     displayDenom: Joi.string().required(),
     decimals: Joi.number().optional(),
     coinType: Joi.string()
-      .regex(/^[0-9]+$/)
+      .regex(/^[0-9]+'?$/)
       .optional(),
     addressPrefix: Joi.string().required(),
     coinGeckoId: Joi.string().optional(),

--- a/src/Popup/pages/Popup/Cosmos/AddChain/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AddChain/entry.tsx
@@ -147,7 +147,7 @@ export default function Entry({ queue }: EntryProps) {
                   purpose: "44'",
                   account: "0'",
                   change: '0',
-                  coinType: coinType ? `${coinType}'` : "118'",
+                  coinType: coinType || "118'",
                 },
                 decimals: decimals ?? 6,
                 gasRate: gasRate ?? { average: '0.025', low: '0.0025', tiny: '0.00025' },

--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -191,7 +191,7 @@ const experimentalSuggestChain: Keplr['experimentalSuggestChain'] = async (chain
           displayDenom: chainInfo.currencies[0].coinDenom,
           decimals: chainInfo.currencies[0].coinDecimals,
           restURL: chainInfo.rest,
-          coinType: String(chainInfo.bip44.coinType),
+          coinType: String(chainInfo.bip44.coinType).concat("'"),
           gasRate: chainInfo.gasPriceStep
             ? {
                 tiny: String(chainInfo.gasPriceStep.low),

--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -191,7 +191,7 @@ const experimentalSuggestChain: Keplr['experimentalSuggestChain'] = async (chain
           displayDenom: chainInfo.currencies[0].coinDenom,
           decimals: chainInfo.currencies[0].coinDecimals,
           restURL: chainInfo.rest,
-          coinType: String(chainInfo.bip44.coinType).concat("'"),
+          coinType: `${String(chainInfo.bip44.coinType)}'`,
           gasRate: chainInfo.gasPriceStep
             ? {
                 tiny: String(chainInfo.gasPriceStep.low),


### PR DESCRIPTION
- 커스템 체인 추가시에 코인 타입 값에 임의적으로 ' 를 콘케네이트하는 로직을 롤백했습니다.
- 케플러 인터페이스에서는 코인 타입 값에 임의적으로 '를 콘케네이트하는 로직을 추가했습니다.