### PR TITLE
[APIS-220] Edit Cosmos Fee token listing

### DIFF
--- a/src/Popup/hooks/SWR/cosmos/useCurrentFeesSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useCurrentFeesSWR.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
 import { useCoinListSWR } from '~/Popup/hooks/SWR/cosmos/useCoinListSWR';
-import { gt } from '~/Popup/utils/big';
+import { minus } from '~/Popup/utils/big';
 import type { CosmosChain, FeeCoin } from '~/types/chain';
 
 import { useAmountSWR } from './useAmountSWR';
@@ -59,44 +59,17 @@ export function useCurrentFeesSWR(chain: CosmosChain, config?: SWRConfiguration)
         gasRate: assetGasRate.data[item.denom],
       }));
 
-    const sortedFeeCoinList = filteredFeeCoins.sort((a, b) => {
-      if (
-        gt(
-          feeCoinBaseDenoms.findIndex((item) => item === b.baseDenom),
-          feeCoinBaseDenoms.findIndex((item) => item === a.baseDenom),
-        )
-      ) {
-        return -1;
-      }
-
-      if (
-        gt(
+    const sortedFeeCoinList = filteredFeeCoins.sort((a, b) =>
+      Number(
+        minus(
           feeCoinBaseDenoms.findIndex((item) => item === a.baseDenom),
           feeCoinBaseDenoms.findIndex((item) => item === b.baseDenom),
-        )
-      ) {
-        return 1;
-      }
-
-      if (a.baseDenom === chain.baseDenom && b.baseDenom !== chain.baseDenom) {
-        return -1;
-      }
-      if (a.baseDenom !== chain.baseDenom && b.baseDenom === chain.baseDenom) {
-        return 1;
-      }
-
-      if (a.baseDenom !== chain.baseDenom && gt(a.availableAmount, '0') && !gt(b.availableAmount, '0')) {
-        return -1;
-      }
-      if (a.baseDenom !== chain.baseDenom && !gt(a.availableAmount, '0') && gt(b.availableAmount, '0')) {
-        return 1;
-      }
-
-      return 0;
-    });
+        ),
+      ),
+    );
 
     return sortedFeeCoinList.length > 0 ? sortedFeeCoinList : [coinAll[0]];
-  }, [assetGasRate.data, chain.baseDenom, coinAll, currentChainAssets.data]);
+  }, [assetGasRate.data, coinAll, currentChainAssets.data]);
 
   return { feeCoins };
 }

--- a/src/Popup/hooks/SWR/cosmos/useCurrentFeesSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useCurrentFeesSWR.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
-import { COSMOS_FEE_BASE_DENOMS } from '~/constants/chain';
 import { useCoinListSWR } from '~/Popup/hooks/SWR/cosmos/useCoinListSWR';
 import { gt } from '~/Popup/utils/big';
 import type { CosmosChain, FeeCoin } from '~/types/chain';
