### PR TITLE
[APIS-319] Sort Aptos coin list

### DIFF
--- a/src/Popup/hooks/useCurrent/useCurrentAptosCoins.ts
+++ b/src/Popup/hooks/useCurrent/useCurrentAptosCoins.ts
@@ -1,6 +1,9 @@
+import { useMemo } from 'react';
 import type { SWRConfiguration } from 'swr';
 
-import { ACCOUNT_TYPE } from '~/constants/aptos';
+import { ACCOUNT_TYPE, APTOS_COIN } from '~/constants/aptos';
+import { getCoinAddress } from '~/Popup/utils/aptos';
+import { isEqualsIgnoringCase } from '~/Popup/utils/string';
 import type { X1CoinCoinstore } from '~/types/aptos/accounts';
 
 import { useCurrentAptosNetwork } from './useCurrentAptosNetwork';
@@ -11,7 +14,13 @@ export function useCurrentAptosCoins(config?: SWRConfiguration) {
 
   const accountResources = useAccountResourcesSWR({ network: currentAptosNetwork }, config);
 
-  const currentAptosCoins = (accountResources.data?.filter((item) => item.type.startsWith(ACCOUNT_TYPE.X1___COIN___COIN_STORE)) || []) as X1CoinCoinstore[];
+  const currentAptosCoins = useMemo(
+    () =>
+      (accountResources.data?.filter((item) => item.type.startsWith(ACCOUNT_TYPE.X1___COIN___COIN_STORE)) || []).sort((item) =>
+        isEqualsIgnoringCase(getCoinAddress(item.type), APTOS_COIN) ? -1 : 1,
+      ) as X1CoinCoinstore[],
+    [accountResources.data],
+  );
 
   return { currentAptosCoins };
 }

--- a/src/Popup/pages/Wallet/Swap/components/SwapCoinContainer/components/TokenListBottomSheet/components/TokenItem/index.tsx
+++ b/src/Popup/pages/Wallet/Swap/components/SwapCoinContainer/components/TokenListBottomSheet/components/TokenItem/index.tsx
@@ -91,7 +91,7 @@ const TokenItem = forwardRef<HTMLButtonElement, TokenItemProps>(({ tokenInfo, on
               </div>
             </Tooltip>
           </TokenRightTitleContainer>
-          {coinPrice && (
+          {gt(coinPrice, '0') && (
             <TokenRightSubTitleContainer>
               <Number typoOfIntegers="h7n" typoOfDecimals="h8n" fixed={2} currency={currency}>
                 {coinAmountPrice}


### PR DESCRIPTION
Aptos계정에서 보유중인 코인을 리스팅할때 APT코인이 가장 낮은 인덱스에 위치하도록 정렬 로직을 추가했습니다.
- 대시보드에서 APT코인 send버튼 클릭 시 APT코인이 선택됩니다.

- 스왑 페이지의 코인 컴포넌트에서 코인 가격이 없는 코인은 가격 텍스트가 노출되지 않도록 변경했습니다.
![스크린샷 2024-06-05 오전 11 38 17](https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/c1378c58-af65-4704-93eb-ce5bd51397ae)

