### PR TITLE
[APSI-327] Support enable api

### DIFF
--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -195,7 +195,7 @@ export const cosmos: Cosmos = {
 
 const enable: Keplr['enable'] = async (chainIds?: string[] | string) => {
   if (!chainIds) {
-    throw new Error('chainIds is required');
+    throw new Error('chain id not set');
   }
 
   const inputChainIds = typeof chainIds === 'string' ? [chainIds] : chainIds;

--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -193,7 +193,11 @@ export const cosmos: Cosmos = {
 
 // keplr provider start
 
-const enable: Keplr['enable'] = async (chainIds: string[] | string) => {
+const enable: Keplr['enable'] = async (chainIds?: string[] | string) => {
+  if (!chainIds) {
+    throw new Error('chainIds is required');
+  }
+
   const inputChainIds = typeof chainIds === 'string' ? [chainIds] : chainIds;
 
   const response = (await request({ method: 'cos_supportedChainIds' })) as CosSupportedChainIdsResponse;

--- a/src/Scripts/injectScript/cosmos.ts
+++ b/src/Scripts/injectScript/cosmos.ts
@@ -193,10 +193,21 @@ export const cosmos: Cosmos = {
 
 // keplr provider start
 
-const enable = () =>
-  new Promise<void>((res) => {
-    res();
-  });
+const enable: Keplr['enable'] = async (chainIds: string[] | string) => {
+  const inputChainIds = typeof chainIds === 'string' ? [chainIds] : chainIds;
+
+  const response = (await request({ method: 'cos_supportedChainIds' })) as CosSupportedChainIdsResponse;
+
+  const suppotedChainIds = [...response.official, ...response.unofficial];
+
+  const invalidChainId = inputChainIds.find((chainId) => !suppotedChainIds.includes(chainId));
+
+  if (invalidChainId) {
+    throw new Error(`There is no chain info for ${invalidChainId}`);
+  }
+
+  await request({ method: 'cos_requestAccount', params: { chainName: inputChainIds[0] } });
+};
 
 const getKey: Keplr['getKey'] = async (chainId) => {
   try {


### PR DESCRIPTION
Keplr 인터페이스의 enable api를 지원하는 코드를 추가했습니다.
- 파라미터에 지원하지 않는 체인이 포함될 경우, 지원하지 않는 체인들 중 가장 낮은 인덱스의 값만 에러로 리턴합니다.