### PR TITLE
[APIS-340] Add comparison of Tx 'value' and estimated fee to balance in EVM sign page

### DIFF
--- a/src/Popup/utils/string.ts
+++ b/src/Popup/utils/string.ts
@@ -68,3 +68,9 @@ export function hexToDecimal(hex?: string) {
 
   return BigInt(hex).toString(10);
 }
+
+export function hexOrDecimalToDecimal(datum?: number | string) {
+  const hexValue = toHex(datum, { addPrefix: true, isStringNumber: true });
+
+  return hexToDecimal(hexValue);
+}


### PR DESCRIPTION
- tx의 타입이 `simpleSend`가 아닌 경우에도 tx의 value값이 fee 지불 가능성 체크 로직에 합산될 수 있도록 로직을 수정했습니다.
  - 인앱 Squid EVM 스왑 시 실제 사용되는 코인의 수량(cross chain fee)을 확인할 수 있게 되었습니다.
- 변수명을 가독성이 있도록 수정했습니다.
  -  displayValue -> displayFeeValue
  - totalDisplayAmount -> totalPayableNativeCoinDisplayAmount
  - totalBaseAmount -> totalPayableNativeCoinBaseAmount