### PR TITLE
[APIS-343] Fix fee coin selection in cosmos sign page

### DIFF
--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -66,8 +66,8 @@ export default function Entry({ queue, chain }: EntryProps) {
   const balance = useBalanceSWR(chain);
 
   const selectableFeeCoins = useMemo<FeeCoin[]>(
-    () => [
-      ...assets.data.map((asset) => ({
+    () =>
+      assets.data.map((asset) => ({
         originBaseDenom: asset.origin_denom,
         baseDenom: asset.denom,
         decimals: asset.decimals,
@@ -75,7 +75,7 @@ export default function Entry({ queue, chain }: EntryProps) {
         coinGeckoId: asset.coinGeckoId,
         availableAmount: balance.data?.balance?.find((item) => item.denom === asset.denom)?.amount || '0',
       })),
-    ],
+
     [assets.data, balance.data?.balance],
   );
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -22,7 +22,7 @@ import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import { useLedgerTransport } from '~/Popup/hooks/useLedgerTransport';
 import { useLoading } from '~/Popup/hooks/useLoading';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
-import { ceil, divide, equal, gte, times } from '~/Popup/utils/big';
+import { ceil, divide, equal, gt, gte, times } from '~/Popup/utils/big';
 import { getAddress, getKeyPair } from '~/Popup/utils/common';
 import { cosmosURL, getDefaultAV, getPublicKeyType, signAmino } from '~/Popup/utils/cosmos';
 import CosmosApp from '~/Popup/utils/ledger/cosmos';
@@ -79,7 +79,7 @@ export default function Entry({ queue, chain }: EntryProps) {
     [assets.data, balance.data?.balance],
   );
 
-  const { feeCoins: supportedFeeCoins, defaultGasRateKey } = useCurrentFeesSWR(chain);
+  const { feeCoins: supportedFeeCoins, defaultGasRateKey } = useCurrentFeesSWR(chain, { suspense: true });
 
   const feeCoins = useMemo(() => {
     const aggregatedCoins = [...supportedFeeCoins, ...selectableFeeCoins];
@@ -166,16 +166,25 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const initialGasRate = useMemo(() => (equal(inputGas, '0') ? '0' : divide(inputFeeAmount, inputGas)), [inputFeeAmount, inputGas]);
 
-  const currentFeeGasRate = useMemo(
-    () =>
-      currentFeeCoin.gasRate ||
-      gasRate || {
+  const currentFeeGasRate = useMemo(() => {
+    if (currentFeeCoin.gasRate) {
+      return currentFeeCoin.gasRate;
+    }
+
+    if (gasRate) {
+      return gasRate;
+    }
+
+    if (gt(initialGasRate, '0')) {
+      return {
         average: initialGasRate,
         low: initialGasRate,
         tiny: initialGasRate,
-      },
-    [currentFeeCoin.gasRate, gasRate, initialGasRate],
-  );
+      };
+    }
+
+    return chain.gasRate;
+  }, [chain.gasRate, currentFeeCoin.gasRate, gasRate, initialGasRate]);
 
   const signingMemo = useMemo(() => (isEditMemo ? memo : doc.memo), [doc.memo, isEditMemo, memo]);
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -125,13 +125,13 @@ export default function Entry({ queue, chain }: EntryProps) {
   const currentFeeCoin = useMemo(
     () =>
       availableFeeCoins.find((item) => item.baseDenom === currentFeeBaseDenom) || {
-        availableAmount: '0',
+        availableAmount: balance.data?.balance?.find((item) => item.denom === inputFee.denom)?.amount || '0',
         decimals: 0,
         baseDenom: inputFee.denom,
         originBaseDenom: inputFee.denom,
         displayDenom: 'UNKNOWN',
       },
-    [currentFeeBaseDenom, inputFee.denom, availableFeeCoins],
+    [availableFeeCoins, balance.data?.balance, currentFeeBaseDenom, inputFee.denom],
   );
 
   const memoizedProtoTx = useMemo(() => {

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -129,13 +129,13 @@ export default function Entry({ queue, chain }: EntryProps) {
   const currentFeeCoin = useMemo(
     () =>
       availableFeeCoins.find((item) => item.baseDenom === currentFeeBaseDenom) || {
-        availableAmount: '0',
+        availableAmount: balance.data?.balance?.find((item) => item.denom === inputFee.denom)?.amount || '0',
         decimals: 0,
         baseDenom: inputFee.denom || '',
         originBaseDenom: inputFee.denom || '',
         displayDenom: 'UNKNOWN',
       },
-    [currentFeeBaseDenom, inputFee.denom, availableFeeCoins],
+    [availableFeeCoins, balance.data?.balance, currentFeeBaseDenom, inputFee.denom],
   );
 
   const memoizedProtoTx = useMemo(() => {

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -8,6 +8,8 @@ import { Tab, TabPanel, Tabs } from '~/Popup/components/common/Tab';
 import Tooltip from '~/Popup/components/common/Tooltip';
 import Fee from '~/Popup/components/Fee';
 import PopupHeader from '~/Popup/components/PopupHeader';
+import { useAssetsSWR } from '~/Popup/hooks/SWR/cosmos/useAssetsSWR';
+import { useBalanceSWR } from '~/Popup/hooks/SWR/cosmos/useBalanceSWR';
 import { useCurrentFeesSWR } from '~/Popup/hooks/SWR/cosmos/useCurrentFeesSWR';
 import { useProtoBuilderDecodeSWR } from '~/Popup/hooks/SWR/cosmos/useProtoBuilderDecodeSWR';
 import { useSimulateSWR } from '~/Popup/hooks/SWR/cosmos/useSimulateSWR';
@@ -21,7 +23,7 @@ import { cosmosURL, getDefaultAV, getPublicKeyType, signDirect } from '~/Popup/u
 import { responseToWeb } from '~/Popup/utils/message';
 import { broadcast, decodeProtobufMessage, protoTxBytes } from '~/Popup/utils/proto';
 import { cosmos } from '~/proto/cosmos-v0.44.2.js';
-import type { CosmosChain, GasRateKey } from '~/types/chain';
+import type { CosmosChain, FeeCoin, GasRateKey } from '~/types/chain';
 import type { Queue } from '~/types/extensionStorage';
 import type { CosSignDirect, CosSignDirectResponse } from '~/types/message/cosmos';
 import type { Path } from '~/types/route';
@@ -50,7 +52,37 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const [isProgress, setIsProgress] = useState(false);
 
-  const { feeCoins, defaultGasRateKey } = useCurrentFeesSWR(chain, { suspense: true });
+  const assets = useAssetsSWR(chain);
+
+  const balance = useBalanceSWR(chain);
+
+  const selectableFeeCoins = useMemo<FeeCoin[]>(
+    () => [
+      ...assets.data.map((asset) => ({
+        originBaseDenom: asset.origin_denom,
+        baseDenom: asset.denom,
+        decimals: asset.decimals,
+        displayDenom: asset.symbol,
+        coinGeckoId: asset.coinGeckoId,
+        availableAmount: balance.data?.balance?.find((item) => item.denom === asset.denom)?.amount || '0',
+      })),
+    ],
+    [assets.data, balance.data?.balance],
+  );
+
+  const { feeCoins: supportedFeeCoins, defaultGasRateKey } = useCurrentFeesSWR(chain, { suspense: true });
+
+  const feeCoins = useMemo(() => {
+    const aggregatedCoins = [...supportedFeeCoins, ...selectableFeeCoins];
+
+    const uniqueFeeCoins = aggregatedCoins.reduce((acc: FeeCoin[], current) => {
+      if (!acc.find((coin) => coin.baseDenom === current.baseDenom)) {
+        return [...acc, current];
+      }
+      return acc;
+    }, []);
+    return uniqueFeeCoins;
+  }, [selectableFeeCoins, supportedFeeCoins]);
 
   const { message, messageId, origin, channel } = queue;
 
@@ -95,11 +127,19 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const inputFeeAmount = useMemo(() => inputFee.amount || '0', [inputFee.amount]);
 
-  const [currentFeeBaseDenom, setCurrentFeeBaseDenom] = useState(
-    feeCoins.find((item) => item.baseDenom === inputFee.denom)?.baseDenom ?? feeCoins[0].baseDenom,
-  );
+  const [currentFeeBaseDenom, setCurrentFeeBaseDenom] = useState(inputFee.denom);
 
-  const currentFeeCoin = useMemo(() => feeCoins.find((item) => item.baseDenom === currentFeeBaseDenom) ?? feeCoins[0], [currentFeeBaseDenom, feeCoins]);
+  const currentFeeCoin = useMemo(
+    () =>
+      feeCoins.find((item) => item.baseDenom === currentFeeBaseDenom) || {
+        availableAmount: '0',
+        decimals: 0,
+        baseDenom: inputFee.denom || '',
+        originBaseDenom: inputFee.denom || '',
+        displayDenom: 'UNKNOWN',
+      },
+    [currentFeeBaseDenom, inputFee.denom, feeCoins],
+  );
 
   const memoizedProtoTx = useMemo(() => {
     if (isEditFee) {
@@ -123,13 +163,23 @@ export default function Entry({ queue, chain }: EntryProps) {
     () => customGas || (gte(simulatedGas || '0', inputGas) ? simulatedGas || inputGas : inputGas),
     [customGas, inputGas, simulatedGas],
   );
-  const currentFeeGasRate = useMemo(() => currentFeeCoin.gasRate || gasRate || chain.gasRate, [chain.gasRate, currentFeeCoin.gasRate, gasRate]);
+
+  const initialGasRate = useMemo(() => (equal(inputGas, '0') ? '0' : divide(inputFeeAmount, inputGas)), [inputFeeAmount, inputGas]);
+
+  const currentFeeGasRate = useMemo(
+    () =>
+      currentFeeCoin.gasRate ||
+      gasRate || {
+        average: initialGasRate,
+        low: initialGasRate,
+        tiny: initialGasRate,
+      },
+    [currentFeeCoin.gasRate, gasRate, initialGasRate],
+  );
 
   const isFeeCustomed = useMemo(() => !!customGas || !!customGasRateKey, [customGasRateKey, customGas]);
 
   const isFeeUpdateAllowed = useMemo(() => isEditFee || isFeeCustomed, [isFeeCustomed, isEditFee]);
-
-  const initialGasRate = useMemo(() => (equal(inputGas, '0') ? '0' : divide(inputFeeAmount, inputGas)), [inputFeeAmount, inputGas]);
 
   const baseFee = useMemo(
     () => (isFeeUpdateAllowed ? times(currentGas, currentGasRateKey ? currentFeeGasRate[currentGasRateKey] : initialGasRate) : inputFeeAmount),
@@ -226,12 +276,13 @@ export default function Entry({ queue, chain }: EntryProps) {
             <FeeContainer>
               <Fee
                 feeCoin={currentFeeCoin}
-                feeCoinList={feeCoins}
+                feeCoinList={supportedFeeCoins}
                 gasRate={currentFeeGasRate}
                 baseFee={baseFee}
                 gas={currentGas}
                 onChangeFeeCoin={(selectedFeeCoin) => {
                   setCurrentFeeBaseDenom(selectedFeeCoin.baseDenom);
+                  setCustomGasRateKey('low');
                 }}
                 onChangeGas={(g) => setCustomGas(g)}
                 onChangeGasRateKey={(gasRateKey) => {

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -17,7 +17,7 @@ import { useCurrentAccount } from '~/Popup/hooks/useCurrent/useCurrentAccount';
 import { useCurrentPassword } from '~/Popup/hooks/useCurrent/useCurrentPassword';
 import { useCurrentQueue } from '~/Popup/hooks/useCurrent/useCurrentQueue';
 import { useTranslation } from '~/Popup/hooks/useTranslation';
-import { ceil, divide, equal, gte, times } from '~/Popup/utils/big';
+import { ceil, divide, equal, gt, gte, times } from '~/Popup/utils/big';
 import { getAddress, getKeyPair } from '~/Popup/utils/common';
 import { cosmosURL, getDefaultAV, getPublicKeyType, signDirect } from '~/Popup/utils/cosmos';
 import { responseToWeb } from '~/Popup/utils/message';
@@ -166,16 +166,25 @@ export default function Entry({ queue, chain }: EntryProps) {
 
   const initialGasRate = useMemo(() => (equal(inputGas, '0') ? '0' : divide(inputFeeAmount, inputGas)), [inputFeeAmount, inputGas]);
 
-  const currentFeeGasRate = useMemo(
-    () =>
-      currentFeeCoin.gasRate ||
-      gasRate || {
+  const currentFeeGasRate = useMemo(() => {
+    if (currentFeeCoin.gasRate) {
+      return currentFeeCoin.gasRate;
+    }
+
+    if (gasRate) {
+      return gasRate;
+    }
+
+    if (gt(initialGasRate, '0')) {
+      return {
         average: initialGasRate,
         low: initialGasRate,
         tiny: initialGasRate,
-      },
-    [currentFeeCoin.gasRate, gasRate, initialGasRate],
-  );
+      };
+    }
+
+    return chain.gasRate;
+  }, [chain.gasRate, currentFeeCoin.gasRate, gasRate, initialGasRate]);
 
   const isFeeCustomed = useMemo(() => !!customGas || !!customGasRateKey, [customGasRateKey, customGas]);
 

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -57,8 +57,8 @@ export default function Entry({ queue, chain }: EntryProps) {
   const balance = useBalanceSWR(chain);
 
   const selectableFeeCoins = useMemo<FeeCoin[]>(
-    () => [
-      ...assets.data.map((asset) => ({
+    () =>
+      assets.data.map((asset) => ({
         originBaseDenom: asset.origin_denom,
         baseDenom: asset.denom,
         decimals: asset.decimals,
@@ -66,7 +66,6 @@ export default function Entry({ queue, chain }: EntryProps) {
         coinGeckoId: asset.coinGeckoId,
         availableAmount: balance.data?.balance?.find((item) => item.denom === asset.denom)?.amount || '0',
       })),
-    ],
     [assets.data, balance.data?.balance],
   );
 


### PR DESCRIPTION
- tx의 fee amount필드의 denom을 통해 fee 코인 변수를 선언할 때 체인리스트의 fee코인 내에서 선택되는게 아닌 tx의 fee.amount필드의 값이 선택되도록 수정했습니다.
  - tx의 fee denom이 체인 리스트의 fee코인 리스트에 포함되지 않았을때 생기는 오류를 해결했습니다.
    - raw tx의 fee코인과 UI상에서의 fee코인이 다른 문제 
- 사인 페이지에서 fee코인을 변경할 때 decimals가 변경되지 않는 오류를 수정했습니다.