### PR TITLE
[APIS-178] 케플러 인터페이스 패키지 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "web3-utils": "^1.7.3"
   },
   "devDependencies": {
-    "@keplr-wallet/types": "^0.10.20",
+    "@keplr-wallet/types": "^0.12.67",
     "@svgr/webpack": "^6.2.1",
     "@types/big.js": "^6.1.3",
     "@types/chrome": "^0.0.193",

--- a/src/Popup/background/joiSchema.ts
+++ b/src/Popup/background/joiSchema.ts
@@ -109,6 +109,7 @@ export const cosSignAminoParamsSchema = (chainNames: string[], chainId: string) 
           value: Joi.any(),
         }),
       ),
+      timeout_height: Joi.string().optional(),
     }).required(),
     isEditFee: Joi.boolean().default(true),
     isEditMemo: Joi.boolean().default(false),

--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -171,6 +171,7 @@ const getKey: Keplr['getKey'] = async (chainId) => {
       bech32Address: account.address,
       name: account.name,
       address: new Uint8Array(),
+      isKeystone: false,
     };
   } catch (e) {
     throw new Error((e as { message?: string }).message || 'Unknown Error');
@@ -192,11 +193,11 @@ const experimentalSuggestChain: Keplr['experimentalSuggestChain'] = async (chain
           decimals: chainInfo.currencies[0].coinDecimals,
           restURL: chainInfo.rest,
           coinType: `${String(chainInfo.bip44.coinType)}'`,
-          gasRate: chainInfo.gasPriceStep
+          gasRate: chainInfo.feeCurrencies[0].gasPriceStep
             ? {
-                tiny: String(chainInfo.gasPriceStep.low),
-                low: String(chainInfo.gasPriceStep.average),
-                average: String(chainInfo.gasPriceStep.high),
+                tiny: String(chainInfo.feeCurrencies[0].gasPriceStep.low),
+                low: String(chainInfo.feeCurrencies[0].gasPriceStep.average),
+                average: String(chainInfo.feeCurrencies[0].gasPriceStep.high),
               }
             : undefined,
         },

--- a/src/types/cosmos/amino.ts
+++ b/src/types/cosmos/amino.ts
@@ -72,4 +72,5 @@ export type SignAminoDoc<T = unknown> = {
   fee: Fee;
   memo: string;
   msgs: Msg<T>[];
+  timeout_height?: string;
 };

--- a/src/types/d.ts/window.d.ts
+++ b/src/types/d.ts/window.d.ts
@@ -10,6 +10,12 @@ type Keplr = Omit<
   | 'getSecret20ViewingKey'
   | 'signEthereum'
   | 'suggestToken'
+  | 'disable'
+  | 'getKeysSettled'
+  | 'signICNSAdr36'
+  | 'experimentalSignEIP712CosmosTx_v0'
+  | 'getChainInfosWithoutEndpoints'
+  | 'changeKeyRingName'
 >;
 
 interface Window {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2260,16 +2260,12 @@
     long "^4.0.0"
     secretjs "^0.17.0"
 
-"@keplr-wallet/types@^0.10.20":
-  version "0.10.20"
-  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.10.20.tgz#034d6fc38c9b7d017a24eff113e60a527c5e7d3e"
-  integrity sha512-nE5YgfF8+xikm8o3KlXOWLWhYXra+/Zvy16ew7VFiQdGq3gGl9cRcIxwWqVoiwUmbE9bFQSP/itfMCQlM3jwQw==
+"@keplr-wallet/types@^0.12.67":
+  version "0.12.67"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.67.tgz#4ca57ad467078a28fbcdd05b052898e46be37562"
+  integrity sha512-HDEYOezWq//ug/R0lkOQWsaOYh3b9ECA8LN+tAA+baWMo81X9m9L63ux7NYw0QmoLxWqWrRO/T9F28+q2dw6+A==
   dependencies:
-    "@cosmjs/launchpad" "^0.24.0-alpha.25"
-    "@cosmjs/proto-signing" "^0.24.0-alpha.25"
-    axios "^0.21.4"
     long "^4.0.0"
-    secretjs "^0.17.0"
 
 "@keplr-wallet/unit@^0.10.24":
   version "0.10.24"
@@ -3879,7 +3875,7 @@ axios@0.27.2, axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
-axios@^0.21.1, axios@^0.21.4:
+axios@^0.21.1:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==


### PR DESCRIPTION
케플러 인터페이스를 업데이트 했습니다.

- StdSignDoc타입에 timeout_height값이 추가되어 이를 반영해 SignAminoDoc의 타입을 수정했습니다.
- 커스텀 체인 추가시 fee rate의 필드가 변경되어 이를 반영했습니다. 
- getKey호출 시 isKeystone필드를 추가하여 반환합니다.
 - 익스텐션에서는 키스톤 월렛을 지원하지 않아 기본값 false로 할당했습니다.  