@@ -46,10 +45,10 @@ export function useCurrentFeesSWR(chain: CosmosChain, config?: SWRConfiguration)
   );
 
   const feeCoins: FeeCoin[] = useMemo(() => {
-    const feeBaseDenoms = COSMOS_FEE_BASE_DENOMS.find((item) => item.chainId === chain.id)?.feeBaseDenoms;
+    const feeCoinBaseDenoms = [...Object.keys(assetGasRate.data)];
 
     const filteredFeeCoins = currentChainAssets.data
-      .filter((item) => [...Object.keys(assetGasRate.data)].includes(item.denom) || feeBaseDenoms?.includes(item.denom))
+      .filter((item) => feeCoinBaseDenoms.includes(item.denom))
       .map((item) => ({
         ...item,
         originBaseDenom: item.origin_denom,
@@ -60,14 +59,44 @@ export function useCurrentFeesSWR(chain: CosmosChain, config?: SWRConfiguration)
         gasRate: assetGasRate.data[item.denom],
       }));
 
-    const sortedFeeCoinList = [
-      ...filteredFeeCoins.filter((item) => item.baseDenom === chain.baseDenom),
-      ...filteredFeeCoins.filter((item) => item.baseDenom !== chain.baseDenom && gt(item.availableAmount, '0')),
-      ...filteredFeeCoins.filter((item) => item.baseDenom !== chain.baseDenom && !gt(item.availableAmount, '0')),
-    ];
+    const sortedFeeCoinList = filteredFeeCoins.sort((a, b) => {
+      if (
+        gt(
+          feeCoinBaseDenoms.findIndex((item) => item === b.baseDenom),
+          feeCoinBaseDenoms.findIndex((item) => item === a.baseDenom),
+        )
+      ) {
+        return -1;
+      }
+
+      if (
+        gt(
+          feeCoinBaseDenoms.findIndex((item) => item === a.baseDenom),
+          feeCoinBaseDenoms.findIndex((item) => item === b.baseDenom),
+        )
+      ) {
+        return 1;
+      }
+
+      if (a.baseDenom === chain.baseDenom && b.baseDenom !== chain.baseDenom) {
+        return -1;
+      }
+      if (a.baseDenom !== chain.baseDenom && b.baseDenom === chain.baseDenom) {
+        return 1;
+      }
+
+      if (a.baseDenom !== chain.baseDenom && gt(a.availableAmount, '0') && !gt(b.availableAmount, '0')) {
+        return -1;
+      }
+      if (a.baseDenom !== chain.baseDenom && !gt(a.availableAmount, '0') && gt(b.availableAmount, '0')) {
+        return 1;
+      }
+
+      return 0;
+    });
 
     return sortedFeeCoinList.length > 0 ? sortedFeeCoinList : [coinAll[0]];
-  }, [assetGasRate.data, chain.baseDenom, chain.id, coinAll, currentChainAssets.data]);
+  }, [assetGasRate.data, chain.baseDenom, coinAll, currentChainAssets.data]);
 
   return { feeCoins };
 }

