### PR TITLE
[APIS-564] Fix getCoinType

### DIFF
--- a/src/Popup/utils/sui.ts
+++ b/src/Popup/utils/sui.ts
@@ -24,7 +24,7 @@ export function getCoinType(type?: string | null) {
   }
 
   const startIndex = type.indexOf('<');
-  const endIndex = type.indexOf('>');
+  const endIndex = type.lastIndexOf('>');
 
   if (startIndex > -1 && endIndex > -1) {
     return type.substring(startIndex + 1, endIndex);


### PR DESCRIPTION
수이 코인 오브젝트중 꺽쇠가 중첩되는 경우 코인 타입을 계산에 오류가 있어 이를 수정했습니다.