### PR TITLE
[APIS-337] Emit 'accountChanged' Event When User Disconnects DApp Connection In-App

### DIFF
--- a/src/Popup/hooks/useCurrent/useCurrentAccount.ts
+++ b/src/Popup/hooks/useCurrent/useCurrentAccount.ts
@@ -37,6 +37,9 @@ export function useCurrentAccount() {
 
   const removeAllowedOrigin = async (origin: string) => {
     const newAllowedOrigins = allowedOrigins.filter((allowedOrigin) => !(allowedOrigin.accountId === selectedAccountId && allowedOrigin.origin === origin));
+
+    emitToWeb({ line: 'ETHEREUM', type: 'accountsChanged', message: { result: [] } }, [origin]);
+
     await setExtensionStorage('allowedOrigins', newAllowedOrigins);
   };
 

--- a/src/Popup/pages/Setting/ConnectedSites/entry.tsx
+++ b/src/Popup/pages/Setting/ConnectedSites/entry.tsx
@@ -6,6 +6,7 @@ import SettingAccordion from '~/Popup/components/SettingAccordion';
 import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
 import { useExtensionStorage } from '~/Popup/hooks/useExtensionStorage';
 import { getSiteIconURL } from '~/Popup/utils/common';
+import { emitToWeb } from '~/Popup/utils/message';
 
 import {
   Container,
@@ -74,6 +75,10 @@ export default function Entry() {
                         onClick={async () => {
                           const newAllowedOrigins = allowedOrigins.filter((item) => !(origin.accountId === item.accountId && origin.origin === item.origin));
                           await setExtensionStorage('allowedOrigins', newAllowedOrigins);
+
+                          if (isCurrentAccount) {
+                            emitToWeb({ line: 'ETHEREUM', type: 'accountsChanged', message: { result: [] } }, [origin.origin]);
+                          }
                         }}
                       >
                         <Close16Icon />

--- a/src/Scripts/injectScript/ethereum.ts
+++ b/src/Scripts/injectScript/ethereum.ts
@@ -43,7 +43,7 @@ const on = (eventName: EthereumListenerType, eventHandler: (data: unknown) => vo
       if (eventName === 'accountsChanged' && Array.isArray(event.data?.message?.result) && event.data?.message?.result.length === 0) {
         void (async () => {
           try {
-            const account = (await request({ method: 'eth_requestAccounts', params: {} })) as EthRequestAccountsResponse;
+            const account = (await request({ method: 'eth_accounts', params: {} })) as EthRequestAccountsResponse;
 
             eventHandler(account);
           } catch {


### PR DESCRIPTION
유저가 인앱에서 디앱과의 연결을 끊을 때, 끊은 오리진(디앱)에 `accountChanged` 이벤트를 빈 리스트로 emit하도록 `removeAllowedOrigin`에 로직을 추가했습니다.

- 이제 유저가 인앱에서 디앱 연결을 해제하면 디앱에서 연결 해제 이벤트를 캐치할 수 있습니다.