### PR TITLE
[APIS-549] Change signet coin type

### DIFF
--- a/src/constants/chain/bitcoin/signet.ts
+++ b/src/constants/chain/bitcoin/signet.ts
@@ -12,7 +12,7 @@ export const SIGNET: BitcoinChain = {
   imageURL: signetChainImg,
   bip44: {
     purpose: "84'",
-    coinType: "0'",
+    coinType: "1'",
     account: "0'",
     change: '0',
   },


### PR DESCRIPTION
비트코인 시그넷 체인의 hd path를 수정했습니다.
 - 코인 타입: 0 -> 1