### PR TITLE
[APIS-391] Remove front API support check in swap chain filtering

### DIFF
--- a/src/Popup/pages/Wallet/Swap/entry.tsx
+++ b/src/Popup/pages/Wallet/Swap/entry.tsx
@@ -22,7 +22,6 @@ import { useAssetsSWR as useCosmosAssetsSWR } from '~/Popup/hooks/SWR/cosmos/use
 import { useBalanceSWR } from '~/Popup/hooks/SWR/cosmos/useBalanceSWR';
 import { useCurrentFeesSWR } from '~/Popup/hooks/SWR/cosmos/useCurrentFeesSWR';
 import { useGasRateSWR } from '~/Popup/hooks/SWR/cosmos/useGasRateSWR';
-import { useSupportChainsSWR } from '~/Popup/hooks/SWR/cosmos/useSupportChainsSWR';
 import { useBalanceSWR as useNativeBalanceSWR } from '~/Popup/hooks/SWR/ethereum/useBalanceSWR';
 import { useTokenBalanceSWR } from '~/Popup/hooks/SWR/ethereum/useTokenBalanceSWR';
 import { useTokensSWR } from '~/Popup/hooks/SWR/ethereum/useTokensSWR';
@@ -116,7 +115,6 @@ export default function Entry() {
   const supportedSwapChains = useSupportSwapChainsSWR({ suspense: true });
 
   const skipSupportedChains = useSkipSupportChainsSWR({ suspense: true });
-  const supportedCosmosChain = useSupportChainsSWR({ suspense: true });
 
   const { squidChains, filterSquidTokens } = useSquidAssetsSWR();
 
@@ -170,19 +168,14 @@ export default function Entry() {
 
   const squidCosmosChains = useMemo(
     () =>
-      COSMOS_CHAINS.filter((item) =>
-        squidChains?.find(
-          (squidChain) =>
-            squidChain.chainType === 'cosmos' &&
-            item.chainId === squidChain.chainId &&
-            supportedCosmosChain.data?.chains.find((cosmosChain) => cosmosChain.chain_id === squidChain.chainId),
-        ),
-      ).map((item) => ({
-        ...item,
-        baseChainUUID: item.id,
-        networkName: item.chainName,
-      })),
-    [squidChains, supportedCosmosChain.data?.chains],
+      COSMOS_CHAINS.filter((item) => squidChains?.find((squidChain) => squidChain.chainType === 'cosmos' && item.chainId === squidChain.chainId)).map(
+        (item) => ({
+          ...item,
+          baseChainUUID: item.id,
+          networkName: item.chainName,
+        }),
+      ),
+    [squidChains],
   );
 
   const skipSwapChains = useMemo(


### PR DESCRIPTION
스왑 가능 체인을 필터링할 때 불필요하게 front api 지원 여부를 필터링하지 않도록 로직을 수정했습니다.