### PR TITLE
[APIS-256] Refactor request() & add 'cos_requestAccounts'

### DIFF
--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -2,11 +2,14 @@ import { v4 as uuidv4 } from 'uuid';
 import type { CosmosRegisterWallet } from '@cosmostation/wallets';
 
 import { LINE_TYPE } from '~/constants/chain';
+import { RPC_ERROR, RPC_ERROR_MESSAGE } from '~/constants/error';
 import { MESSAGE_TYPE } from '~/constants/message';
+import { CosmosRPCError } from '~/Popup/utils/error';
 import type { SignAminoDoc } from '~/types/cosmos/amino';
 import type { SignDirectDoc } from '~/types/cosmos/proto';
 import type { ContentScriptToWebEventMessage, CosmosListenerType, CosmosRequestMessage, ListenerMessage, ResponseMessage } from '~/types/message';
 import type {
+  CosRequestAccount,
   CosRequestAccountResponse,
   CosSendTransactionResponse,
   CosSignAminoResponse,
@@ -17,7 +20,7 @@ import type {
   CosVerifyMessageResponse,
 } from '~/types/message/cosmos';
 
-export const request = (message: CosmosRequestMessage) =>
+export const executeRequest = (message: CosmosRequestMessage) =>
   new Promise((res, rej) => {
     const messageId = uuidv4();
 
@@ -29,31 +32,6 @@ export const request = (message: CosmosRequestMessage) =>
 
         if (data.response?.error) {
           rej(data.response.error);
-        } else if (
-          data.message.method === 'cos_requestAccount' ||
-          data.message.method === 'cos_account' ||
-          data.message.method === 'ten_requestAccount' ||
-          data.message.method === 'ten_account'
-        ) {
-          const { publicKey } = data.response.result as CosRequestAccountResponse;
-
-          res({
-            ...(data.response.result as { publicKey: string; address: string }),
-            publicKey: new Uint8Array(Buffer.from(publicKey, 'hex')),
-          });
-        } else if (data.message.method === 'cos_signDirect' || data.message.method === 'ten_signDirect') {
-          const result = data.response.result as CosSignDirectResponse;
-
-          const response: CosSignDirectResponse = {
-            ...result,
-            signed_doc: {
-              ...result.signed_doc,
-              auth_info_bytes: new Uint8Array(result.signed_doc.auth_info_bytes),
-              body_bytes: new Uint8Array(result.signed_doc.body_bytes),
-            },
-          };
-
-          res(response);
         } else {
           res(data.response.result);
         }
@@ -62,54 +40,116 @@ export const request = (message: CosmosRequestMessage) =>
 
     window.addEventListener('message', handler);
 
-    if (message.method === 'cos_signDirect' || message.method === 'ten_signDirect') {
-      const { params } = message;
-
-      const doc = params?.doc;
-
-      const newDoc: SignDirectDoc = doc
-        ? {
-            ...doc,
-            auth_info_bytes: doc.auth_info_bytes ? [...Array.from(new Uint8Array(doc.auth_info_bytes))] : doc.auth_info_bytes,
-            body_bytes: doc.body_bytes ? [...Array.from(new Uint8Array(doc.body_bytes))] : doc.body_bytes,
-          }
-        : doc;
-
-      const newParams: CosSignDirectParams = params ? { ...params, doc: newDoc } : params;
-      const newMessage = { ...message, params: newParams };
-
-      window.postMessage({
-        isCosmostation: true,
-        line: LINE_TYPE.COSMOS,
-        type: MESSAGE_TYPE.REQUEST__WEB_TO_CONTENT_SCRIPT,
-        messageId,
-        message: newMessage,
-      });
-    } else if (message.method === 'cos_sendTransaction') {
-      const { params } = message;
-
-      const txBytes = params?.txBytes && typeof params.txBytes === 'object' ? Buffer.from(params.txBytes).toString('base64') : params.txBytes;
-
-      const newParams = { ...params, txBytes };
-      const newMessage = { ...message, params: newParams };
-
-      window.postMessage({
-        isCosmostation: true,
-        line: LINE_TYPE.COSMOS,
-        type: MESSAGE_TYPE.REQUEST__WEB_TO_CONTENT_SCRIPT,
-        messageId,
-        message: newMessage,
-      });
-    } else {
-      window.postMessage({
-        isCosmostation: true,
-        line: LINE_TYPE.COSMOS,
-        type: MESSAGE_TYPE.REQUEST__WEB_TO_CONTENT_SCRIPT,
-        messageId,
-        message,
-      });
-    }
+    window.postMessage({
+      isCosmostation: true,
+      line: LINE_TYPE.COSMOS,
+      type: MESSAGE_TYPE.REQUEST__WEB_TO_CONTENT_SCRIPT,
+      messageId,
+      message,
+    });
   });
+
+export const request = async (message: CosmosRequestMessage) => {
+  if (
+    message.method === 'cos_requestAccount' ||
+    message.method === 'cos_account' ||
+    message.method === 'ten_requestAccount' ||
+    message.method === 'ten_account'
+  ) {
+    const result = (await executeRequest(message)) as CosRequestAccountResponse;
+
+    const { publicKey } = result;
+
+    const response = {
+      ...(result as { publicKey: string; address: string }),
+      publicKey: new Uint8Array(Buffer.from(publicKey, 'hex')),
+    };
+
+    return response;
+  }
+
+  if (message.method === 'cos_requestAccounts') {
+    const supportedChainIds = (await executeRequest({ method: 'cos_supportedChainIds' })) as CosSupportedChainIdsResponse;
+
+    const isValidChainIds = message.params?.chainIds?.every(
+      (chainId) => supportedChainIds?.official?.includes(chainId) || supportedChainIds?.unofficial?.includes(chainId),
+    );
+
+    if (!isValidChainIds) {
+      throw new CosmosRPCError(RPC_ERROR.INVALID_PARAMS, RPC_ERROR_MESSAGE[RPC_ERROR.INVALID_PARAMS]);
+    }
+
+    const initialAccountRequestMessage = {
+      ...message,
+      method: 'cos_requestAccount',
+      params: {
+        chainName: message.params?.chainIds?.[0],
+      },
+    } as CosRequestAccount;
+
+    await executeRequest(initialAccountRequestMessage);
+
+    const result = await Promise.all(
+      message.params.chainIds.map(
+        async (chainId) => (await executeRequest({ method: 'cos_requestAccount', params: { chainName: chainId } })) as CosRequestAccountResponse,
+      ),
+    );
+
+    const response = result.map((item) => {
+      const { publicKey } = item;
+
+      return {
+        ...(item as { publicKey: string; address: string }),
+        publicKey: new Uint8Array(Buffer.from(publicKey, 'hex')),
+      };
+    });
+
+    return response;
+  }
+
+  if (message.method === 'cos_signDirect' || message.method === 'ten_signDirect') {
+    const { params } = message;
+
+    const doc = params?.doc;
+
+    const newDoc: SignDirectDoc = doc
+      ? {
+          ...doc,
+          auth_info_bytes: doc.auth_info_bytes ? [...Array.from(new Uint8Array(doc.auth_info_bytes))] : doc.auth_info_bytes,
+          body_bytes: doc.body_bytes ? [...Array.from(new Uint8Array(doc.body_bytes))] : doc.body_bytes,
+        }
+      : doc;
+
+    const newParams: CosSignDirectParams = params ? { ...params, doc: newDoc } : params;
+    const newMessage = { ...message, params: newParams };
+
+    const result = (await executeRequest(newMessage)) as CosSignDirectResponse;
+
+    const response: CosSignDirectResponse = {
+      ...result,
+      signed_doc: {
+        ...result.signed_doc,
+        auth_info_bytes: new Uint8Array(result.signed_doc.auth_info_bytes),
+        body_bytes: new Uint8Array(result.signed_doc.body_bytes),
+      },
+    };
+
+    return response;
+  }
+
+  if (message.method === 'cos_sendTransaction') {
+    const { params } = message;
+
+    const txBytes = params?.txBytes && typeof params.txBytes === 'object' ? Buffer.from(params.txBytes).toString('base64') : params.txBytes;
+
+    const newParams = { ...params, txBytes };
+    const newMessage = { ...message, params: newParams };
+
+    return executeRequest(newMessage);
+  }
+
+  return executeRequest(message);
+};
 
 export const on = (eventName: CosmosListenerType, eventHandler: (data: unknown) => void) => {
   const handler = (event: MessageEvent<ListenerMessage>) => {

--- a/src/constants/message/cosmos.ts
+++ b/src/constants/message/cosmos.ts
@@ -6,6 +6,7 @@ export const COSMOS_POPUP_METHOD_TYPE = {
   TEN__SIGN_DIRECT: 'ten_signDirect',
 
   COS__REQUEST_ACCOUNT: 'cos_requestAccount',
+  COS__REQUEST_ACCOUNTS: 'cos_requestAccounts',
   COS__ADD_CHAIN: 'cos_addChain',
   COS__SIGN_AMINO: 'cos_signAmino',
   COS__SIGN_DIRECT: 'cos_signDirect',

--- a/src/types/message/cosmos.ts
+++ b/src/types/message/cosmos.ts
@@ -56,6 +56,8 @@ export type CosAccount = {
 
 export type CosAccountResponse = { publicKey: string; address: string; name: string; isLedger: boolean; isEthermint: boolean };
 
+export type CosAccountResponses = CosAccountResponse[];
+
 export type CosSendTransactionParams = {
   chainName: string;
   txBytes: string;
@@ -125,7 +127,15 @@ export type CosRequestAccount = {
   id?: number | string;
 };
 
+export type CosRequestAccounts = {
+  method: typeof COSMOS_POPUP_METHOD_TYPE.COS__REQUEST_ACCOUNTS;
+  params: { chainIds: string[] };
+  id?: number | string;
+};
+
 export type CosRequestAccountResponse = CosAccountResponse;
+
+export type CosRequestAccountsResponse = CosAccountResponses;
 
 export type CosAddChainParams = {
   type?: CosmosType;

--- a/src/types/message/cosmos.ts
+++ b/src/types/message/cosmos.ts
@@ -56,7 +56,7 @@ export type CosAccount = {
 
 export type CosAccountResponse = { publicKey: string; address: string; name: string; isLedger: boolean; isEthermint: boolean };
 
-export type CosAccountResponses = CosAccountResponse[];
+export type CosAccountsResponse = CosAccountResponse[];
 
 export type CosSendTransactionParams = {
   chainName: string;
@@ -135,7 +135,7 @@ export type CosRequestAccounts = {
 
 export type CosRequestAccountResponse = CosAccountResponse;
 
-export type CosRequestAccountsResponse = CosAccountResponses;
+export type CosRequestAccountsResponse = CosAccountsResponse;
 
 export type CosAddChainParams = {
   type?: CosmosType;

--- a/src/types/message/index.ts
+++ b/src/types/message/index.ts
@@ -24,6 +24,7 @@ import type {
   CosGetBalanceCW20,
   CosGetTokenInfoCW20,
   CosRequestAccount,
+  CosRequestAccounts,
   CosSendTransaction,
   CosSignAmino,
   CosSignDirect,
@@ -92,6 +93,7 @@ export type EthereumRequestMessage =
 
 export type CosmosRequestMessage =
   | CosRequestAccount
+  | CosRequestAccounts
   | CosAddChain
   | CosSignAmino
   | CosSignDirect


### PR DESCRIPTION
- `request()`의 백그라운드로로 요청을 전달하는 부분과 요청문, 리스폰스 수정 부분을 분리했습니다.
- `cos_requestAccounts`메서드를 추가했습니다.
   - 기존 `cos_requestAccounts`에서 pararms의 키 명이 `chainName`이며 체인 이름, 체인 id를 모두 받는 것과 달리
   - 키 명을 `chainIds`로 사용했으며 체인 id 리스트만 입력받도록 했습니다.

- wallets 패키지에 멀티어카운트 주소를 제공하는 api가 제공되면 wallets에서도 `cos_requestAccounts`를 사용할 수 있도록 작업해놓겠습니다.