### PR TITLE
chore: Update shentu chain bank send msgs type to 'cosmos-sdk/MsgSend'

### DIFF
--- a/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
+++ b/src/Popup/pages/Wallet/Send/Entry/Cosmos/components/Send/index.tsx
@@ -268,7 +268,7 @@ export default function Send({ chain }: CosmosProps) {
           memo: currentMemo,
           msgs: [
             {
-              type: chain.chainName === SHENTU.chainName ? 'bank/MsgSend' : 'cosmos-sdk/MsgSend',
+              type: 'cosmos-sdk/MsgSend',
               value: {
                 from_address: address,
                 to_address: currentDepositAddress,


### PR DESCRIPTION
In version v2.12.0, the Shentu chain upgraded to Cosmos-SDK v0.50.8:

During this upgrade, the message type for bank send transactions changed from **bank/MsgSend** to **cosmos-sdk/MsgSend**, which is no longer compatible with the previous format.

Currently, using **bank/MsgSend** to send transactions will fail.

Support from Cosmostation is required to accommodate this change.