### PR TITLE
[APIS-389] Update Image component to handle null src value

### DIFF
--- a/src/Popup/components/common/Image/index.tsx
+++ b/src/Popup/components/common/Image/index.tsx
@@ -1,17 +1,19 @@
 import unknownImg from '~/images/symbols/unknown.png';
 
 type ImageProps = {
-  src?: string;
+  src?: string | null;
   defaultImgSrc?: string;
   alt?: string;
   className?: string;
 };
 
 export default function Image({ src = 'https://', defaultImgSrc = unknownImg, alt, className }: ImageProps) {
+  const validSrc = src || 'https://';
+
   return (
     <img
       className={className}
-      src={src}
+      src={validSrc}
       alt={alt}
       onError={(event) => {
         // eslint-disable-next-line no-param-reassign

--- a/src/Popup/pages/Wallet/Swap/components/SwapCoinContainer/index.tsx
+++ b/src/Popup/pages/Wallet/Swap/components/SwapCoinContainer/index.tsx
@@ -80,7 +80,7 @@ export default function SwapCoinContainer({ isChainAvailable = true, ...remainde
               isActive={isOpenedChainList}
               leftProps={
                 <ContentLeftContainer>
-                  {remainder.currentSelectedChain?.imageURL && remainder.currentSelectedChain?.networkName ? (
+                  {remainder.currentSelectedChain ? (
                     <>
                       <ContentLeftChainImageContainer>
                         <ContentLeftAbsoluteChainImageContainer>
@@ -107,7 +107,7 @@ export default function SwapCoinContainer({ isChainAvailable = true, ...remainde
               isActive={isOpenedCoinList}
               leftProps={
                 <ContentLeftContainer>
-                  {remainder.currentSelectedCoin?.imageURL && remainder.currentSelectedCoin?.displayDenom ? (
+                  {remainder.currentSelectedCoin ? (
                     <>
                       <ContentLeftImageContainer>
                         <ContentLeftAbsoluteImageContainer>


### PR DESCRIPTION
Image 컴포넌트의 null값이 src로 전달되었을때 에러를 발생시키지 않아 디폴트 이미지를 노출시키지 않는 오류를 해결했습니다.

- 스왑 페이지의 애셋 선택 버튼 활성화 로직을 변경했습니다
  - 이미지, 이름이 없더라도 애셋 객체가 있다면 선택된 에셋을 렌더링합니다.