### PR TITLE
[APIS-641] Throttle dupe balance / staking request

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -16,5 +16,6 @@ export const MOONPAY_API_URL = 'https://buy.moonpay.com';
 
 export const MOONPAY_API_KEY = 'pk_live_zbG1BOGMVTcfKibboIE2K3vduJBTuuCn';
 
-export const BALANCE_FETCH_TIME_OUT_MS = 1000 * 2;
+export const BALANCE_FETCH_TIME_OUT_MS = 1000 * 15;
+export const STAKING_FETCH_TIME_OUT_MS = 1000 * 15;
 export const DEFAULT_FETCH_TIME_OUT_MS = 1000 * 1;

--- a/src/constants/updateRequest.ts
+++ b/src/constants/updateRequest.ts
@@ -1,0 +1,5 @@
+export const RATE_LIMIT_MS = {
+  updateBalance: 3 * 60 * 1000,
+  updateStaking: 3 * 60 * 1000,
+  updateAccountInfo: 3 * 60 * 1000,
+} as const;

--- a/src/hooks/useCurrentAccount.ts
+++ b/src/hooks/useCurrentAccount.ts
@@ -11,6 +11,7 @@ import { removeAccountName, removeAccountNames } from '@/utils/zustand/accountNa
 import { removeAccountFromNotBackedupList, removeAccountFromNotBackedupLists } from '@/utils/zustand/backupAccount';
 import { removeInitAccountId, removeInitAccountIds } from '@/utils/zustand/initAccountIds';
 import { removeInitCheckLegacyBalanceAccountId, removeInitCheckLegacyBalanceAccountIds } from '@/utils/zustand/initCheckLegacyBalanceAccountId';
