### PR TITLE
[APIS-226] EIP-1559 지원체인 가스 계산 방식 변경

### DIFF
--- a/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
 import { SMART_CHAIN } from '~/constants/chain/ethereum/network/smartChain';
-import { GAS_SETTINGS_BY_PRIORITY_LEVEL } from '~/constants/ethereum';
+import { GAS_SETTINGS_BY_GAS_RATE_KEY } from '~/constants/ethereum';
 import { calculatePercentiles, divide, gt, plus } from '~/Popup/utils/big';
 import type { GasRateKey } from '~/types/chain';
 import type { FeeType, GasEstimates } from '~/types/ethereum/common';
@@ -43,8 +43,8 @@ export function useFeeSWR(config?: SWRConfiguration) {
       .reduce((prev, cur) => [plus(prev[0], parseInt(cur[0], 16)), plus(prev[1], parseInt(cur[1], 16)), plus(prev[2], parseInt(cur[2], 16))], ['0', '0', '0'])
       .map((item) => divide(item, rewardCount, 0));
 
-    return (['tiny', 'low', 'average'] as GasRateKey[]).reduce((acc: GasEstimates, level, index) => {
-      const { minBaseFeePerGas, minMaxPriorityFeePerGas } = GAS_SETTINGS_BY_PRIORITY_LEVEL[level];
+    return (['tiny', 'low', 'average'] as GasRateKey[]).reduce((acc, gasRateKey, index) => {
+      const { minBaseFeePerGas, minMaxPriorityFeePerGas } = GAS_SETTINGS_BY_GAS_RATE_KEY[gasRateKey];
 
       const maxPriorityFeePerGas = averageReward[index] && gt(averageReward[index], minMaxPriorityFeePerGas) ? averageReward[index] : minMaxPriorityFeePerGas;
 
@@ -55,7 +55,7 @@ export function useFeeSWR(config?: SWRConfiguration) {
 
       return {
         ...acc,
-        [level]: {
+        [gasRateKey]: {
           maxBaseFeePerGas,
           maxPriorityFeePerGas,
         },

--- a/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
@@ -2,32 +2,38 @@ import { useCallback, useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
 import { SMART_CHAIN } from '~/constants/chain/ethereum/network/smartChain';
+import { GAS_SETTINGS_BY_PRIORITY_LEVEL } from '~/constants/ethereum';
 import { calculatePercentiles, divide, gt, plus } from '~/Popup/utils/big';
-import type { FeeType } from '~/types/ethereum/common';
+import type { GasRateKey } from '~/types/chain';
+import type { FeeType, GasEstimates } from '~/types/ethereum/common';
 
 import { useFeeHistorySWR } from './useFeeHistorySWR';
 import { useGasPriceSWR } from './useGasPriceSWR';
 import { useCurrentEthereumNetwork } from '../../useCurrent/useCurrentEthereumNetwork';
 
+const REWARD_PERCENTILES = [25, 50, 75];
+
+const BLOCK_COUNT = 20;
+
 export function useFeeSWR(config?: SWRConfiguration) {
   const { currentEthereumNetwork } = useCurrentEthereumNetwork();
 
-  const feeHistory = useFeeHistorySWR([20, 'latest', [25, 50, 75]], config);
+  const feeHistory = useFeeHistorySWR([BLOCK_COUNT, 'latest', REWARD_PERCENTILES], config);
 
   const gasPrice = useGasPriceSWR(config);
 
   const currentGasPrice = gasPrice.data?.result ? plus(parseInt(gasPrice.data.result, 16), '1000') : null;
 
   const currentFee = useMemo(() => {
-    if (!feeHistory.data?.result || !feeHistory.data.result.baseFeePerGas.every((item) => item !== null)) {
+    if (!feeHistory.data?.result || feeHistory.data.result.baseFeePerGas.some((item) => item === null)) {
       return null;
     }
 
     const { baseFeePerGas } = feeHistory.data.result;
 
-    const gasFeePercentiles = calculatePercentiles(
+    const baseFeePercentiles = calculatePercentiles(
       baseFeePerGas.map((item) => parseInt(item || '0', 16)),
-      [25, 50, 75],
+      REWARD_PERCENTILES,
     );
 
     const originReward = feeHistory.data.result.reward || [];
@@ -37,29 +43,24 @@ export function useFeeSWR(config?: SWRConfiguration) {
       .reduce((prev, cur) => [plus(prev[0], parseInt(cur[0], 16)), plus(prev[1], parseInt(cur[1], 16)), plus(prev[2], parseInt(cur[2], 16))], ['0', '0', '0'])
       .map((item) => divide(item, rewardCount, 0));
 
-    return {
-      tiny: {
-        maxBaseFeePerGas: plus(
-          gasFeePercentiles[0] && gt(gasFeePercentiles[0], '500000000') ? gasFeePercentiles[0] : '500000000',
-          averageReward[0] && gt(averageReward[0], '1000000000') ? averageReward[0] : '1000000000',
-        ),
-        maxPriorityFeePerGas: averageReward[0] && gt(averageReward[0], '1000000000') ? averageReward[0] : '1000000000',
-      },
-      low: {
-        maxBaseFeePerGas: plus(
-          gasFeePercentiles[1] && gt(gasFeePercentiles[1], '500000000') ? gasFeePercentiles[1] : '500000000',
-          averageReward[1] && gt(averageReward[1], '1000000000') ? averageReward[1] : '1000000000',
-        ),
-        maxPriorityFeePerGas: averageReward[1] && gt(averageReward[1], '1000000000') ? averageReward[1] : '1000000000',
-      },
-      average: {
-        maxBaseFeePerGas: plus(
-          gasFeePercentiles[2] && gt(gasFeePercentiles[2], '500000000') ? gasFeePercentiles[2] : '500000000',
-          averageReward[2] && gt(averageReward[2], '1000000000') ? averageReward[2] : '1000000000',
-        ),
-        maxPriorityFeePerGas: averageReward[2] && gt(averageReward[2], '1000000000') ? averageReward[2] : '1000000000',
-      },
-    };
+    return (['tiny', 'low', 'average'] as GasRateKey[]).reduce((acc: GasEstimates, level, index) => {
+      const { minBaseFeePerGas, minMaxPriorityFeePerGas } = GAS_SETTINGS_BY_PRIORITY_LEVEL[level];
+
+      const maxPriorityFeePerGas = averageReward[index] && gt(averageReward[index], minMaxPriorityFeePerGas) ? averageReward[index] : minMaxPriorityFeePerGas;
+
+      const maxBaseFeePerGas = plus(
+        baseFeePercentiles[index] && gt(baseFeePercentiles[index], minBaseFeePerGas) ? baseFeePercentiles[index] : minBaseFeePerGas,
+        maxPriorityFeePerGas,
+      );
+
+      return {
+        ...acc,
+        [level]: {
+          maxBaseFeePerGas,
+          maxPriorityFeePerGas,
+        },
+      };
+    }, {} as GasEstimates);
   }, [feeHistory]);
 
   const type: FeeType | null = (() => {

--- a/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
@@ -1,47 +1,21 @@
 import { useCallback, useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
+import { SMART_CHAIN } from '~/constants/chain/ethereum/network/smartChain';
+import { GAS_SETTINGS_BY_PRIORITY_LEVEL, PRIORITY_LEVEL } from '~/constants/ethereum';
 import { gt, medianOf, plus, times } from '~/Popup/utils/big';
-import type { FeeType } from '~/types/ethereum/common';
+import type { FeeType, GasEstimates } from '~/types/ethereum/common';
 
 import { useFeeHistorySWR } from './useFeeHistorySWR';
 import { useGasPriceSWR } from './useGasPriceSWR';
 import { useGetBlockByNumberSWR } from './useGetBlockByNumberSWR';
 import { useCurrentEthereumNetwork } from '../../useCurrent/useCurrentEthereumNetwork';
 
-const SETTINGS_BY_PRIORITY_LEVEL = {
-  tiny: {
-    baseFeePercentageMultiplier: 1.1,
-    priorityFeePercentageMultiplier: 0.94,
-    minMaxPriorityFeePerGas: '1000000000',
-  },
-  low: {
-    baseFeePercentageMultiplier: 1.2,
-    priorityFeePercentageMultiplier: 0.97,
-    minMaxPriorityFeePerGas: '1500000000',
-  },
-  average: {
-    baseFeePercentageMultiplier: 1.25,
-    priorityFeePercentageMultiplier: 0.98,
-    minMaxPriorityFeePerGas: '2000000000',
-  },
-};
-type GasFeeConfiguration = {
-  maxBaseFeePerGas: string;
-  maxPriorityFeePerGas: string;
-};
-
-type GasFeeEstimates = {
-  tiny: GasFeeConfiguration;
-  low: GasFeeConfiguration;
-  average: GasFeeConfiguration;
-};
-
 export function useFeeSWR(config?: SWRConfiguration) {
   const { currentEthereumNetwork } = useCurrentEthereumNetwork();
 
-  const block = useGetBlockByNumberSWR(['pending', false], config);
-  const feeHistory = useFeeHistorySWR([5, 'pending', [10, 20, 30]], config);
+  const block = useGetBlockByNumberSWR(['latest', false], config);
+  const feeHistory = useFeeHistorySWR([5, 'latest', [10, 20, 30]], config);
   const gasPrice = useGasPriceSWR(config);
 
   const currentGasPrice = gasPrice.data?.result ? plus(parseInt(gasPrice.data.result, 16), '1000') : null;
@@ -59,59 +33,26 @@ export function useFeeSWR(config?: SWRConfiguration) {
 
     const medianRewards = transposedRewards.map((item) => medianOf(item.map((reward) => parseInt(reward, 16))));
 
-    return medianRewards.reduce((acc: GasFeeEstimates, item, i) => {
-      if (i === 0) {
-        const { minMaxPriorityFeePerGas, priorityFeePercentageMultiplier, baseFeePercentageMultiplier } = SETTINGS_BY_PRIORITY_LEVEL.tiny;
+    const priorityLevels = Object.values(PRIORITY_LEVEL);
 
-        const feeWithPriorityMultiplier = times(item, priorityFeePercentageMultiplier);
-        const maxPriorityFeePerGas = gt(feeWithPriorityMultiplier, minMaxPriorityFeePerGas) ? feeWithPriorityMultiplier : minMaxPriorityFeePerGas;
+    const rewardsWithLevels = medianRewards.map((reward, i) => ({ reward, level: priorityLevels[i] }));
 
-        const maxBaseFeePerGas = plus(times(baseFeePerGas, baseFeePercentageMultiplier), maxPriorityFeePerGas);
+    return rewardsWithLevels.reduce((acc: GasEstimates, { reward, level }) => {
+      const { minMaxPriorityFeePerGas, priorityFeePercentageMultiplier, baseFeePercentageMultiplier } = GAS_SETTINGS_BY_PRIORITY_LEVEL[level];
 
-        return {
-          ...acc,
-          tiny: {
-            maxBaseFeePerGas,
-            maxPriorityFeePerGas,
-          },
-        };
-      }
+      const multipliedPriorityFee = times(reward, priorityFeePercentageMultiplier, 0);
+      const maxPriorityFeePerGas = gt(multipliedPriorityFee, minMaxPriorityFeePerGas) ? multipliedPriorityFee : minMaxPriorityFeePerGas;
 
-      if (i === 1) {
-        const { minMaxPriorityFeePerGas, priorityFeePercentageMultiplier, baseFeePercentageMultiplier } = SETTINGS_BY_PRIORITY_LEVEL.low;
+      const maxBaseFeePerGas = plus(times(baseFeePerGas, baseFeePercentageMultiplier, 0), maxPriorityFeePerGas);
 
-        const feeWithPriorityMultiplier = times(item, priorityFeePercentageMultiplier);
-        const maxPriorityFeePerGas = gt(feeWithPriorityMultiplier, minMaxPriorityFeePerGas) ? feeWithPriorityMultiplier : minMaxPriorityFeePerGas;
-
-        const maxBaseFeePerGas = plus(times(baseFeePerGas, baseFeePercentageMultiplier), maxPriorityFeePerGas);
-
-        return {
-          ...acc,
-          low: {
-            maxBaseFeePerGas,
-            maxPriorityFeePerGas,
-          },
-        };
-      }
-
-      if (i === 2) {
-        const { minMaxPriorityFeePerGas, priorityFeePercentageMultiplier, baseFeePercentageMultiplier } = SETTINGS_BY_PRIORITY_LEVEL.average;
-
-        const feeWithPriorityMultiplier = times(item, priorityFeePercentageMultiplier);
-        const maxPriorityFeePerGas = gt(feeWithPriorityMultiplier, minMaxPriorityFeePerGas) ? feeWithPriorityMultiplier : minMaxPriorityFeePerGas;
-
-        const maxBaseFeePerGas = plus(times(baseFeePerGas, baseFeePercentageMultiplier), maxPriorityFeePerGas);
-
-        return {
-          ...acc,
-          average: {
-            maxBaseFeePerGas,
-            maxPriorityFeePerGas,
-          },
-        };
-      }
-      return acc;
-    }, {} as GasFeeEstimates);
+      return {
+        ...acc,
+        [level]: {
+          maxBaseFeePerGas,
+          maxPriorityFeePerGas,
+        },
+      };
+    }, {} as GasEstimates);
   }, [feeHistory, block]);
 
   const type: FeeType | null = (() => {
@@ -119,7 +60,7 @@ export function useFeeSWR(config?: SWRConfiguration) {
       return null;
     }
 
-    const basicFeeOnlyChainIds: string[] = [];
+    const basicFeeOnlyChainIds = [SMART_CHAIN.id];
 
     if (basicFeeOnlyChainIds.includes(currentEthereumNetwork.id)) {
       return 'BASIC';

--- a/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
@@ -2,58 +2,65 @@ import { useCallback, useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
 import { SMART_CHAIN } from '~/constants/chain/ethereum/network/smartChain';
-import { GAS_SETTINGS_BY_PRIORITY_LEVEL, PRIORITY_LEVEL } from '~/constants/ethereum';
-import { gt, medianOf, plus, times } from '~/Popup/utils/big';
-import type { FeeType, GasEstimates } from '~/types/ethereum/common';
+import { calculatePercentiles, divide, gt, plus } from '~/Popup/utils/big';
+import type { FeeType } from '~/types/ethereum/common';
 
 import { useFeeHistorySWR } from './useFeeHistorySWR';
 import { useGasPriceSWR } from './useGasPriceSWR';
-import { useGetBlockByNumberSWR } from './useGetBlockByNumberSWR';
 import { useCurrentEthereumNetwork } from '../../useCurrent/useCurrentEthereumNetwork';
 
 export function useFeeSWR(config?: SWRConfiguration) {
   const { currentEthereumNetwork } = useCurrentEthereumNetwork();
 
-  const block = useGetBlockByNumberSWR(['latest', false], config);
-  const feeHistory = useFeeHistorySWR([5, 'latest', [10, 20, 30]], config);
+  const feeHistory = useFeeHistorySWR([20, 'latest', [25, 50, 75]], config);
+
   const gasPrice = useGasPriceSWR(config);
 
   const currentGasPrice = gasPrice.data?.result ? plus(parseInt(gasPrice.data.result, 16), '1000') : null;
 
   const currentFee = useMemo(() => {
-    if (!feeHistory.data?.result || !block.data?.result?.baseFeePerGas) {
+    if (!feeHistory.data?.result || !feeHistory.data.result.baseFeePerGas.every((item) => item !== null)) {
       return null;
     }
 
-    const baseFeePerGas = plus(parseInt(block.data.result.baseFeePerGas, 16), '1000');
+    const { baseFeePerGas } = feeHistory.data.result;
+
+    const gasFeePercentiles = calculatePercentiles(
+      baseFeePerGas.map((item) => parseInt(item || '0', 16)),
+      [25, 50, 75],
+    );
 
     const originReward = feeHistory.data.result.reward || [];
 
-    const transposedRewards = originReward.reduce<string[][]>((result, row) => row.map((_, i) => [...(result[i] || []), row[i].toString()]), []);
+    const rewardCount = originReward.length;
+    const averageReward = originReward
+      .reduce((prev, cur) => [plus(prev[0], parseInt(cur[0], 16)), plus(prev[1], parseInt(cur[1], 16)), plus(prev[2], parseInt(cur[2], 16))], ['0', '0', '0'])
+      .map((item) => divide(item, rewardCount, 0));
 
-    const medianRewards = transposedRewards.map((item) => medianOf(item.map((reward) => parseInt(reward, 16))));
-
-    const priorityLevels = Object.values(PRIORITY_LEVEL);
-
-    const rewardsWithLevels = medianRewards.map((reward, i) => ({ reward, level: priorityLevels[i] }));
-
-    return rewardsWithLevels.reduce((acc: GasEstimates, { reward, level }) => {
-      const { minMaxPriorityFeePerGas, priorityFeePercentageMultiplier, baseFeePercentageMultiplier } = GAS_SETTINGS_BY_PRIORITY_LEVEL[level];
-
-      const multipliedPriorityFee = times(reward, priorityFeePercentageMultiplier, 0);
-      const maxPriorityFeePerGas = gt(multipliedPriorityFee, minMaxPriorityFeePerGas) ? multipliedPriorityFee : minMaxPriorityFeePerGas;
-
-      const maxBaseFeePerGas = plus(times(baseFeePerGas, baseFeePercentageMultiplier, 0), maxPriorityFeePerGas);
-
-      return {
-        ...acc,
-        [level]: {
-          maxBaseFeePerGas,
-          maxPriorityFeePerGas,
-        },
-      };
-    }, {} as GasEstimates);
-  }, [feeHistory, block]);
+    return {
+      tiny: {
+        maxBaseFeePerGas: plus(
+          gasFeePercentiles[0] && gt(gasFeePercentiles[0], '500000000') ? gasFeePercentiles[0] : '500000000',
+          averageReward[0] && gt(averageReward[0], '1000000000') ? averageReward[0] : '1000000000',
+        ),
+        maxPriorityFeePerGas: averageReward[0] && gt(averageReward[0], '1000000000') ? averageReward[0] : '1000000000',
+      },
+      low: {
+        maxBaseFeePerGas: plus(
+          gasFeePercentiles[1] && gt(gasFeePercentiles[1], '500000000') ? gasFeePercentiles[1] : '500000000',
+          averageReward[1] && gt(averageReward[1], '1000000000') ? averageReward[1] : '1000000000',
+        ),
+        maxPriorityFeePerGas: averageReward[1] && gt(averageReward[1], '1000000000') ? averageReward[1] : '1000000000',
+      },
+      average: {
+        maxBaseFeePerGas: plus(
+          gasFeePercentiles[2] && gt(gasFeePercentiles[2], '500000000') ? gasFeePercentiles[2] : '500000000',
+          averageReward[2] && gt(averageReward[2], '1000000000') ? averageReward[2] : '1000000000',
+        ),
+        maxPriorityFeePerGas: averageReward[2] && gt(averageReward[2], '1000000000') ? averageReward[2] : '1000000000',
+      },
+    };
+  }, [feeHistory]);
 
   const type: FeeType | null = (() => {
     if (!currentFee && !currentGasPrice) {
@@ -70,10 +77,9 @@ export function useFeeSWR(config?: SWRConfiguration) {
   })();
 
   const mutate = useCallback(async () => {
-    await block.mutate();
     await feeHistory.mutate();
     await gasPrice.mutate();
-  }, [block, feeHistory, gasPrice]);
+  }, [feeHistory, gasPrice]);
 
   const returnData = useMemo(
     () => ({

--- a/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
@@ -25,7 +25,7 @@ export function useFeeSWR(config?: SWRConfiguration) {
       return null;
     }
 
-    const baseFeePerGas = parseInt(block.data.result.baseFeePerGas, 16);
+    const baseFeePerGas = plus(parseInt(block.data.result.baseFeePerGas, 16), '1000');
 
     const originReward = feeHistory.data.result.reward || [];
 

--- a/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useFeeSWR.ts
@@ -5,7 +5,7 @@ import { SMART_CHAIN } from '~/constants/chain/ethereum/network/smartChain';
 import { GAS_SETTINGS_BY_GAS_RATE_KEY } from '~/constants/ethereum';
 import { calculatePercentiles, divide, gt, plus } from '~/Popup/utils/big';
 import type { GasRateKey } from '~/types/chain';
-import type { FeeType, GasEstimates } from '~/types/ethereum/common';
+import type { FeeType, GasRateKeyConfigurations } from '~/types/ethereum/common';
 
 import { useFeeHistorySWR } from './useFeeHistorySWR';
 import { useGasPriceSWR } from './useGasPriceSWR';
@@ -60,7 +60,7 @@ export function useFeeSWR(config?: SWRConfiguration) {
           maxPriorityFeePerGas,
         },
       };
-    }, {} as GasEstimates);
+    }, {} as GasRateKeyConfigurations);
   }, [feeHistory]);
 
   const type: FeeType | null = (() => {

--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -202,7 +202,7 @@ export default function Entry({ queue }: EntryProps) {
         ...mixedEthereumTx,
         gasPrice: undefined,
         maxPriorityFeePerGas: toHex(currentFee.currentFee[feeMode].maxPriorityFeePerGas, { addPrefix: true, isStringNumber: true }),
-        maxFeePerGas: toHex(times(currentFee.currentFee[feeMode].maxBaseFeePerGas, '1.2', 0), { addPrefix: true, isStringNumber: true }),
+        maxFeePerGas: toHex(currentFee.currentFee[feeMode].maxBaseFeePerGas, { addPrefix: true, isStringNumber: true }),
       };
     }
 

--- a/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
@@ -168,6 +168,7 @@ export default function Ethereum({ chain }: EthereumProps) {
 
   const handleOnClickMax = () => {
     if (currentToken === null) {
+      // TODO 유지 고려 필요
       const fee15 = times(baseFee, '1.5');
       const maxAmount = minus(baseBalance, fee15);
 

--- a/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Ethereum/index.tsx
@@ -168,7 +168,6 @@ export default function Ethereum({ chain }: EthereumProps) {
 
   const handleOnClickMax = () => {
     if (currentToken === null) {
-      // TODO 유지 고려 필요
       const fee15 = times(baseFee, '1.5');
       const maxAmount = minus(baseBalance, fee15);
 

--- a/src/Popup/utils/big.ts
+++ b/src/Popup/utils/big.ts
@@ -73,10 +73,10 @@ export function calculatePercentiles(numbers: number[], percentiles: number[]) {
     return [];
   }
 
-  const sortedNumbers = numbers.slice().sort((a, b) => Number(minus(a, b)));
+  const sortedNumbers = numbers.slice().sort((a, b) => a - b);
 
   return percentiles.map((percentile) => {
-    const index = Math.ceil((percentile / 100) * sortedNumbers.length) - 1;
+    const index = Number(minus(ceil(times(divide(percentile, '100'), sortedNumbers.length)), '1'));
     return sortedNumbers[index];
   });
 }

--- a/src/Popup/utils/big.ts
+++ b/src/Popup/utils/big.ts
@@ -68,15 +68,17 @@ export function ceil(num: string | number) {
   return new Big(num).toFixed(0, 0);
 }
 
-export function medianOf(numbers: string[] | number[]): string {
-  const sortedNumbers = numbers
-    .slice()
-    .sort((a, b) => Number(minus(a, b)))
-    .map((num) => String(num));
-  const len = sortedNumbers.length;
-  const index = Math.floor(len / 2);
+export function calculatePercentiles(numbers: number[], percentiles: number[]) {
+  if (numbers.length === 0) {
+    return [];
+  }
 
-  return len % 2 === 0 ? ceil(divide(plus(sortedNumbers[index - 1], sortedNumbers[index]), '2')) : sortedNumbers[index];
+  const sortedNumbers = numbers.slice().sort((a, b) => Number(minus(a, b)));
+
+  return percentiles.map((percentile) => {
+    const index = Math.ceil((percentile / 100) * sortedNumbers.length) - 1;
+    return sortedNumbers[index];
+  });
 }
 
 export function fix(number: string, decimal?: number, optional: RoundingMode = 0) {

--- a/src/Popup/utils/big.ts
+++ b/src/Popup/utils/big.ts
@@ -68,6 +68,17 @@ export function ceil(num: string | number) {
   return new Big(num).toFixed(0, 0);
 }
 
+export function medianOf(numbers: string[] | number[]): string {
+  const sortedNumbers = numbers
+    .slice()
+    .sort((a, b) => Number(minus(a, b)))
+    .map((num) => String(num));
+  const len = sortedNumbers.length;
+  const index = Math.floor(len / 2);
+
+  return len % 2 === 0 ? ceil(divide(plus(sortedNumbers[index - 1], sortedNumbers[index]), '2')) : sortedNumbers[index];
+}
+
 export function fix(number: string, decimal?: number, optional: RoundingMode = 0) {
   return Big(number).toFixed(decimal, optional);
 }

--- a/src/constants/ethereum.ts
+++ b/src/constants/ethereum.ts
@@ -48,7 +48,7 @@ export const TRANSACTION_RESULT = {
   SUCCESS: '1',
 } as const;
 
-export const GAS_SETTINGS_BY_PRIORITY_LEVEL = {
+export const GAS_SETTINGS_BY_GAS_RATE_KEY = {
   tiny: {
     minBaseFeePerGas: '500000000',
     minMaxPriorityFeePerGas: '1000000000',

--- a/src/constants/ethereum.ts
+++ b/src/constants/ethereum.ts
@@ -47,27 +47,3 @@ export const ERC1155_INTERFACE_ID = '0xd9b67a26';
 export const TRANSACTION_RESULT = {
   SUCCESS: '1',
 } as const;
-
-export const PRIORITY_LEVEL = {
-  TINY: 'tiny',
-  LOW: 'low',
-  AVERAGE: 'average',
-} as const;
-
-export const GAS_SETTINGS_BY_PRIORITY_LEVEL = {
-  tiny: {
-    baseFeePercentageMultiplier: '1.1',
-    priorityFeePercentageMultiplier: '0.94',
-    minMaxPriorityFeePerGas: '1000000000',
-  },
-  low: {
-    baseFeePercentageMultiplier: '1.2',
-    priorityFeePercentageMultiplier: '0.97',
-    minMaxPriorityFeePerGas: '1500000000',
-  },
-  average: {
-    baseFeePercentageMultiplier: '1.25',
-    priorityFeePercentageMultiplier: '0.98',
-    minMaxPriorityFeePerGas: '2000000000',
-  },
-};

--- a/src/constants/ethereum.ts
+++ b/src/constants/ethereum.ts
@@ -47,3 +47,18 @@ export const ERC1155_INTERFACE_ID = '0xd9b67a26';
 export const TRANSACTION_RESULT = {
   SUCCESS: '1',
 } as const;
+
+export const GAS_SETTINGS_BY_PRIORITY_LEVEL = {
+  tiny: {
+    minBaseFeePerGas: '500000000',
+    minMaxPriorityFeePerGas: '1000000000',
+  },
+  low: {
+    minBaseFeePerGas: '500000000',
+    minMaxPriorityFeePerGas: '1000000000',
+  },
+  average: {
+    minBaseFeePerGas: '500000000',
+    minMaxPriorityFeePerGas: '1000000000',
+  },
+};

--- a/src/constants/ethereum.ts
+++ b/src/constants/ethereum.ts
@@ -47,3 +47,27 @@ export const ERC1155_INTERFACE_ID = '0xd9b67a26';
 export const TRANSACTION_RESULT = {
   SUCCESS: '1',
 } as const;
+
+export const PRIORITY_LEVEL = {
+  TINY: 'tiny',
+  LOW: 'low',
+  AVERAGE: 'average',
+} as const;
+
+export const GAS_SETTINGS_BY_PRIORITY_LEVEL = {
+  tiny: {
+    baseFeePercentageMultiplier: '1.1',
+    priorityFeePercentageMultiplier: '0.94',
+    minMaxPriorityFeePerGas: '1000000000',
+  },
+  low: {
+    baseFeePercentageMultiplier: '1.2',
+    priorityFeePercentageMultiplier: '0.97',
+    minMaxPriorityFeePerGas: '1500000000',
+  },
+  average: {
+    baseFeePercentageMultiplier: '1.25',
+    priorityFeePercentageMultiplier: '0.98',
+    minMaxPriorityFeePerGas: '2000000000',
+  },
+};

--- a/src/types/ethereum/common.ts
+++ b/src/types/ethereum/common.ts
@@ -14,7 +14,7 @@ export type Token = EthereumToken | null;
 
 export type EthereumNFTStandard = ValueOf<typeof ETHEREUM_NFT_STANDARD>;
 
-export type GasEstimates = {
+export type GasRateKeyConfigurations = {
   tiny: EIP1559Configuration;
   low: EIP1559Configuration;
   average: EIP1559Configuration;

--- a/src/types/ethereum/common.ts
+++ b/src/types/ethereum/common.ts
@@ -13,3 +13,14 @@ export type EthereumContractKind = ValueOf<typeof ETHEREUM_CONTRACT_KIND>;
 export type Token = EthereumToken | null;
 
 export type EthereumNFTStandard = ValueOf<typeof ETHEREUM_NFT_STANDARD>;
+
+export type GasEstimates = {
+  tiny: EIP1559Configuration;
+  low: EIP1559Configuration;
+  average: EIP1559Configuration;
+};
+
+export type EIP1559Configuration = {
+  maxBaseFeePerGas: string;
+  maxPriorityFeePerGas: string;
+};

--- a/src/types/ethereum/common.ts
+++ b/src/types/ethereum/common.ts
@@ -13,14 +13,3 @@ export type EthereumContractKind = ValueOf<typeof ETHEREUM_CONTRACT_KIND>;
 export type Token = EthereumToken | null;
 
 export type EthereumNFTStandard = ValueOf<typeof ETHEREUM_NFT_STANDARD>;
-
-export type GasEstimates = {
-  tiny: EIP1559Configuration;
-  low: EIP1559Configuration;
-  average: EIP1559Configuration;
-};
-
-export type EIP1559Configuration = {
-  maxBaseFeePerGas: string;
-  maxPriorityFeePerGas: string;
-};


### PR DESCRIPTION
eth_feeHistory를 사용해서 maxBaseFeePerGas와 maxPriorityFeePerGas를 계산하는 방법을 수정했습니다.

- eth_getBlockByNumber, eth_feeHistory메서드의 인자값을 'pending'에서 'latest'로 변경했습니다.
- eth_feeHistory의 인자값을 변경했습니다.
    - 블록 수 20개로 변경. reward 백분율 변경([25,50,75]) : ios web3패키지에서 사용하는 값과 동일합니다.
- maxPriorityFeePerGas, maxBaseFeePerGas계산 시 일정값보다 작을떄는 사전 정의된 최소값을 사용하도록 수정했습니다.