### PR TITLE
[APIS-282] Add hover styles on Fee buttons

### DIFF
--- a/src/Popup/components/Fee/styled.tsx
+++ b/src/Popup/components/Fee/styled.tsx
@@ -59,6 +59,10 @@ export const GasButton = styled('button')(({ theme }) => ({
   color: theme.accentColors.purple01,
 
   cursor: 'pointer',
+
+  '&:hover': {
+    opacity: 0.8,
+  },
 }));
 export const FeeSettingButton = styled('button')(({ theme }) => ({
   border: 0,
@@ -73,6 +77,10 @@ export const FeeSettingButton = styled('button')(({ theme }) => ({
 
   '& > svg': {
     fill: theme.colors.base06,
+  },
+
+  '&:hover': {
+    opacity: 0.8,
   },
 }));
 
@@ -98,4 +106,8 @@ export const FeeButton = styled('button')<FeeButtonProps>(({ theme, ...props }) 
   color: props['data-is-active'] ? theme.accentColors.white : theme.colors.text02,
 
   cursor: 'pointer',
+
+  '&:hover': {
+    opacity: 0.8,
+  },
 }));

--- a/src/Popup/pages/Popup/Aptos/Transaction/styled.tsx
+++ b/src/Popup/pages/Popup/Aptos/Transaction/styled.tsx
@@ -101,6 +101,10 @@ export const FeeButton = styled('button')<FeeButtonProps>(({ theme, ...props }) 
   },
 
   cursor: 'pointer',
+
+  '&:hover': {
+    opacity: 0.8,
+  },
 }));
 
 export const BottomContainer = styled('div')({

--- a/src/Popup/pages/Popup/Ethereum/Transaction/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/styled.tsx
@@ -88,6 +88,10 @@ export const FeeGasButton = styled('button')(({ theme }) => ({
   color: theme.accentColors.purple01,
 
   cursor: 'pointer',
+
+  '&:hover': {
+    opacity: 0.8,
+  },
 }));
 
 type FeeButtonProps = {
@@ -113,6 +117,10 @@ export const FeeButton = styled('button')<FeeButtonProps>(({ theme, ...props }) 
   },
 
   cursor: 'pointer',
+
+  '&:hover': {
+    opacity: 0.8,
+  },
 }));
 
 export const FeeEditButton = styled(FeeButton)({


### PR DESCRIPTION
Fee컴포넌트의 fee 코인 변경 버튼, 가스 레이트 버튼의 시인성 개선을 위해 버튼 스타일에 호버 스타일을 추가했습니다.

- fee 컴포넌트의 fee코인 선택 버튼, 가스 레이트 버튼에 호버 시 투명도 효과를 추가했습니다.

![스크린샷 2024-04-29 오후 12 16 55](https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/fbc14463-4bad-4a04-aaf8-bf6b79f59e74)
