### PR TITLE
[APIS-607] Fix hide coins priced under $1 based on updated logic

### DIFF
--- a/src/hooks/useCoinGeckoPrice.ts
+++ b/src/hooks/useCoinGeckoPrice.ts
@@ -4,13 +4,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { MINTSCAN_FRONT_API_V10_URL } from '@/constants/common';
 import type { CoinGeckoPriceResponse, SimplePrice } from '@/types/coinGecko';
+import type { CurrencyType } from '@/types/currency';
 import { get } from '@/utils/axios';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
-export function useCoinGeckoPrice(config?: UseQueryOptions<CoinGeckoPriceResponse>) {
+export function useCoinGeckoPrice(currency?: CurrencyType, config?: UseQueryOptions<CoinGeckoPriceResponse>) {
   const { userCurrencyPreference } = useExtensionStorageStore((state) => state);
 
-  const requestURL = `${MINTSCAN_FRONT_API_V10_URL}/utils/market/prices?currency=${userCurrencyPreference}`;
+  const selectedCurrency = currency || userCurrencyPreference;
+  const requestURL = `${MINTSCAN_FRONT_API_V10_URL}/utils/market/prices?currency=${selectedCurrency}`;
 
   const fetcher = () => get<CoinGeckoPriceResponse>(requestURL);
   const { data, isLoading, error, refetch } = useQuery({
@@ -28,13 +30,13 @@ export function useCoinGeckoPrice(config?: UseQueryOptions<CoinGeckoPriceRespons
     () =>
       data?.reduce((acc: SimplePrice, item) => {
         acc[item.coinGeckoId] = {
-          [`${userCurrencyPreference}`]: item.current_price,
-          [`${userCurrencyPreference}_24h_change`]: item.daily_price_change_in_percent,
-          [`${userCurrencyPreference}_market_cap`]: item.market_cap,
+          [`${selectedCurrency}`]: item.current_price,
+          [`${selectedCurrency}_24h_change`]: item.daily_price_change_in_percent,
+          [`${selectedCurrency}_market_cap`]: item.market_cap,
         };
         return acc;
       }, {}) || undefined,
-    [userCurrencyPreference, data],
+    [selectedCurrency, data],
   );
 
   return { data: returnData, error, refetch, isLoading };

--- a/src/pages/-entry.tsx
+++ b/src/pages/-entry.tsx
@@ -59,6 +59,8 @@ export default function Entry() {
   const { isLoading: isUpdateBalnaceLoading } = useUpdateBalance();
 
   const { data: coinGeckoPrice } = useCoinGeckoPrice();
+  const { data: usdCoinGeckoPrice } = useCoinGeckoPrice('usd');
+
   const { dashboardCoinSortKey, userCurrencyPreference, isHideSmalValue, updateExtensionStorageStore } = useExtensionStorageStore((state) => state);
   useCurrentAccountAddedNFTsWithMetaData();
   const [search, setSearch] = useState('');
@@ -104,7 +106,7 @@ export default function Entry() {
       const displayAmount = item.totalDisplayAmount || '0';
 
       const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-      const coinPriceInDolalr = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[CURRENCY_TYPE.USD]) || 0;
+      const coinPriceInDolalr = (item.asset.coinGeckoId && usdCoinGeckoPrice?.[item.asset.coinGeckoId]?.[CURRENCY_TYPE.USD]) || 0;
 
       const value = times(displayAmount, coinPrice);
       const valueInDollar = times(displayAmount, coinPriceInDolalr);
@@ -116,14 +118,15 @@ export default function Entry() {
       };
     });
   }, [
+    groupAccountAssets?.groupAccountAssets,
+    groupAccountAssets?.singleAccountAssets,
+    groupAccountAssets?.groupMap,
+    search,
+    debouncedSearch.length,
+    currentSelectedChainId,
     coinGeckoPrice,
     userCurrencyPreference,
-    currentSelectedChainId,
-    debouncedSearch.length,
-    groupAccountAssets?.groupAccountAssets,
-    groupAccountAssets?.groupMap,
-    groupAccountAssets?.singleAccountAssets,
-    search,
+    usdCoinGeckoPrice,
   ]);
 
   const hideSmallValueAssets = useMemo(() => {


### PR DESCRIPTION
달러 이외의 다른 통화량을 선택했을때 소액 자산 숨기기 기능이 정상동작하지 않던 문제를 수정했습니다.