### PR TITLE
[APIS-269] Migrate mintscan v1, v3 api to v10

### DIFF
--- a/src/Popup/hooks/SWR/cosmos/useAssetsSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useAssetsSWR.ts
@@ -3,6 +3,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
+import { MINTSCAN_FRONT_API_URL } from '~/constants/common';
 import { get } from '~/Popup/utils/axios';
 import { convertCosmosToAssetName } from '~/Popup/utils/cosmos';
 import type { CosmosChain } from '~/types/chain';
@@ -11,7 +12,7 @@ import type { AssetV3Response } from '~/types/cosmos/asset';
 export function useAssetsSWR(chain?: CosmosChain, config?: SWRConfiguration) {
   const mappingName = chain ? convertCosmosToAssetName(chain) : '';
 
-  const requestURL = 'https://front.api.mintscan.io/v3/assets';
+  const requestURL = `${MINTSCAN_FRONT_API_URL}/assets`;
 
   const fetcher = async (fetchUrl: string) => {
     try {

--- a/src/Popup/hooks/SWR/cosmos/useParamsSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useParamsSWR.ts
@@ -2,6 +2,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
+import { MINTSCAN_FRONT_API_URL } from '~/constants/common';
 import { get } from '~/Popup/utils/axios';
 import { convertCosmosToAssetName } from '~/Popup/utils/cosmos';
 import type { CosmosChain } from '~/types/chain';
@@ -10,7 +11,7 @@ import type { ParamsResponse } from '~/types/cosmos/params';
 export function useParamsSWR(chain: CosmosChain, config?: SWRConfiguration) {
   const mappingName = convertCosmosToAssetName(chain);
 
-  const requestURL = `https://front.api.mintscan.io/v10/utils/params/${mappingName}`;
+  const requestURL = `${MINTSCAN_FRONT_API_URL}/utils/params/${mappingName}`;
 
   const fetcher = async (fetchUrl: string) => {
     try {

--- a/src/Popup/hooks/SWR/cosmos/useSupportChainsSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useSupportChainsSWR.ts
@@ -2,11 +2,12 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
+import { MINTSCAN_FRONT_API_URL } from '~/constants/common';
 import { get } from '~/Popup/utils/axios';
 import type { SupportChainPayload } from '~/types/cosmos/supportChains';
 
 export function useSupportChainsSWR(config?: SWRConfiguration) {
-  const requestURL = `https://front.api.mintscan.io/v1/meta/support/chains`;
+  const requestURL = `${MINTSCAN_FRONT_API_URL}/meta/support/chains`;
 
   const fetcher = (fetchUrl: string) => get<SupportChainPayload>(fetchUrl);
 

--- a/src/Popup/hooks/SWR/cosmos/useTokensSWR.ts
+++ b/src/Popup/hooks/SWR/cosmos/useTokensSWR.ts
@@ -3,6 +3,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
+import { MINTSCAN_FRONT_API_URL } from '~/constants/common';
 import { get } from '~/Popup/utils/axios';
 import { convertCosmosToAssetName } from '~/Popup/utils/cosmos';
 import type { CosmosChain } from '~/types/chain';
@@ -11,7 +12,7 @@ import type { CW20AssetResponse } from '~/types/cosmos/asset';
 export function useTokensSWR(chain: CosmosChain, config?: SWRConfiguration) {
   const mappingName = convertCosmosToAssetName(chain);
 
-  const requestURL = `https://front.api.mintscan.io/v3/assets/${mappingName}/cw20`;
+  const requestURL = `${MINTSCAN_FRONT_API_URL}/assets/${mappingName}/cw20`;
 
   const fetcher = async (fetchUrl: string) => {
     try {

--- a/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
+++ b/src/Popup/hooks/SWR/ethereum/useTokensSWR.ts
@@ -5,6 +5,7 @@ import useSWR from 'swr';
 import { ETHEREUM } from '~/constants/chain/ethereum/network/ethereum';
 import { KAVA } from '~/constants/chain/ethereum/network/kava';
 import { SMART_CHAIN } from '~/constants/chain/ethereum/network/smartChain';
+import { MINTSCAN_FRONT_API_URL } from '~/constants/common';
 import { get } from '~/Popup/utils/axios';
 import { toHex } from '~/Popup/utils/string';
 import type { EthereumNetwork } from '~/types/chain';
@@ -25,7 +26,7 @@ export function useTokensSWR(chain?: EthereumNetwork, config?: SWRConfiguration)
 
   const mappingName = nameMap[currentChain.id] || currentChain.networkName.toLowerCase();
 
-  const requestURL = `https://front.api.mintscan.io/v10/assets/${mappingName}/erc20/info`;
+  const requestURL = `${MINTSCAN_FRONT_API_URL}/assets/${mappingName}/erc20/info`;
 
   const fetcher = async (fetchUrl: string) => {
     try {

--- a/src/Popup/hooks/SWR/useCoinGeckoPriceSWR.ts
+++ b/src/Popup/hooks/SWR/useCoinGeckoPriceSWR.ts
@@ -3,6 +3,7 @@ import type { AxiosError } from 'axios';
 import type { SWRConfiguration } from 'swr';
 import useSWR from 'swr';
 
+import { MINTSCAN_FRONT_API_URL } from '~/constants/common';
 import { get } from '~/Popup/utils/axios';
 import type { CoinGeckoPriceResponse, SimplePrice } from '~/types/coinGecko';
 
@@ -11,7 +12,7 @@ import { useExtensionStorage } from '../useExtensionStorage';
 export function useCoinGeckoPriceSWR(config?: SWRConfiguration) {
   const { extensionStorage } = useExtensionStorage();
 
-  const requestURL = `https://front.api.mintscan.io/v10/utils/market/prices?currency=${extensionStorage.currency}`;
+  const requestURL = `${MINTSCAN_FRONT_API_URL}/utils/market/prices?currency=${extensionStorage.currency}`;
 
   const fetcher = (fetchUrl: string) => get<CoinGeckoPriceResponse>(fetchUrl);
 

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -4,3 +4,5 @@ export const MINTSCAN_URL = 'https://www.mintscan.io';
 export const MINTSCAN_DEV_URL = 'https://dev.mintscan.io';
 
 export const CHAINLIST_RESOURCE_URL = 'https://raw.githubusercontent.com/cosmostation/chainlist/main/wallet_extension';
+
+export const MINTSCAN_FRONT_API_URL = 'https://front.api.mintscan.io/v10';


### PR DESCRIPTION
민트스캔 프론트 v3, v1 api를 v10으로 마이그레이션 했습니다.

- api 리스폰스 타입은 v3,v1과 v10이 동일하여 수정하지 않았습니다.
- `MINTSCAN_FRONT_API_URL`상수를 사용해서 v10 api를 사용하도록 수정했습니다.