+import { removeAccountLastRequestTimestamps } from '@/utils/zustand/lastRequestTimestamps';
 import { removePreferAccountType, removePreferAccountTypes } from '@/utils/zustand/preferAccountType';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -76,6 +77,7 @@ export function useCurrentAccount() {
     await removePreferAccountType(id);
     await removeInitAccountId(id);
     await removeInitCheckLegacyBalanceAccountId(id);
+    await removeAccountLastRequestTimestamps([id]);
 
     if (encryptedRestoreString && !newAccounts.some((account) => account.type === 'MNEMONIC' && account.encryptedRestoreString === encryptedRestoreString)) {
       await removeMnemonicName(encryptedRestoreString);

--- a/src/script/service-worker/index.ts
+++ b/src/script/service-worker/index.ts
@@ -5,6 +5,7 @@ import type { ServiceWorkerMessage } from '@/types/message/service-worker';
 import { extension } from '@/utils/browser';
 import { devLogger } from '@/utils/devLogger';
 import { getExtensionLocalStorage, setExtensionLocalStorage } from '@/utils/storage';
+import { isRequestThrottled, recordRequestTimestamp } from '@/utils/updateRequest';
 import { openTab } from '@/utils/view/controlView';
 import { closeWindow } from '@/utils/view/window';
 
@@ -40,8 +41,20 @@ chrome.runtime.onMessage.addListener((message: ServiceWorkerMessage, sender, sen
     if (sender?.id === chrome.runtime.id && message?.target === 'SERVICE_WORKER') {
       if (message.method === 'updateBalance') {
         const [id] = message.params;
-        await updateActiveAssetsBalance(id);
-        await updateCustomBalance(id);
+
+        if (await isRequestThrottled('updateBalance', id)) {
+          devLogger.log(`[updateBalance] Throttled for id=${id}`);
+          sendResponse(null);
+          return;
+        }
+
+        try {
+          await updateActiveAssetsBalance(id);
+          await updateCustomBalance(id);
+          await recordRequestTimestamp('updateBalance', id);
+        } catch (e) {
+          devLogger.error('updateBalance error', e);
+        }
 
         sendResponse(null);
       }
@@ -54,13 +67,39 @@ chrome.runtime.onMessage.addListener((message: ServiceWorkerMessage, sender, sen
 
       if (message.method === 'updateStaking') {
         const [id] = message.params;
-        await updateStakingRelatedBalance(id);
+
+        if (await isRequestThrottled('updateStaking', id)) {
+          devLogger.log(`[updateStaking] Throttled for id=${id}`);
+          sendResponse(null);
+          return;
+        }
+
+        try {
+          await updateStakingRelatedBalance(id);
+          await recordRequestTimestamp('updateStaking', id);
+        } catch (e) {
+          devLogger.error('updateStaking error', e);
+        }
+
         sendResponse(null);
       }
 
       if (message.method === 'updateAccountInfo') {
         const [id] = message.params;
-        await updateAccountInfo(id);
+
+        if (await isRequestThrottled('updateAccountInfo', id)) {
+          devLogger.log(`[updateAccountInfo] Throttled for id=${id}`);
+          sendResponse(null);
+          return;
+        }
+
+        try {
+          await updateAccountInfo(id);
+          await recordRequestTimestamp('updateAccountInfo', id);
+        } catch (e) {
+          devLogger.error('updateAccountInfo error', e);
+        }
+
         sendResponse(null);
       }
 

--- a/src/script/service-worker/update/balance.ts
+++ b/src/script/service-worker/update/balance.ts
@@ -325,7 +325,7 @@ async function cosmosBalances(id: string, { isMinimal = false, address, chainId 
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -410,7 +410,7 @@ async function customCosmosBalances(id: string, { address, chainId }: BalanceFet
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -461,7 +461,7 @@ async function evmBalances(id: string, { isMinimal = false, address, chainId }: 
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -513,7 +513,7 @@ async function customEvmBalances(id: string, { address, chainId }: BalanceFetchO
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -563,7 +563,7 @@ async function bitcoinBalances(id: string, { address, chainId }: BalanceFetchOpt
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -631,7 +631,7 @@ async function aptosBalances(id: string, { address, chainId }: BalanceFetchOptio
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -695,7 +695,7 @@ async function suiBalances(id: string, { address, chainId }: BalanceFetchOption 
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -745,7 +745,7 @@ async function iotaBalances(id: string, { address, chainId }: BalanceFetchOption
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -837,7 +837,7 @@ async function erc20Balance(id: string, { address, chainId }: BalanceFetchOption
           return result;
         }
       } else {
-        const { results: allBalances } = await PromisePool.withConcurrency(10)
+        const { results: allBalances } = await PromisePool.withConcurrency(5)
           .for(assets)
           .process(async (asset) => {
             const { id: contractAddress } = asset;
@@ -927,7 +927,7 @@ async function customErc20Balance(id: string, { address, chainId }: BalanceFetch
           return result;
         }
       } else {
-        const { results: allBalances } = await PromisePool.withConcurrency(10)
+        const { results: allBalances } = await PromisePool.withConcurrency(5)
           .for(assets)
           .process(async (asset) => {
             const { id: contractAddress } = asset;
@@ -1002,7 +1002,7 @@ async function cw20Balance(id: string, { address, chainId }: BalanceFetchOption 
       const { lcdUrls } = chain;
       const assets = cw20AssetsWithoutHidden.filter((asset) => asset.chainType === addr.chainType && asset.chainId === addr.chainId && asset.type === 'cw20');
 
-      const { results: allBalances } = await PromisePool.withConcurrency(10)
+      const { results: allBalances } = await PromisePool.withConcurrency(5)
         .for(assets)
         .process(async (asset) => {
           const { id: contractAddress } = asset;
@@ -1070,7 +1070,7 @@ async function customCw20Balance(id: string, { address, chainId }: BalanceFetchO
       const { lcdUrls } = chain;
       const assets = customCw20Assets.filter((asset) => asset.chainType === addr.chainType && asset.chainId === addr.chainId && asset.type === 'cw20');
 
-      const { results: allBalances } = await PromisePool.withConcurrency(10)
+      const { results: allBalances } = await PromisePool.withConcurrency(5)
         .for(assets)
         .process(async (asset) => {
           const { id: contractAddress } = asset;

--- a/src/script/service-worker/update/staking.ts
+++ b/src/script/service-worker/update/staking.ts
@@ -119,7 +119,7 @@ async function cosmosDelegations(id: string, { address, chainId }: BalanceFetchO
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -168,7 +168,7 @@ async function cosmosUnbondings(id: string, { address, chainId }: BalanceFetchOp
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -219,7 +219,7 @@ async function cosmosRewards(id: string, { address, chainId }: BalanceFetchOptio
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -307,7 +307,7 @@ async function cosmosCommissions(id: string, { address, chainId }: BalanceFetchO
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -375,7 +375,7 @@ async function suiStaking(id: string, { address, chainId }: BalanceFetchOption =
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;
@@ -421,7 +421,7 @@ async function iotaStaking(id: string, { address, chainId }: BalanceFetchOption 
     })
     .filter((addr) => addr.chain);
 
-  const { results } = await PromisePool.withConcurrency(10)
+  const { results } = await PromisePool.withConcurrency(5)
     .for(addressWithChain)
     .process(async (addr) => {
       const { chainId, chainType, address, chain } = addr;

--- a/src/types/extension.ts
+++ b/src/types/extension.ts
@@ -1,5 +1,6 @@
 import type { PERMISSION as IOTA_PERMISSION } from '@/constants/iota';
 import type { PERMISSION } from '@/constants/sui';
+import type { RATE_LIMIT_MS } from '@/constants/updateRequest';
 
 import type {
   Account,
@@ -83,6 +84,11 @@ export type PrioritizedProvider = {
 
 export type MigrationStatus = Record<string, boolean>;
 
+type RateLimitedMethod = keyof typeof RATE_LIMIT_MS;
+export type LastRequestTimestampsKey = `${RateLimitedMethod}:${string}`;
+
+type LastRequestTimestamps = Record<LastRequestTimestampsKey, number>;
+
 export interface ExtensionStorage {
   userAccounts: Account[];
   paramsV11: Record<string, V11Param>;
@@ -154,6 +160,7 @@ export interface ExtensionStorage {
   autoLockTimeStampAt: number | null;
   migrationStatus: MigrationStatus | null;
   userPriceTrendPreference: PriceTrendType;
+  lastRequestTimestamps: LastRequestTimestamps | null;
 }
 
 export type ExtensionStorageKeys = keyof ExtensionStorage;

--- a/src/utils/cosmos/fetch/accountInfo.ts
+++ b/src/utils/cosmos/fetch/accountInfo.ts
@@ -11,7 +11,7 @@ export const fetchCosmosAccountInfo = async (address: string, lcdUrls: string[])
     const requestUrl = `${base}${urlPath}`;
 
     const response = await get<AuthAccountsPayload>(requestUrl, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: DEFAULT_FETCH_TIME_OUT_MS * 15,
     });
 
     return response;

--- a/src/utils/cosmos/fetch/staking.ts
+++ b/src/utils/cosmos/fetch/staking.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
+import { STAKING_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { CommissionResponse } from '@/types/cosmos/balance';
 import type { NTRNRewardsResponse } from '@/types/cosmos/contract';
 import type { DelegationPayload, KavaDelegationPayload, LcdDelegationResponse } from '@/types/cosmos/delegation';
@@ -22,7 +22,7 @@ export const fetchCosmosDelegations = async (address: string, lcdUrls: string[])
     const requestUrl = `${base}${urlPath}`;
 
     const response = await axios.get<DelegationPayload | KavaDelegationPayload>(requestUrl, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
       headers: {
         Cosmostation: `extension/${__APP_VERSION__}`,
       },
@@ -52,7 +52,7 @@ export const fetchCosmosDelegations = async (address: string, lcdUrls: string[])
         const paginatedRequestUrl = `${requestUrl}&pagination.key=${nextKey}`;
 
         const paginatedResponse = await axios.get<DelegationPayload | KavaDelegationPayload>(paginatedRequestUrl, {
-          timeout: DEFAULT_FETCH_TIME_OUT_MS,
+          timeout: STAKING_FETCH_TIME_OUT_MS,
           headers: {
             Cosmostation: `extension/${__APP_VERSION__}`,
           },
@@ -100,7 +100,7 @@ export const fetchCosmosUnbondings = async (address: string, lcdUrls: string[]):
     const requestUrl = `${base}${urlPath}`;
 
     const response = await axios.get<UnbondingPayload>(requestUrl, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
       headers: {
         Cosmostation: `extension/${__APP_VERSION__}`,
       },
@@ -125,7 +125,7 @@ export const fetchCosmosUnbondings = async (address: string, lcdUrls: string[]):
         const paginatedRequestUrl = `${requestUrl}&pagination.key=${nextKey}`;
 
         const paginatedResponse = await axios.get<UnbondingPayload>(paginatedRequestUrl, {
-          timeout: DEFAULT_FETCH_TIME_OUT_MS,
+          timeout: STAKING_FETCH_TIME_OUT_MS,
           headers: {
             Cosmostation: `extension/${__APP_VERSION__}`,
           },
@@ -166,7 +166,7 @@ export const fetchCosmosRewards = async (address: string, lcdUrls: string[]): Pr
     const requestUrl = `${base}${urlPath}`;
 
     const response = await axios.get<RewardPayload>(requestUrl, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
       headers: {
         Cosmostation: `extension/${__APP_VERSION__}`,
       },
@@ -209,7 +209,7 @@ export const fetchNTRNRewards = async (address: string, rewardContractAddress: s
     const requestUrl = `${base}${urlPath}`;
 
     const response = await axios.get<NTRNRewardsResponse>(requestUrl, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
       headers: {
         Cosmostation: `extension/${__APP_VERSION__}`,
       },
@@ -244,7 +244,7 @@ export const fetchCosmosCommission = async (validatorAddress: string, lcdUrls: s
     const requestUrl = `${base}${urlPath}`;
 
     const response = await axios.get<CommissionResponse>(requestUrl, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
       headers: {
         Cosmostation: `extension/${__APP_VERSION__}`,
       },

--- a/src/utils/iota/fetch/staking.ts
+++ b/src/utils/iota/fetch/staking.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import type { DelegatedStake as IotaDelegatedStake } from '@iota/iota-sdk/client';
 
-import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
+import { STAKING_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { IotaRpcGetDelegatedStakeResponse } from '@/types/iota/api';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
 import { removeTrailingSlash } from '@/utils/string';
@@ -18,7 +18,7 @@ export const fetchIotaDelegations = async (address: string, rpcUrls: string[]): 
     };
 
     const response = await axios.post<IotaRpcGetDelegatedStakeResponse>(requestUrl, body, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
     });
 
     if (response.data.error) {

--- a/src/utils/sui/fetch/balance.ts
+++ b/src/utils/sui/fetch/balance.ts
@@ -17,7 +17,7 @@ export const fetchSuiBalances = async (address: string, rpcUrls: string[]): Prom
     const baseRpcUrl = removeTrailingSlash(rpcUrl);
 
     const response = await axios.post<SuiRpcGetBalanceResponse>(baseRpcUrl, body, {
-      timeout: BALANCE_FETCH_TIME_OUT_MS * 2,
+      timeout: BALANCE_FETCH_TIME_OUT_MS,
     });
 
     if (response.data.error) {

--- a/src/utils/sui/fetch/staking.ts
+++ b/src/utils/sui/fetch/staking.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import type { DelegatedStake as SuiDelegatedStake } from '@mysten/sui/client';
 
-import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
+import { STAKING_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { SuiRpcGetDelegatedStakeResponse } from '@/types/sui/api';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
 import { removeTrailingSlash } from '@/utils/string';
@@ -18,7 +18,7 @@ export const fetchSuiDelegations = async (address: string, rpcUrls: string[]): P
     };
 
     const response = await axios.post<SuiRpcGetDelegatedStakeResponse>(requestUrl, body, {
-      timeout: DEFAULT_FETCH_TIME_OUT_MS * 2,
+      timeout: STAKING_FETCH_TIME_OUT_MS,
     });
 
     if (response.data.error) {

--- a/src/utils/updateRequest.ts
+++ b/src/utils/updateRequest.ts
@@ -1,0 +1,35 @@
+import { RATE_LIMIT_MS } from '@/constants/updateRequest';
+import type { LastRequestTimestampsKey } from '@/types/extension';
+
+import { getExtensionLocalStorage, setExtensionLocalStorage } from './storage';
+
+type RateLimitedMethod = keyof typeof RATE_LIMIT_MS;
+
+export async function isRequestThrottled(method: RateLimitedMethod, id: string): Promise<boolean> {
+  const result = await getExtensionLocalStorage('lastRequestTimestamps');
+
+  const now = Date.now();
+
+  const key: LastRequestTimestampsKey = `${method}:${id}`;
+  const lastRun = result?.[key];
+
+  if (!lastRun) return false;
+
+  const limit = RATE_LIMIT_MS[method];
+
+  const isUnderCooldown = now - lastRun < limit;
+
+  return isUnderCooldown;
+}
+
+export async function recordRequestTimestamp(method: RateLimitedMethod, id: string): Promise<void> {
+  const timestamps = await getExtensionLocalStorage('lastRequestTimestamps');
+  const key = `${method}:${id}`;
+
+  const newTimeStamps = {
+    ...timestamps,
+    [key]: Date.now(),
+  };
+
+  await setExtensionLocalStorage('lastRequestTimestamps', newTimeStamps);
+}

--- a/src/utils/zustand/lastRequestTimestamps.ts
+++ b/src/utils/zustand/lastRequestTimestamps.ts
@@ -1,0 +1,30 @@
+import { produce } from 'immer';
+
+import type { LastRequestTimestampsKey } from '@/types/extension';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
+
+import { getExtensionLocalStorage, setExtensionLocalStorage } from '../storage';
+
+export const removeAccountLastRequestTimestamps = async (accountIds: string[]) => {
+  const storedLastRequestTimestamps = await getExtensionLocalStorage('lastRequestTimestamps');
+
+  if (!storedLastRequestTimestamps) return;
+
+  const updatedLastRequestTimestamps = produce(storedLastRequestTimestamps, (draft) => {
+    accountIds.forEach((id) => {
+      const targetKeys = Object.keys(storedLastRequestTimestamps).filter((item) => item.includes(id)) as LastRequestTimestampsKey[];
+
+      targetKeys.forEach((key) => {
+        delete draft[key];
+      });
+    });
+  });
+
+  await setExtensionLocalStorage('lastRequestTimestamps', updatedLastRequestTimestamps);
+
+  useExtensionStorageStore.setState((currentState) =>
+    produce(currentState, (draft) => {
+      draft.lastRequestTimestamps = updatedLastRequestTimestamps;
+    }),
+  );
+};

--- a/src/zustand/hooks/useExtensionStorageStore.ts
+++ b/src/zustand/hooks/useExtensionStorageStore.ts
@@ -62,6 +62,7 @@ export const initialState: ExtensionStorageState = {
   autoLockTimeStampAt: null,
   migrationStatus: null,
   userPriceTrendPreference: PRICE_TREND_TYPE.GREEN_UP,
+  lastRequestTimestamps: null,
 };
 
 export const notDeleteKeys = ['paramsV11', 'assetsV11', 'erc20Assets', 'cw20Assets', 'migrationStatus'];


### PR DESCRIPTION
- 동일한 ID에 대한 밸런스 조회에 쓰로틀링 추가
- 밸런스 조회 풀 컨커런시 조절
- 타임아웃 조정

------

수동 밸런스 조회 기능과 의존성이 겹치는 부분이 있어 해당 기능을 고려해야합니다.

-------
486번 PR에 포함됐기 때문에 해당 PR은 내리곘습니다..

https://github.com/cosmostation/cosmostation-chrome-extension/pull/486