### PR TITLE
[APIS-217] fee 덮어쓰기 로직 예외처리

### DIFF
--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -4,6 +4,7 @@ import secp256k1 from 'secp256k1';
 import sortKeys from 'sort-keys';
 
 import { COSMOS_DEFAULT_GAS } from '~/constants/chain';
+import { STARGAZE } from '~/constants/chain/cosmos/stargaze';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '~/constants/error';
 import Button from '~/Popup/components/common/Button';
 import OutlineButton from '~/Popup/components/common/OutlineButton';
@@ -92,7 +93,7 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const isInvalidFeeRequest = useMemo(() => !isEditFee && lt(inputGas, '1') && lt(inputFeeAmount, '1'), [inputFeeAmount, inputGas, isEditFee]);
 
-  const isNeedToReplaceFeeAmount = useMemo(() => isEditFee || isInvalidFeeRequest, [isEditFee, isInvalidFeeRequest]);
+  const isNeedToReplaceFeeAmount = useMemo(() => (isEditFee || isInvalidFeeRequest) && chain.id !== STARGAZE.id, [chain.id, isEditFee, isInvalidFeeRequest]);
 
   const [currentFeeBaseDenom, setCurrentFeeBaseDenom] = useState(
     feeCoins.find((item) => item.baseDenom === inputFee.denom)?.baseDenom ?? feeCoins[0].baseDenom,

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useSnackbar } from 'notistack';
 
+import { STARGAZE } from '~/constants/chain/cosmos/stargaze';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '~/constants/error';
 import Button from '~/Popup/components/common/Button';
 import OutlineButton from '~/Popup/components/common/OutlineButton';
@@ -94,7 +95,7 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const isInvalidFeeRequest = useMemo(() => !isEditFee && lt(inputGas, '1') && lt(inputFeeAmount, '1'), [inputFeeAmount, inputGas, isEditFee]);
 
-  const isNeedToReplaceFeeAmount = useMemo(() => isEditFee || isInvalidFeeRequest, [isEditFee, isInvalidFeeRequest]);
+  const isNeedToReplaceFeeAmount = useMemo(() => (isEditFee || isInvalidFeeRequest) && chain.id !== STARGAZE.id, [chain.id, isEditFee, isInvalidFeeRequest]);
 
   const [currentFeeBaseDenom, setCurrentFeeBaseDenom] = useState(
     feeCoins.find((item) => item.baseDenom === inputFee.denom)?.baseDenom ?? feeCoins[0].baseDenom,


### PR DESCRIPTION
현재 체인이 스타게이즈일때 fee를 덮어쓰지 않도록 예외처리합니다.