### PR TITLE
[APIS-355] Fix Referencing 'currentFeeCoing.gasRate' in cosmos sign page

### DIFF
--- a/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Amino/entry.tsx
@@ -68,13 +68,14 @@ export default function Entry({ queue, chain }: EntryProps) {
   const { feeCoins: supportedFeeCoins, defaultGasRateKey } = useCurrentFeesSWR(chain, { suspense: true });
 
   const availableFeeCoins = useMemo(() => {
-    const availableCoins = assets.data.map((asset) => ({
+    const availableCoins: FeeCoin[] = assets.data.map((asset) => ({
       originBaseDenom: asset.origin_denom,
       baseDenom: asset.denom,
       decimals: asset.decimals,
       displayDenom: asset.symbol,
       coinGeckoId: asset.coinGeckoId,
       availableAmount: balance.data?.balance?.find((item) => item.denom === asset.denom)?.amount || '0',
+      gasRate: undefined,
     }));
 
     const aggregatedFeeCoins = [...supportedFeeCoins, ...availableCoins];
@@ -130,6 +131,7 @@ export default function Entry({ queue, chain }: EntryProps) {
         baseDenom: inputFee.denom,
         originBaseDenom: inputFee.denom,
         displayDenom: 'UNKNOWN',
+        gasRate: undefined,
       },
     [availableFeeCoins, balance.data?.balance, currentFeeBaseDenom, inputFee.denom],
   );

--- a/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
+++ b/src/Popup/pages/Popup/Cosmos/Sign/Direct/entry.tsx
@@ -59,13 +59,14 @@ export default function Entry({ queue, chain }: EntryProps) {
   const { feeCoins: supportedFeeCoins, defaultGasRateKey } = useCurrentFeesSWR(chain, { suspense: true });
 
   const availableFeeCoins = useMemo(() => {
-    const availableCoins = assets.data.map((asset) => ({
+    const availableCoins: FeeCoin[] = assets.data.map((asset) => ({
       originBaseDenom: asset.origin_denom,
       baseDenom: asset.denom,
       decimals: asset.decimals,
       displayDenom: asset.symbol,
       coinGeckoId: asset.coinGeckoId,
       availableAmount: balance.data?.balance?.find((item) => item.denom === asset.denom)?.amount || '0',
+      gasRate: undefined,
     }));
 
     const aggregatedFeeCoins = [...supportedFeeCoins, ...availableCoins];
@@ -134,6 +135,7 @@ export default function Entry({ queue, chain }: EntryProps) {
         baseDenom: inputFee.denom || '',
         originBaseDenom: inputFee.denom || '',
         displayDenom: 'UNKNOWN',
+        gasRate: undefined,
       },
     [availableFeeCoins, balance.data?.balance, currentFeeBaseDenom, inputFee.denom],
   );


### PR DESCRIPTION
Cosmos 서명 페이지에서 currentFeeCoin.gasRate를 참조할 때, currentFeeCoin 객체에 `gasRate` 속성이 없어서 발생하는 오류를 해결했습니다.

- 선택 가능한 fee 코인을 리스팅할 때 각 아이템이 'gasRate'속성을 가지도록 수정했습니다.
- tx의 fee코인이 선택 가능한 fee 코인 리스트에 없을때 currentFeeCoin에 할당되는 값에  `gasRate`속성을 추가했습니다.