### PR TITLE
[APIS-412] Update REST URLs for CANTO chain in Cosmos and Ethereum networks

### DIFF
--- a/src/constants/chain/cosmos/canto.ts
+++ b/src/constants/chain/cosmos/canto.ts
@@ -8,7 +8,7 @@ export const CANTO: CosmosChain = {
   type: 'ETHERMINT',
   chainId: 'canto_7700-1',
   chainName: 'CANTO',
-  restURL: 'https://lcd-canto.cosmostation.io',
+  restURL: 'https://canto-api.polkachu.com',
   tokenImageURL: cantoTokenImg,
   imageURL: cantoChainImg,
   baseDenom: 'acanto',

--- a/src/constants/chain/ethereum/network/canto.ts
+++ b/src/constants/chain/ethereum/network/canto.ts
@@ -5,7 +5,7 @@ export const CANTO: EthereumNetwork = {
   id: 'd25243d2-cf65-4768-bbc0-ec439683568d',
   chainId: '0x1e14',
   networkName: COSMOS_CANTO.chainName,
-  rpcURL: 'https://rpc-canto-evm.cosmostation.io',
+  rpcURL: 'https://canto.slingshot.finance',
   tokenImageURL: COSMOS_CANTO.tokenImageURL,
   imageURL: COSMOS_CANTO.imageURL,
   displayDenom: COSMOS_CANTO.displayDenom,


### PR DESCRIPTION
칸토 체인의 lcd. evm rpc url을 변경했습니다.