### PR TITLE
[APIS-381] Fix fill color for FeeButton in Ethereum transaction page

### DIFF
--- a/src/Popup/pages/Popup/Ethereum/Transaction/styled.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/styled.tsx
@@ -110,9 +110,9 @@ export const FeeButton = styled('button')<FeeButtonProps>(({ theme, ...props }) 
   color: props['data-is-active'] ? theme.accentColors.white : theme.colors.text02,
 
   '& > svg': {
-    fill: props['data-is-active'] ? theme.colors.text01 : theme.colors.text02,
+    fill: props['data-is-active'] ? theme.accentColors.white : theme.colors.text02,
     '& > path': {
-      fill: props['data-is-active'] ? theme.colors.text01 : theme.colors.text02,
+      fill: props['data-is-active'] ? theme.accentColors.white : theme.colors.text02,
     },
   },
 


### PR DESCRIPTION
이더리움 사인 페이지의 dapp fee icon의 색상을 수정했습니다.

- light 모드에서 아이콘의 색상이 흰색으로 표시되도록 수정합니다.