### PR TITLE
[APIS-326] 주소 마이그레이션 로직 추가

### DIFF
--- a/src/Popup/hooks/SWR/cache/useAccounts.ts
+++ b/src/Popup/hooks/SWR/cache/useAccounts.ts
@@ -27,12 +27,19 @@ export function useAccounts(suspense?: boolean) {
           const addresses: Record<string, string> = {};
 
           [...CHAINS, ...additionalChains].forEach((chain) => {
+            // 추후 삭제 예정
+            const legacyKey = `${account.id}${chain.id}`;
+            const legacyStorageAddress = localStorage.getItem(legacyKey);
+
             const key = getAddressKey(account, chain);
             const storageAddress = address?.[key];
 
             if (storageAddress) {
               addresses[chain.id] = storageAddress;
               accountAddress[key] = storageAddress;
+            } else if (legacyStorageAddress) {
+              addresses[chain.id] = legacyStorageAddress;
+              accountAddress[key] = legacyStorageAddress;
             } else {
               const keypair = getKeyPair(account, chain, currentPassword);
               const chainAddress = getAddress(chain, keypair?.publicKey);


### PR DESCRIPTION
browser -> chrome localstorage 로 옮기는 과정에서 주소를 새로 생성해야하는 문제점 발견

결과적으로 계정이 많을 수록 마이그레이션 시간이 오래 걸림

과거 저장했던 데이터를 활용하여 마이그레이션 할 수 있도록 로직 추가