### PR TITLE
[APIS-262] update chains coinGeckoIds

### DIFF
--- a/src/constants/chain/cosmos/comdex.ts
+++ b/src/constants/chain/cosmos/comdex.ts
@@ -20,6 +20,7 @@ export const COMDEX: CosmosChain = {
     change: '0',
   },
   bech32Prefix: { address: 'comdex' },
+  coinGeckoId: 'comdex',
   explorerURL: `${MINTSCAN_URL}/comdex`,
   gasRate: {
     tiny: '0.03',

--- a/src/constants/chain/cosmos/lum.ts
+++ b/src/constants/chain/cosmos/lum.ts
@@ -20,6 +20,7 @@ export const LUM: CosmosChain = {
     change: '0',
   },
   bech32Prefix: { address: 'lum' },
+  coinGeckoId: 'lum-network',
   explorerURL: `${MINTSCAN_URL}/lum`,
   gasRate: {
     tiny: '0.001',

--- a/src/constants/chain/cosmos/rizon.ts
+++ b/src/constants/chain/cosmos/rizon.ts
@@ -20,7 +20,7 @@ export const RIZON: CosmosChain = {
     change: '0',
   },
   bech32Prefix: { address: 'rizon' },
-  coinGeckoId: 'hdac',
+  coinGeckoId: 'rizon',
   explorerURL: `${MINTSCAN_URL}/rizon`,
   gasRate: {
     tiny: '0.00025',

--- a/src/constants/chain/cosmos/sentinel.ts
+++ b/src/constants/chain/cosmos/sentinel.ts
@@ -20,7 +20,7 @@ export const SENTINEL: CosmosChain = {
     change: '0',
   },
   bech32Prefix: { address: 'sent' },
-  coinGeckoId: 'sentinel-group',
+  coinGeckoId: 'sentinel',
   explorerURL: `${MINTSCAN_URL}/sentinel`,
   gasRate: {
     tiny: '0.01',


### PR DESCRIPTION
Lum, Comdex, Rizon, Sentinel 체인의 코인 게코 id를 추가했습니다.