### PR TITLE
[APIS-642] Fix timing issue in useMultipleAccountTypes

### DIFF
--- a/src/components/CheckLegacyAddressBalanceBottomSheet/index.tsx
+++ b/src/components/CheckLegacyAddressBalanceBottomSheet/index.tsx
@@ -114,6 +114,7 @@ export default function CheckLegacyAddressBalanceBottomSheet({ ...remainder }: C
     accountAllAssets?.cw20AccountAssets,
     isAlreayChecked,
     isShow,
+    isUpdateBalnaceLoading,
     multipleAccountTypeWithAddress,
   ]);
 

--- a/src/hooks/useMultipleAccountTypes.ts
+++ b/src/hooks/useMultipleAccountTypes.ts
@@ -1,6 +1,7 @@
 import type { UseQueryOptions } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 
+import { getAccountAddress } from '@/libs/account';
 import { getMultipleAccountTypesChain } from '@/libs/accountType';
 import type { AccountAddress } from '@/types/account';
 
@@ -18,13 +19,32 @@ export function useMultipleAccountTypes({ accountId, config }: UseMultipleAccoun
 
   const param = accountId || currentAccount.id;
 
+  const { data: addresses = [] } = useQuery({
+    queryKey: ['multi_accountAddresses', param],
+    queryFn: async () => {
+      const result = await getAccountAddress(param);
+
+      if (!result || result.length === 0) {
+        throw new Error('No addresses found yet');
+      }
+
+      return result;
+    },
+    staleTime: Infinity,
+    retry: 5,
+    retryDelay: 3000,
+  });
+
+  const enabled = addresses.length > 0;
+
   const fetcher = async () => {
     return getMultipleAccountTypesChain(param);
   };
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['multipleAccountTypes', param],
+    queryKey: ['multipleAccountTypes', param, addresses.length],
     queryFn: fetcher,
+    enabled,
     staleTime: Infinity,
     ...config,
   });


### PR DESCRIPTION
계정 생성 직후 주소값이 저장이 안된 상태에서 useMultipleAccountTypes이 트리거됐을때 빈값을 리턴하는 문제를 수정했습니다.