### PR TITLE
[APIS-424] Avoid making meaningless one-inch api call 

### DIFF
--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -237,7 +237,11 @@ export default function Entry({ queue }: EntryProps) {
     currentEthereumNetwork.chainId,
   ]);
 
-  const oneInchTokens = useOneInchTokensSWR(queue.channel === 'inApp' ? String(parseInt(currentEthereumNetwork.chainId, 16)) : '');
+  const oneInchTokens = useOneInchTokensSWR(
+    queue.channel === 'inApp' && isEqualsIgnoringCase(originEthereumTx.to, ONEINCH_CONTRACT_ADDRESS)
+      ? String(parseInt(currentEthereumNetwork.chainId, 16))
+      : '',
+  );
 
   const oneInchSwapDstToken = useMemo(() => {
     if (txType.data?.type === 'swap' && oneInchTokens.data && isEqualsIgnoringCase(originEthereumTx.to, ONEINCH_CONTRACT_ADDRESS)) {

--- a/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
+++ b/src/Popup/pages/Popup/Ethereum/Transaction/entry.tsx
@@ -244,12 +244,12 @@ export default function Entry({ queue }: EntryProps) {
   );
 
   const oneInchSwapDstToken = useMemo(() => {
-    if (txType.data?.type === 'swap' && oneInchTokens.data && isEqualsIgnoringCase(originEthereumTx.to, ONEINCH_CONTRACT_ADDRESS)) {
+    if (txType.data?.type === 'swap' && oneInchTokens.data) {
       const oneInchSwapTxData = txType.data.txDescription?.args as unknown as OneInchSwapTxData;
       return oneInchTokens.data.find((item) => isEqualsIgnoringCase(item.address, oneInchSwapTxData.desc.dstToken));
     }
     return undefined;
-  }, [oneInchTokens.data, originEthereumTx.to, txType.data?.txDescription?.args, txType.data?.type]);
+  }, [oneInchTokens.data, txType.data?.txDescription?.args, txType.data?.type]);
 
   const baseFee = useMemo(() => {
     if (ethereumTx.maxFeePerGas) {


### PR DESCRIPTION
EVM 체인 사인 페이지에서 1인치 스왑 tx가 아닌 경우에도 1인치 api를 호출하는 로직을 수정했습니다.

- tx의 `to` 값이 1인치 컨트랙트 주소일 경우에만 1인치 api를 호출하도록 수정했습니다.