### PR TITLE
[APIS-445] Update RIZON restURL to use new API endpoint

### DIFF
--- a/src/constants/chain/cosmos/rizon.ts
+++ b/src/constants/chain/cosmos/rizon.ts
@@ -9,7 +9,7 @@ export const RIZON: CosmosChain = {
   type: '',
   chainId: 'titan-1',
   chainName: 'RIZON',
-  restURL: 'https://lcd-rizon.cosmostation.io',
+  restURL: 'https://api.rizon.chaintools.tech',
   tokenImageURL: rizonTokenImg,
   imageURL: rizonChainImg,
   baseDenom: 'uatolo',


### PR DESCRIPTION
Rizon체인의 lcd url을 변경했습니다.