### PR TITLE
[APIS-211] erc-20 에셋 리스트 fetcher 엔드포인트 변경

### DIFF
--- a/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
@@ -25,7 +25,7 @@ export function useTokensSWR(chain?: EthereumNetwork, config?: SWRConfiguration)
 
   const mappingName = nameMap[currentChain.id] || currentChain.networkName.toLowerCase();
 
-  const requestURL = `https://front.api.mintscan.io/v3/assets/${mappingName}/erc20`;
+  const requestURL = `https://front.api.mintscan.io/v10/assets/${mappingName}/erc20/info`;
 
   const fetcher = async (fetchUrl: string) => {
     try {
@@ -43,7 +43,7 @@ export function useTokensSWR(chain?: EthereumNetwork, config?: SWRConfiguration)
   });
 
   const returnData: ModifiedAsset[] =
-    data?.assets.map((item) => ({
+    data?.map((item) => ({
       chainId: toHex(item.chainId, { addPrefix: true }),
       address: item.address,
       decimals: item.decimals,

--- a/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
@@ -43,7 +43,7 @@ export function useTokensSWR(chain?: EthereumNetwork, config?: SWRConfiguration)
   });
 
   const returnData: ModifiedAsset[] =
-    data?.map((item) => ({
+    data?.map?.((item) => ({
       chainId: toHex(item.chainId, { addPrefix: true }),
       address: item.address,
       decimals: item.decimals,

--- a/src/types/ethereum/asset.ts
+++ b/src/types/ethereum/asset.ts
@@ -10,9 +10,7 @@ export type Asset = {
   default?: boolean;
 };
 
-export type AssetPayload = {
-  assets: Asset[];
-};
+export type AssetPayload = Asset[];
 
 export type ModifiedAsset = {
   chainId: string;


### PR DESCRIPTION
erc20 토큰의 리스트를 가져오는 fetcher의 엔드포인트와 리스폰스 타입을 변경했습니다

변경 전
- https://front.api.mintscan.io/v3/assets/${mappingName}/erc20 

변경 후
- https://front.api.mintscan.io/v10/assets/${mappingName}/erc20/info