--- a/src/Popup/hooks/SWR/cosmos/useGasRateSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useGasRateSWR.ts
@@ -15,10 +15,10 @@ export function useGasRateSWR(chain: CosmosChain, config?: SWRConfiguration) {
     const result: Record<string, GasRate> = {};
 
     if (gasRate.length === 0) {
-      const exceptGasRate = COSMOS_NON_NATIVE_GAS_RATES.filter((item) => item.chainId === chain.id);
+      const nonNativeGasRates = COSMOS_NON_NATIVE_GAS_RATES.filter((item) => item.chainId === chain.id);
 
-      return exceptGasRate
-        ? exceptGasRate.reduce((acc: Record<string, GasRate>, item) => {
+      return nonNativeGasRates
+        ? nonNativeGasRates.reduce((acc: Record<string, GasRate>, item) => {
             acc[item.baseDenom] = item.gasRate;
             return acc;
           }, {})

--- a/src/Popup/hooks/SWR/cosmos/useGasRateSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useGasRateSWR.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
-import { NYX, NYX_GAS_RATES } from '~/constants/chain/cosmos/nyx';
+import { COSMOS_NON_NATIVE_GAS_RATES } from '~/constants/chain';
 import type { CosmosChain, GasRate } from '~/types/chain';
 
 import { useParamsSWR } from './useParamsSWR';
@@ -12,10 +12,18 @@ export function useGasRateSWR(chain: CosmosChain, config?: SWRConfiguration) {
   const gasRate = useMemo(() => (data ? data.params?.chainlist_params?.fee?.rate ?? [] : []), [data]);
 
   const returnData: Record<string, GasRate> = useMemo(() => {
-    const result: Record<string, GasRate> =
-      chain.baseDenom === NYX.baseDenom
-        ? { [NYX.baseDenom]: NYX_GAS_RATES.find((item) => item.chainId === NYX.id)!.gasRate }
+    const result: Record<string, GasRate> = {};
+
+    if (gasRate.length === 0) {
+      const exceptGasRate = COSMOS_NON_NATIVE_GAS_RATES.filter((item) => item.chainId === chain.id);
+
+      return exceptGasRate
+        ? exceptGasRate.reduce((acc: Record<string, GasRate>, item) => {
+            acc[item.baseDenom] = item.gasRate;
+            return acc;
+          }, {})
         : { [chain.baseDenom]: chain.gasRate };
+    }
 
     gasRate.forEach((gr, idx) => {
       const splitedItems = gr.split(',');
@@ -61,7 +69,7 @@ export function useGasRateSWR(chain: CosmosChain, config?: SWRConfiguration) {
     });
 
     return result;
-  }, [chain.baseDenom, chain.gasRate, gasRate]);
+  }, [chain.baseDenom, chain.gasRate, chain.id, gasRate]);
 
   return { data: returnData, error, mutate };
 }

--- a/src/Popup/hooks/SWR/integratedSwap/squid/useSquidCosmosSwap.ts
+++ b/src/Popup/hooks/SWR/integratedSwap/squid/useSquidCosmosSwap.ts
@@ -12,7 +12,7 @@ import { convertAssetNameToCosmos, findCosmosChainByAddress, getPublicKeyType } 
 import { protoTx, protoTxBytes } from '~/Popup/utils/proto';
 import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { CosmosChain } from '~/types/chain';
-import type { IntegratedSwapChain, IntegratedSwapToken } from '~/types/swap/asset';
+import type { IntegratedSwapChain, IntegratedSwapFeeToken, IntegratedSwapToken } from '~/types/swap/asset';
 import type { TransferPayload, WasmPayload } from '~/types/swap/squid';
 
 import { useSquidRouteSWR } from './SWR/useSquidRouteSWR';
@@ -33,6 +33,7 @@ type UseSquidCosmosSwapProps = {
   senderAddress: string;
   receiverAddress: string;
   slippage: string;
+  feeToken: IntegratedSwapFeeToken;
 };
 
 type SquidContractSwapMsg = {
@@ -56,6 +57,7 @@ export function useSquidCosmosSwap(squidSwapProps?: UseSquidCosmosSwapProps) {
   const senderAddress = useMemo(() => squidSwapProps?.senderAddress, [squidSwapProps?.senderAddress]);
   const receiverAddress = useMemo(() => squidSwapProps?.receiverAddress, [squidSwapProps?.receiverAddress]);
   const slippage = useMemo(() => squidSwapProps?.slippage || '1', [squidSwapProps?.slippage]);
+  const feeToken = useMemo(() => squidSwapProps?.feeToken, [squidSwapProps?.feeToken]);
 
   const account = useAccountSWR(fromChain || COSMOS_CHAINS[0]);
   const nodeInfo = useNodeInfoSWR(fromChain || COSMOS_CHAINS[0]);
@@ -227,7 +229,14 @@ export function useSquidCosmosSwap(squidSwapProps?: UseSquidCosmosSwapProps) {
   );
 
   const memoizedSquidSwapAminoTx = useMemo(() => {
-    if (gt(inputBaseAmount, '0') && account.data?.value.account_number && fromChain?.chainId && fromChain.line === 'COSMOS' && parsedSquidSwapTx) {
+    if (
+      gt(inputBaseAmount, '0') &&
+      account.data?.value.account_number &&
+      fromChain?.chainId &&
+      fromChain.line === 'COSMOS' &&
+      parsedSquidSwapTx &&
+      feeToken?.address
+    ) {
       const sequence = String(account.data?.value.sequence || '0');
 
       if (parsedSquidSwapTx.msgTypeUrl === '/ibc.applications.transfer.v1.MsgTransfer') {
@@ -263,7 +272,7 @@ export function useSquidCosmosSwap(squidSwapProps?: UseSquidCosmosSwapProps) {
           account_number: String(account.data.value.account_number),
           sequence,
           chain_id: nodeInfo.data?.default_node_info?.network ?? fromChain.chainId,
-          fee: { amount: [{ amount: '1', denom: fromChain.baseDenom }], gas: COSMOS_DEFAULT_SWAP_GAS },
+          fee: { amount: [{ amount: '1', denom: feeToken.address }], gas: COSMOS_DEFAULT_SWAP_GAS },
           memo: '',
           msgs: [
             {
@@ -298,6 +307,7 @@ export function useSquidCosmosSwap(squidSwapProps?: UseSquidCosmosSwapProps) {
     revisionHeight,
     revisionNumber,
     senderAddress,
+    feeToken?.address,
   ]);
 
   const [squidSwapAminoTx] = useDebounce(memoizedSquidSwapAminoTx, 700);

--- a/src/Popup/utils/calculate.ts
+++ b/src/Popup/utils/calculate.ts
@@ -1,7 +1,7 @@
-import { divide, minus, times } from './big';
+import { divide, equal, minus, times } from './big';
 
 export function calcPriceImpact(amountIn: string, amountOut: string): string {
-  if (amountIn === '0' || amountOut === '0') return '0';
+  if (equal(amountIn, '0') || equal(amountOut, '0')) return '0';
 
   return times(divide(minus(amountIn, amountOut), amountIn), '100');
 }

--- a/src/constants/chain/cosmos/noble.ts
+++ b/src/constants/chain/cosmos/noble.ts
@@ -1,6 +1,6 @@
 import { MINTSCAN_URL } from '~/constants/common';
 import nobleImg from '~/images/symbols/noble.png';
-import type { CosmosChain } from '~/types/chain';
+import type { CosmosChain, CosmosGasRate } from '~/types/chain';
 
 export const NOBLE: CosmosChain = {
   id: 'd0c01aa8-dfc3-4c30-80c1-4faa8b0279a6',
@@ -26,6 +26,19 @@ export const NOBLE: CosmosChain = {
     low: '0.0025',
     average: '0.025',
   },
-  gas: {},
+  gas: { send: '100000' },
   custom: 'no-stake',
 };
+
+export const NOBLE_GAS_RATES: CosmosGasRate[] = [
+  {
+    chainId: NOBLE.id,
+    baseDenom: 'uusdc',
+    originDenom: 'uusdc',
+    gasRate: {
+      tiny: '0.1',
+      low: '0.1',
+      average: '0.1',
+    },
+  },
+];

--- a/src/constants/chain/cosmos/nyx.ts
+++ b/src/constants/chain/cosmos/nyx.ts
@@ -1,6 +1,6 @@
 import { MINTSCAN_URL } from '~/constants/common';
 import nyxImg from '~/images/symbols/nyx.png';
-import type { CosmosChain, CosmosFeeBaseDenom, CosmosGasRate } from '~/types/chain';
+import type { CosmosChain, CosmosGasRate } from '~/types/chain';
 
 export const NYX: CosmosChain = {
   id: 'f7d12742-2a2f-49d0-a1cd-3c38092f670b',
@@ -29,23 +29,21 @@ export const NYX: CosmosChain = {
   gas: {},
 };
 
-export const NYX_FEE_BASE_DENOMS: CosmosFeeBaseDenom[] = [
-  {
-    chainId: NYX.id,
-    baseDenom: 'unym',
-    feeBaseDenoms: ['unym'],
-  },
-  {
-    chainId: NYX.id,
-    baseDenom: 'ibc/FC9D92EC12BC974E8B6179D411351524CD5C2EBC3CE29D5BA856414FEFA47093',
-    feeBaseDenoms: ['unym'],
-  },
-];
-
 export const NYX_GAS_RATES: CosmosGasRate[] = [
   {
     chainId: NYX.id,
     baseDenom: 'unym',
+    originDenom: 'unym',
+    gasRate: {
+      tiny: '0.025',
+      low: '0.03',
+      average: '0.035',
+    },
+  },
+  {
+    chainId: NYX.id,
+    baseDenom: 'unyx',
+    originDenom: 'unyx',
     gasRate: {
       tiny: '0.025',
       low: '0.03',

--- a/src/constants/chain/index.ts
+++ b/src/constants/chain/index.ts
@@ -1,14 +1,4 @@
-import type {
-  AptosChain,
-  AptosNetwork,
-  CosmosChain,
-  CosmosFeeBaseDenom,
-  CosmosGasRate,
-  EthereumChain,
-  EthereumNetwork,
-  SuiChain,
-  SuiNetwork,
-} from '~/types/chain';
+import type { AptosChain, AptosNetwork, CosmosChain, CosmosGasRate, EthereumChain, EthereumNetwork, SuiChain, SuiNetwork } from '~/types/chain';
 
 import { APTOS } from './aptos/aptos';
 import { DEVNET as APTOS_NETWORK__DEVNET } from './aptos/network/devnet';
@@ -52,8 +42,8 @@ import { MARS } from './cosmos/mars';
 import { MEDIBLOC } from './cosmos/medibloc';
 import { NEUTRON } from './cosmos/neutron';
 import { NIBIRU } from './cosmos/nibiru';
-import { NOBLE } from './cosmos/noble';
-import { NYX, NYX_FEE_BASE_DENOMS, NYX_GAS_RATES } from './cosmos/nyx';
+import { NOBLE, NOBLE_GAS_RATES } from './cosmos/noble';
+import { NYX, NYX_GAS_RATES } from './cosmos/nyx';
 import { OMNIFLIX } from './cosmos/omniflix';
 import { ONOMY } from './cosmos/onomy';
 import { OSMOSIS } from './cosmos/osmosis';
@@ -183,9 +173,7 @@ export const COSMOS_CHAINS: CosmosChain[] = [
   XPLA,
 ];
 
-export const COSMOS_FEE_BASE_DENOMS: CosmosFeeBaseDenom[] = [...NYX_FEE_BASE_DENOMS];
-
-export const COSMOS_GAS_RATES: CosmosGasRate[] = [...NYX_GAS_RATES];
+export const COSMOS_NON_NATIVE_GAS_RATES: CosmosGasRate[] = [...NYX_GAS_RATES, ...NOBLE_GAS_RATES];
 
 export const ETHEREUM_CHAINS: EthereumChain[] = [ETHEREUM];
 

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -71,20 +71,11 @@ export type CosmosCW20Token = {
 
 export type CosmosToken = CosmosCW20Token;
 
-export type CosmosFeeBaseDenom = {
-  chainId: string;
-  baseDenom: string;
-  feeBaseDenoms: string[];
-};
-
 export type CosmosGasRate = {
   chainId: string;
   baseDenom: string;
-  gasRate: {
-    tiny: string;
-    low: string;
-    average: string;
-  };
+  originDenom: string;
+  gasRate: GasRate;
 };
 
 export type Coin = {

--- a/src/types/swap/asset.ts
+++ b/src/types/swap/asset.ts
@@ -22,6 +22,14 @@ export type IntegratedSwapEVMToken = Omit<EthereumToken, 'id' | 'ethereumNetwork
 
 export type IntegratedSwapToken = IntegratedSwapEVMToken | IntegratedSwapCosmosToken;
 
+export type IntegratedSwapFeeToken = {
+  address: string;
+  decimals: number;
+  displayDenom: string;
+  coinGeckoId?: string;
+  imageURL?: string;
+};
+
 export type SquidTokensPayload = {
   mainnet: SupportNetwork[];
   testnet: SupportNetwork[];


### PR DESCRIPTION
코스모스 게열의 체인에서 fee 토큰 리스팅 로직을 수정했습니다.
- 기존 체인의 기본 토큰이 fee토큰에 포함되어 있던 로직을 제거하고 체인리스트에 등록된 토큰으로만 fee 토큰 리스팅이 되도록 수정했습니다.
- gasRate 데이터를 가져오는데에 실패했을 경우에만 체인의 기본 토큰이 fee 토큰으로 리스팅되도록 코드를 수정했습니다.
- fee토큰 정렬 로직을 수정했습니다
 - gasRate의 정렬에 맞추도록 정렬 우선순위를 수정했습니다.

스왑 페이지에서 fee 토큰이 선택되는 로직을 수정했습니다.
skip api에서 price impact를 계산하는 로직을 수정했습니다.
 - skip api에서 price impact값을 리턴하지 않을때 usd 가격으로 게산하는 함수의 아규먼트로  '0.00'값이 들어갔을 때 0으로 인식하지 못하는 오류를 수정했습니다.