### PR TITLE
[APIS-350] firefox 권한 요청 로직 추가

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -45,6 +45,7 @@
     }
   ],
   "permissions": ["storage", "unlimitedStorage", "clipboardWrite", "activeTab", "webRequest"],
+  "optional_permissions": ["clipboardWrite", "activeTab", "webRequest"],
   "host_permissions": ["<all_urls>"],
   "web_accessible_resources": [
     {

--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -318,6 +318,7 @@
           "entry": {
             "description1": "Gateway to the Interchain &",
             "description2": "Ethereum ecosystem",
+            "permissionError": "Permission request denied. Please allow permissions to use the wallet.",
             "startButton": "Start",
             "termsAgreement1": "I have read and agree to the ",
             "termsAgreement2": "Terms of use",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -318,7 +318,7 @@
           "entry": {
             "description1": "코스모스 & 이더리움 생태계를 위한",
             "description2": "암호화폐 지갑입니다",
-            "permissionError": "권한 요청이 거부되었습니다.",
+            "permissionError": "권한 요청이 거부되었습니다. 지갑을 사용하려면 권한을 허용해주세요.",
             "startButton": "시작하기",
             "termsAgreement1": "서비스 이용약관 및 이용안내",
             "termsAgreement2": "에 동의합니다",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -318,6 +318,7 @@
           "entry": {
             "description1": "코스모스 & 이더리움 생태계를 위한",
             "description2": "암호화폐 지갑입니다",
+            "permissionError": "권한 요청이 거부되었습니다.",
             "startButton": "시작하기",
             "termsAgreement1": "서비스 이용약관 및 이용안내",
             "termsAgreement2": "에 동의합니다",


### PR DESCRIPTION
firefox manifest v3 부터는 설치시에 webRequest 권한이 풀리지 않음

설치 시에 권한을 풀기 위한 로직 추가

* 나중에 해당 페이지를 따로 빼야할 것 같음 지금은 임시 조치
