### PR TITLE
[APIS-154] 체인 추가 코인타입 파라미터 포맷팅 & 인앱 체인추가 폼 타입 변경

### DIFF
--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -475,7 +475,7 @@
               "restURLPlaceholder": "Rest URL",
               "sendGasPlaceholder": "Send Gas value (option)",
               "submitButton": "Add a custom chain",
-              "typePlaceholder": "Chain type (option)",
+              "typePlaceholder": "Chain type (option) (e.g. ETHERMINT)",
               "warning": "A malicious chain provider can lie about the state of the blockchain and record your chain activity. Only add custom chain you trust."
             },
             "layout": {

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -462,7 +462,7 @@
               "chainIdPlaceholder": "Chain id (e.g., cosmoshub-1)",
               "chainNamePlaceholder": "Custom Chain name",
               "coinGeckoIdPlaceholder": "Coingecko API id (option)",
-              "coinTypePlaceholder": "Coin type (option) (default: 118)",
+              "coinTypePlaceholder": "Coin type (option) (default: 118')",
               "cosmWasmPlaceholder": "Cosmwasm (option)",
               "decimalsPlaceholder": "Decimals (option) (default: 6)",
               "displayDenomPlaceholder": "Currency symbol",
@@ -1792,6 +1792,11 @@
       "chainName": {
         "any": {
           "invalid": "Already registered"
+        }
+      },
+      "coinType": {
+        "any": {
+          "invalid": "The input format is not valid"
         }
       },
       "decimal": {

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -462,7 +462,7 @@
               "chainIdPlaceholder": "체인 ID (예: cosmoshub-1)",
               "chainNamePlaceholder": "커스텀 체인 이름",
               "coinGeckoIdPlaceholder": "Coingecko API id (선택)",
-              "coinTypePlaceholder": "coin type (선택) (default: 118)",
+              "coinTypePlaceholder": "coin type (선택) (default: 118')",
               "cosmWasmPlaceholder": "cosmwasm 여부 (선택) (default: false)",
               "decimalsPlaceholder": "decimals (선택) (default: 6)",
               "displayDenomPlaceholder": "통화 기호",
@@ -1792,6 +1792,11 @@
       "chainName": {
         "any": {
           "invalid": "이미 등록된 체인입니다."
+        }
+      },
+      "coinType": {
+        "any": {
+          "invalid": "입력값의 형식이 올바르지 않습니다."
         }
       },
       "decimal": {

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -475,7 +475,7 @@
               "restURLPlaceholder": "Rest URL",
               "sendGasPlaceholder": "'보내기' 가스량 (선택)",
               "submitButton": "새 체인 추가",
-              "typePlaceholder": "체인 타입 (선택)",
+              "typePlaceholder": "체인 타입 (선택) (예시:ETHERMINT)",
               "warning": "악의적인 체인 제공자는 블록체인 상태를 위조하여 개인 활동을 기록할 수도 있습니다. 신뢰 가능한 체인만 추가하세요."
             },
             "layout": {

--- a/src/Popup/pages/Chain/Cosmos/Chain/Add/entry.tsx
+++ b/src/Popup/pages/Chain/Cosmos/Chain/Add/entry.tsx
@@ -76,7 +76,7 @@ export default function Entry() {
           purpose: "44'",
           account: "0'",
           change: '0',
-          coinType: data.coinType ? (data.coinType.includes("'") ? data.coinType : `${data.coinType}'`) : "118'",
+          coinType: data.coinType ? (data.coinType.endsWith("'") ? data.coinType : `${data.coinType}'`) : "118'",
         },
         decimals: data.decimals ?? 6,
         gasRate: { average: data.gasRateAverage ?? '0.025', low: data.gasRateLow ?? '0.0025', tiny: data.gasRateTiny ?? '0.00025' },

--- a/src/Popup/pages/Chain/Cosmos/Chain/Add/entry.tsx
+++ b/src/Popup/pages/Chain/Cosmos/Chain/Add/entry.tsx
@@ -76,7 +76,7 @@ export default function Entry() {
           purpose: "44'",
           account: "0'",
           change: '0',
-          coinType: data.coinType ? `${data.coinType}'` : "118'",
+          coinType: data.coinType ? (data.coinType.includes("'") ? data.coinType : `${data.coinType}'`) : "118'",
         },
         decimals: data.decimals ?? 6,
         gasRate: { average: data.gasRateAverage ?? '0.025', low: data.gasRateLow ?? '0.0025', tiny: data.gasRateTiny ?? '0.00025' },

--- a/src/Popup/pages/Chain/Cosmos/Chain/Add/useSchema.ts
+++ b/src/Popup/pages/Chain/Cosmos/Chain/Add/useSchema.ts
@@ -109,10 +109,10 @@ export function useSchema() {
     coinType: Joi.string()
       .optional()
       .empty('')
-      .pattern(/^[0-9]+$/)
+      .pattern(/^[0-9]+'?$/)
       .messages({
         'string.base': t('schema.common.string.base'),
-        'string.pattern.base': t('schema.common.number.base'),
+        'string.pattern.base': t('schema.addChainForm.coinType.any.invalid'),
       }),
     addressPrefix: Joi.string()
       .required()

--- a/src/Popup/pages/Popup/Cosmos/AddChain/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AddChain/entry.tsx
@@ -147,7 +147,7 @@ export default function Entry({ queue }: EntryProps) {
                   purpose: "44'",
                   account: "0'",
                   change: '0',
-                  coinType: coinType ? (coinType.includes("'") ? coinType : `${coinType}'`) : "118'",
+                  coinType: coinType ? (coinType.endsWith("'") ? coinType : `${coinType}'`) : "118'",
                 },
                 decimals: decimals ?? 6,
                 gasRate: gasRate ?? { average: '0.025', low: '0.0025', tiny: '0.00025' },

--- a/src/Popup/pages/Popup/Cosmos/AddChain/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/AddChain/entry.tsx
@@ -147,7 +147,7 @@ export default function Entry({ queue }: EntryProps) {
                   purpose: "44'",
                   account: "0'",
                   change: '0',
-                  coinType: coinType || "118'",
+                  coinType: coinType ? (coinType.includes("'") ? coinType : `${coinType}'`) : "118'",
                 },
                 decimals: decimals ?? 6,
                 gasRate: gasRate ?? { average: '0.025', low: '0.0025', tiny: '0.00025' },


### PR DESCRIPTION
- 네이티브 체인 추가 메서드 파라미터중 coinType값을 자동으로 쉼표를 붙이도록 포맷팅합니다.
- 인앱 커스텀 체인 추가페이지에서 사용되는 폼을 수정했습니다.
 - 코인타입값으로 118, 118' 이 입력 가능하도록 수정했습니다.
 - 번역 문구를 추가 & 수정했습니다.