### PR TITLE
[APIS-354] Update color variable in InformContainer component

### DIFF
--- a/src/Popup/components/common/InformContainer/styled.tsx
+++ b/src/Popup/components/common/InformContainer/styled.tsx
@@ -20,7 +20,7 @@ type TextContainerProps = {
 
 export const TextContainer = styled('div')<TextContainerProps>(({ theme, ...props }) => ({
   marginLeft: '0.4rem',
-  color: props['data-varient'] === 'info' ? theme.accentColors.white : theme.accentColors.red,
+  color: props['data-varient'] === 'info' ? theme.colors.text01 : theme.accentColors.red,
 }));
 
 type IconContainerProps = {


### PR DESCRIPTION
다이렉트 사인 페이지의 Inform 컴포넌트의 폰트 색상을 수정했습니다.
- theme이 브라이트 일때도 폰트 색상이 하얀색으로 고정되어 가독성이 떨어지는 문제를 해결했습니다.
![스크린샷 2024-06-25 오후 7 35 24](https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/d91f112c-5d0e-4974-88c2-7640fa695959)
![스크린샷 2024-06-25 오후 7 34 34](https://github.com/cosmostation/cosmostation-chrome-extension/assets/87967564/b87d77ec-6c4a-451c-95d7-f74efee7c4a0)
