### PR TITLE
[APIS-261] Prevent the use of iBC transfer functionality on custom chains

### DIFF
--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/IBCSend/index.tsx
@@ -86,7 +86,7 @@ export default function IBCSend({ chain }: IBCSendProps) {
   const { enQueue } = useCurrentQueue();
   const coinGeckoPrice = useCoinGeckoPriceSWR();
   const { extensionStorage } = useExtensionStorage();
-  const { currency } = extensionStorage;
+  const { currency, additionalChains } = extensionStorage;
   const params = useParams();
 
   const [isDisabled, setIsDisabled] = useState(false);
@@ -125,7 +125,13 @@ export default function IBCSend({ chain }: IBCSendProps) {
 
   const [debouncedCurrentAddress] = useDebounce(currentAddress, 500);
 
+  const cosmosAdditionalChains = additionalChains.filter((item) => item.line === 'COSMOS') as CosmosChain[];
+
   const senderCoinAndTokenList: CoinOrTokenInfo[] = useMemo(() => {
+    if (cosmosAdditionalChains.some((item) => item.id === chain.id)) {
+      return [];
+    }
+
     const coinOrTokenList = [
       ...currentChainAssets.data
         .filter((item) => {
@@ -186,16 +192,18 @@ export default function IBCSend({ chain }: IBCSendProps) {
       .sort((a, b) => (gt(a.price, b.price) ? -1 : 1))
       .sort((a) => (a.displayDenom === chain.displayDenom ? -1 : 1));
   }, [
-    coinsBalance?.balance,
-    chain.chainName,
-    chain.displayDenom,
-    coinGeckoPrice.data,
-    cosmosTokensBalance.data,
-    currency,
+    cosmosAdditionalChains,
     currentChainAssets.data,
     currentCosmosTokens,
+    chain.id,
+    chain.chainName,
+    chain.displayDenom,
     filteredCosmosChainAssets,
     filteredCurrentChainAssets,
+    coinsBalance?.balance,
+    coinGeckoPrice.data,
+    currency,
+    cosmosTokensBalance.data,
   ]);
 
   const currentCoinOrToken = useMemo(


### PR DESCRIPTION
커스텀 추가 코스모스 계열 체인은 IBC기능을 사용하지 못하도록 전송 가능한 코인 리스트를 빈 리스트로 반환하여
에러 컴포넌트가 노출될 수 있도록 코드를 수정했습니다.