### PR TITLE
[APIS-432] Update liquidity warning messages in Swap page

### DIFF
--- a/src/Popup/i18n/en/translation.json
+++ b/src/Popup/i18n/en/translation.json
@@ -1626,7 +1626,7 @@
           "invalidSwapTx": "Invalid tx data",
           "lessThanFeeWarningDescription1": "You do not have enough balance to cover the estimated gas costs for this transaction. Make sure you have more than",
           "lessThanFeeWarningDescription2": "before trying again.",
-          "liquidityWarning": "The size of this trade is large compared to the available liquidity. Reduce the swap amount to get a better price.",
+          "liquidityWarning": "There will be a large difference between your input and output values due to current liquidity.",
           "minimumReceived": "Minimum received after slippage",
           "minutes": "minutes",
           "multiTxSwap": "Swap with multiple transactions is unavailable",

--- a/src/Popup/i18n/ko/translation.json
+++ b/src/Popup/i18n/ko/translation.json
@@ -1626,7 +1626,7 @@
           "invalidSwapTx": "Invalid tx data",
           "lessThanFeeWarningDescription1": "예상 가스비를 위한 잔액이 부족합니다. 잔액이",
           "lessThanFeeWarningDescription2": "이상인지 확인하세요.",
-          "liquidityWarning": "해당 스왑을 진행하기에 풀 유동성이 부족합니다. 스왑 금액을 낮추고 다시 시도하세요.",
+          "liquidityWarning": "유동성이 부족하여 보다 적은 수량의 토큰을 수령하게 됩니다.",
           "minimumReceived": "슬리피지 이후 받을 최소 수량",
           "minutes": "분",
           "multiTxSwap": "2개 이상의 트랜잭션이 포함된 스왑은 현재 이용할 수 없습니다.",


### PR DESCRIPTION
스왑 시뮬레이션에서 price impact가 3% 이상일때 노출되는 문구를 수정했습니다.
- 기존 문구가 스왑 수량이 너무 커서 발생하는 유동성 문제에만 한정되어 있었던 점을 보완하여, 스왑 수량에 따른 다양한 유동성 문제를 포괄할 수 있도록 문구를 수정했습니다.
