### PR TITLE
[APIS-297] Fixing Issues with Converting 'chainId' Variable from Dec to Hex

### DIFF
--- a/src/Popup/background/messageProcessor.ts
+++ b/src/Popup/background/messageProcessor.ts
@@ -1039,7 +1039,7 @@ export async function cstob(request: ContentScriptToBackgroundEventMessage<Reque
 
               const chainId = param2?.domain?.chainId;
 
-              if (chainId && toHex(chainId, { addPrefix: true }) !== currentNetwork.chainId) {
+              if (chainId && toHex(chainId, { addPrefix: true, isStringNumber: true }) !== currentNetwork.chainId) {
                 throw new EthereumRPCError(RPC_ERROR.INVALID_PARAMS, 'Invalid chainId', message.id);
               }
 


### PR DESCRIPTION
`eth_signTypedData_v4`메서드로 들어온 파라미터 값을 파싱해서 16진수로 변환하는 과정에서 타입이 다른 경우 변환이 잘못되는 오류를 수정했습니다.