### PR TITLE
[APIS-571] Enable cosmWasm support for Injective chain

### DIFF
--- a/src/constants/chain/cosmos/injective.ts
+++ b/src/constants/chain/cosmos/injective.ts
@@ -30,4 +30,5 @@ export const INJECTIVE: CosmosChain = {
     average: '600000000',
   },
   gas: { send: '150000' },
+  cosmWasm: true,
 };


### PR DESCRIPTION
인젝티브 체인의 타입을 cosmwasm으로 변경합니다.