### PR TITLE
[APIS-276] Update Sui explorer urls

### DIFF
--- a/src/Popup/pages/Popup/TxReceipt/Entry/Sui/entry.tsx
+++ b/src/Popup/pages/Popup/TxReceipt/Entry/Sui/entry.tsx
@@ -73,10 +73,7 @@ export default function Sui({ txDigest }: SuiProps) {
 
   const txInfo = useTxInfoSWR({ digest: txDigest, network: currentSuiNetwork });
 
-  const txDetailExplorerURL = useMemo(
-    () => (explorerURL ? `${explorerURL}/txblock/${txDigest}?network=${currentSuiNetwork.networkName.toLowerCase()}` : ''),
-    [currentSuiNetwork.networkName, explorerURL, txDigest],
-  );
+  const txDetailExplorerURL = useMemo(() => (explorerURL ? `${explorerURL}/tx/${txDigest}` : ''), [explorerURL, txDigest]);
 
   const formattedTimestamp = useMemo(() => {
     if (txInfo.data?.result?.timestampMs) {

--- a/src/Popup/pages/Wallet/NFTDetail/Entry/sui/index.tsx
+++ b/src/Popup/pages/Wallet/NFTDetail/Entry/sui/index.tsx
@@ -38,7 +38,7 @@ export default function Sui() {
 
   const { currentSuiNetwork } = useCurrentSuiNetwork();
 
-  const { explorerURL, networkName } = currentSuiNetwork;
+  const { explorerURL } = currentSuiNetwork;
 
   const params = useParams();
 
@@ -83,7 +83,7 @@ export default function Sui() {
                 )}
               </NFTInfoLeftHeaderContainer>
 
-              <StyledIconButton onClick={() => window.open(`${explorerURL || ''}/object/${objectId || ''}?network=${networkName.toLowerCase()}`)}>
+              <StyledIconButton onClick={() => window.open(`${explorerURL || ''}/object/${objectId || ''}`)}>
                 <ExplorerIcon />
               </StyledIconButton>
             </NFTInfoHeaderContainer>

--- a/src/Popup/pages/Wallet/Receive/Entry/Cosmos.tsx
+++ b/src/Popup/pages/Wallet/Receive/Entry/Cosmos.tsx
@@ -52,7 +52,7 @@ export default function Cosmos({ chain }: CosmosProps) {
           </TitleContainer>
           <ButtonContainer>
             {explorerURL && (
-              <StyledIconButton onClick={() => window.open(`${explorerURL}/account/${currentAddress}`)}>
+              <StyledIconButton onClick={() => window.open(`${explorerURL}/address/${currentAddress}`)}>
                 <ExplorerIcon />
               </StyledIconButton>
             )}

--- a/src/Popup/pages/Wallet/Receive/Entry/Sui.tsx
+++ b/src/Popup/pages/Wallet/Receive/Entry/Sui.tsx
@@ -54,7 +54,7 @@ export default function Sui({ chain }: SuiProps) {
           </TitleContainer>
           <ButtonContainer>
             {explorerURL && (
-              <StyledIconButton onClick={() => window.open(`${explorerURL}/address/${currentAddress}`)}>
+              <StyledIconButton onClick={() => window.open(`${explorerURL}/account/${currentAddress}`)}>
                 <ExplorerIcon />
               </StyledIconButton>
             )}

--- a/src/Popup/pages/Wallet/components/sui/NativeChainCard/index.tsx
+++ b/src/Popup/pages/Wallet/components/sui/NativeChainCard/index.tsx
@@ -177,7 +177,7 @@ export default function NativeChainCard({ chain, isCustom }: NativeChainCardProp
           {explorerURL && (
             <StyledIconButton
               onClick={() => {
-                window.open(`${explorerURL}/address/${currentAddress}?network=${currentSuiNetwork.networkName.toLowerCase()}`);
+                window.open(`${explorerURL}/account/${currentAddress}}`);
               }}
             >
               <ExplorerIcon />
@@ -343,7 +343,7 @@ export function NativeChainCardSkeleton({ chain, isCustom }: NativeChainCardProp
           {explorerURL && (
             <StyledIconButton
               onClick={() => {
-                window.open(`${explorerURL}/address/${address}`);
+                window.open(`${explorerURL}/account/${address}`);
               }}
             >
               <ExplorerIcon />
@@ -488,7 +488,7 @@ export function NativeChainCardError({ chain, isCustom, resetErrorBoundary }: Na
           {explorerURL && (
             <StyledIconButton
               onClick={() => {
-                window.open(`${explorerURL}/address/${address}`);
+                window.open(`${explorerURL}/account/${address}`);
               }}
             >
               <ExplorerIcon />

--- a/src/constants/chain/sui/network/devnet.ts
+++ b/src/constants/chain/sui/network/devnet.ts
@@ -6,7 +6,7 @@ export const DEVNET: SuiNetwork = {
   networkName: 'Devnet',
   rpcURL: 'https://fullnode.devnet.sui.io',
   imageURL: suiImg,
-  explorerURL: 'https://explorer.sui.io',
+  explorerURL: 'https://suiscan.xyz/devnet',
   displayDenom: 'SUI',
   decimals: 9,
 };

--- a/src/constants/chain/sui/network/mainnet.ts
+++ b/src/constants/chain/sui/network/mainnet.ts
@@ -6,7 +6,7 @@ export const MAINNET: SuiNetwork = {
   networkName: 'Mainnet',
   rpcURL: 'https://sui-mainnet-us-1.cosmostation.io',
   imageURL: suiImg,
-  explorerURL: 'https://explorer.sui.io',
+  explorerURL: 'https://suiscan.xyz/mainnet',
   displayDenom: 'SUI',
   decimals: 9,
   coinGeckoId: 'sui',

--- a/src/constants/chain/sui/network/testnet.ts
+++ b/src/constants/chain/sui/network/testnet.ts
@@ -6,7 +6,7 @@ export const TESTNET: SuiNetwork = {
   networkName: 'Testnet',
   rpcURL: 'https://sui-testnet-kr-1.cosmostation.io',
   imageURL: suiImg,
-  explorerURL: 'https://explorer.sui.io',
+  explorerURL: 'https://suiscan.xyz/testnet',
   displayDenom: 'SUI',
   decimals: 9,
 };


### PR DESCRIPTION
기존에 사용중이던 수이 체인의 익스플로러가 서비스종료를 함에 따라 `https://suiscan.xyz`으로 주소를 변경했습니다.
- 수이 공식 익스텐션 지갑에서 사용하고 있는 익스플로러를 사용했습니다.