### PR TITLE
[APIS-645] Remove removeTrailingSlash in chains' api endpoints

### DIFF
--- a/src/hooks/bitcoin/useAccountTxs.ts
+++ b/src/hooks/bitcoin/useAccountTxs.ts
@@ -3,6 +3,7 @@ import { throttle } from 'lodash';
 import type { AccountTxPayload } from '@/types/bitcoin/txs';
 import { get } from '@/utils/axios';
 import { sortByLatestDate } from '@/utils/date';
+import { buildRequestUrl } from '@/utils/fetch';
 
 import { useInfiniteFetch, type UseInfiniteFetchConfig } from '../common/useInfiniteFetch';
 import { useGetAccountAsset } from '../useGetAccountAsset';
@@ -19,7 +20,7 @@ export function useAccountTxs({ coinId, config }: UseAccountTxsProps) {
   const mempoolSpaceURL = accountAsset?.chain.mempoolURL || '';
   const address = accountAsset?.address.address || '';
 
-  const requestURL = mempoolSpaceURL && `${mempoolSpaceURL}/address/${address}/txs`;
+  const requestURL = mempoolSpaceURL && buildRequestUrl(mempoolSpaceURL, `/address/${address}/txs`);
 
   const fetcher = async (pageParam: string, requestURL: string) => {
     const paginatedRequestURL = pageParam ? `${requestURL}?after_txid=${pageParam}` : requestURL;

--- a/src/hooks/bitcoin/useUtxo.ts
+++ b/src/hooks/bitcoin/useUtxo.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import type { Utxo } from '@/types/bitcoin/balance';
 import { get } from '@/utils/axios';
+import { buildRequestUrl } from '@/utils/fetch';
 
 import type { UseFetchConfig } from '../common/useFetch';
 import { useFetch } from '../common/useFetch';
@@ -20,7 +21,7 @@ export function useUtxo({ coinId, config }: UseUtxoProps) {
   const requestURL = useMemo(() => {
     if (!asset?.chain.mempoolURL || !asset.address.address) return '';
 
-    return `${asset.chain.mempoolURL}/address/${asset.address.address}/utxo`;
+    return buildRequestUrl(asset.chain.mempoolURL, `/address/${asset.address.address}/utxo`);
   }, [asset?.chain.mempoolURL, asset?.address.address]);
 
   const fetcher = async () => {

--- a/src/libs/chain.ts
+++ b/src/libs/chain.ts
@@ -52,11 +52,7 @@ export async function getChains() {
     const isTestnet = isTestnetChain(id);
     const isEvm = chain.params.chainlist_params?.chain_type?.includes('evm') ?? false;
 
-    const lcdUrls =
-      chain.params.chainlist_params.lcd_endpoint?.map((endpoint) => ({
-        ...endpoint,
-        url: removeTrailingSlash(endpoint.url),
-      })) ?? [];
+    const lcdUrls = chain.params.chainlist_params.lcd_endpoint ?? [];
 
     const explorer = chain.params.chainlist_params?.explorer
       ? Object.entries(chain.params.chainlist_params.explorer).reduce((acc, [key, value]) => {
@@ -151,11 +147,7 @@ export async function getChains() {
 
     const isTestnet = isTestnetChain(id);
 
-    const rpcUrls =
-      chain.params.chainlist_params.evm_rpc_endpoint?.map((endpoint) => ({
-        ...endpoint,
-        url: removeTrailingSlash(endpoint.url),
-      })) ?? [];
+    const rpcUrls = chain.params.chainlist_params.evm_rpc_endpoint ?? [];
 
     const filteredAccountTypes = chain.params.chainlist_params?.account_type
       ?.filter((item) => {
@@ -225,11 +217,7 @@ export async function getChains() {
     const mainAssetDenom = chain.params.chainlist_params?.staking_asset_denom ?? SUI_COIN_TYPE;
     const chainDefaultCoinDenoms = collectDefaultDenoms(chain.params.chainlist_params);
 
-    const rpcUrls =
-      chain.params.chainlist_params.rpc_endpoint?.map((endpoint) => ({
-        ...endpoint,
-        url: removeTrailingSlash(endpoint.url),
-      })) ?? [];
+    const rpcUrls = chain.params.chainlist_params.rpc_endpoint ?? [];
 
     const explorer = chain.params.chainlist_params?.explorer
       ? Object.entries(chain.params.chainlist_params.explorer).reduce((acc, [key, value]) => {
@@ -280,11 +268,7 @@ export async function getChains() {
     const mainAssetDenom = chain.params.chainlist_params?.staking_asset_denom ?? APTOS_COIN_TYPE;
     const chainDefaultCoinDenoms = collectDefaultDenoms(chain.params.chainlist_params);
 
-    const rpcUrls =
-      chain.params.chainlist_params.rpc_endpoint?.map((endpoint) => ({
-        ...endpoint,
-        url: removeTrailingSlash(endpoint.url),
-      })) ?? [];
+    const rpcUrls = chain.params.chainlist_params.rpc_endpoint ?? [];
 
     const explorer = chain.params.chainlist_params?.explorer
       ? Object.entries(chain.params.chainlist_params.explorer).reduce((acc, [key, value]) => {
@@ -413,11 +397,7 @@ export async function getChains() {
     const mainAssetDenom = chain.params.chainlist_params?.staking_asset_denom ?? IOTA_COIN_TYPE;
     const chainDefaultCoinDenoms = collectDefaultDenoms(chain.params.chainlist_params);
 
-    const rpcUrls =
-      chain.params.chainlist_params.rpc_endpoint?.map((endpoint) => ({
-        ...endpoint,
-        url: removeTrailingSlash(endpoint.url),
-      })) ?? [];
+    const rpcUrls = chain.params.chainlist_params.rpc_endpoint ?? [];
 
     const explorer = chain.params.chainlist_params?.explorer
       ? Object.entries(chain.params.chainlist_params.explorer).reduce((acc, [key, value]) => {

--- a/src/pages/popup/cosmos/add-chain/-entry.tsx
+++ b/src/pages/popup/cosmos/add-chain/-entry.tsx
@@ -22,7 +22,6 @@ import { sendMessage } from '@/libs/extension';
 import type { CustomAsset } from '@/types/asset';
 import type { CustomCosmosChain } from '@/types/chain';
 import type { CosRequestAddChain, CosRequestAddChainResponse } from '@/types/message/inject/cosmos';
-import { removeTrailingSlash } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
 
 import { DetailWrapper, Divider, InformationContainer, LabelContainer, LineDivider } from './-styled';
@@ -53,8 +52,6 @@ export default function Entry({ request }: EntryProps) {
     try {
       setIsProcessing(true);
 
-      const trimmedRestUrl = removeTrailingSlash(request.params.restURL);
-
       const chainId = request.params.chainId;
 
       const formattedCoinType = request.params.coinType
@@ -77,7 +74,7 @@ export default function Entry({ request }: EntryProps) {
         lcdUrls: [
           {
             provider: 'Custom',
-            url: trimmedRestUrl,
+            url: request.params.restURL,
           },
         ],
         explorer: null,

--- a/src/pages/popup/evm/add-chain/-entry.tsx
+++ b/src/pages/popup/evm/add-chain/-entry.tsx
@@ -59,9 +59,7 @@ export default function Entry({ request }: EntryProps) {
 
       const paramData = request.params[0];
 
-      const trimmedRpcUrl = removeTrailingSlash(paramData.rpcURL);
-
-      const response = await requestRPC<EvmRpc<string>>('eth_chainId', [], '1', trimmedRpcUrl);
+      const response = await requestRPC<EvmRpc<string>>('eth_chainId', [], '1', paramData.rpcURL);
 
       const convertChainId = toHex(paramData.chainId, { addPrefix: true, isStringNumber: true });
 
@@ -91,7 +89,7 @@ export default function Entry({ request }: EntryProps) {
         rpcUrls: [
           {
             provider: 'Custom',
-            url: trimmedRpcUrl,
+            url: paramData.rpcURL,
           },
         ],
         explorer: {

--- a/src/utils/cosmos/address.ts
+++ b/src/utils/cosmos/address.ts
@@ -4,7 +4,7 @@ import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { CosmosValidator } from '@/types/cosmos/validator';
 
 import { get } from '../axios';
-import { removeTrailingSlash } from '../string';
+import { buildRequestUrl } from '../fetch';
 
 export function isValidCosmosAddress(address: string, addressPrefix: string): boolean {
   try {
@@ -34,8 +34,8 @@ export function getAddressPrefix(address?: string) {
 }
 
 export async function isValidatorAddress(address: string, lcdUrl: string): Promise<boolean> {
-  const base = removeTrailingSlash(lcdUrl);
-  const url = `${base}/cosmos/staking/v1beta1/validators/${address}`;
+  const url = buildRequestUrl(lcdUrl, `/cosmos/staking/v1beta1/validators/${address}`);
+
   try {
     const response = await get<{
       validator: CosmosValidator;

--- a/src/utils/cosmos/fetch/accountInfo.ts
+++ b/src/utils/cosmos/fetch/accountInfo.ts
@@ -1,14 +1,14 @@
 import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { AuthAccountsPayload } from '@/types/cosmos/account';
 import { get } from '@/utils/axios';
+import { buildRequestUrl } from '@/utils/fetch';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash } from '@/utils/string';
 
 export const fetchCosmosAccountInfo = async (address: string, lcdUrls: string[]): Promise<AuthAccountsPayload> => {
   return await fetchWithFailover(lcdUrls, async (lcdUrl) => {
-    const base = removeTrailingSlash(lcdUrl);
     const urlPath = `/cosmos/auth/v1beta1/accounts/${address}`;
-    const requestUrl = `${base}${urlPath}`;
+
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await get<AuthAccountsPayload>(requestUrl, {
       timeout: DEFAULT_FETCH_TIME_OUT_MS,

--- a/src/utils/cosmos/fetch/balance.ts
+++ b/src/utils/cosmos/fetch/balance.ts
@@ -5,8 +5,8 @@ import { MulticallWrapper } from 'ethers-multicall-provider';
 import { BALANCE_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { CosmosBalance, CosmosBalanceResponse, CosmosCw20BalanceResponse } from '@/types/cosmos/api';
 import type { EvmRpcGetBalanceResponse } from '@/types/evm/api';
+import { buildRequestUrl } from '@/utils/fetch';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash } from '@/utils/string';
 
 export const fetchCosmosBalances = async (
   address: string,
@@ -19,10 +19,11 @@ export const fetchCosmosBalances = async (
     let nextKey: string | null = null;
     const responseBalances: CosmosBalance[][] = [];
 
-    const base = removeTrailingSlash(lcdUrl);
     const urlPath = option?.path || `/cosmos/bank/v1beta1/balances/${address}`;
-    const urlQuery = 'pagination.limit=10000';
-    const requestUrl = `${base}${urlPath}?${urlQuery}`;
+
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath, {
+      'pagination.limit': '10000',
+    });
 
     const response = await axios.get<CosmosBalanceResponse>(requestUrl, {
       timeout: BALANCE_FETCH_TIME_OUT_MS,
@@ -69,9 +70,9 @@ export const fetchCoreumSpendableBalances = async (address: string, lcdUrls: str
 
 export const fetchCW20Balances = async (address: string, contractAddress: string, lcdUrls: string[]): Promise<string> => {
   return await fetchWithFailover(lcdUrls, async (lcdUrl) => {
-    const base = removeTrailingSlash(lcdUrl);
-    const urlPath = `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${btoa(`{"balance":{"address":"${address}"}}`)}`;
-    const requestUrl = `${base}${urlPath}`;
+    const urlPath = `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(btoa(`{"balance":{"address":"${address}"}}`))}`;
+
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await axios.get<CosmosCw20BalanceResponse>(requestUrl, {
       timeout: BALANCE_FETCH_TIME_OUT_MS,
@@ -93,7 +94,7 @@ export const fetchEVMBalances = async (address: string, rpcUrls: string[]): Prom
       id: 1,
     };
 
-    const baseRpcUrl = removeTrailingSlash(rpcUrl);
+    const baseRpcUrl = rpcUrl;
     const response = await axios.post<EvmRpcGetBalanceResponse>(baseRpcUrl, body, {
       timeout: BALANCE_FETCH_TIME_OUT_MS,
     });
@@ -118,7 +119,7 @@ const ERC20_READ_ABI = [ERC20_TOTAL_SUPPLY, ERC20_DECIMALS, ERC20_SYMBOL, ERC20_
 
 export const fetchERC20Balances = async (address: string, contractAddress: string, rpcUrls: string[]): Promise<string> => {
   return await fetchWithFailover(rpcUrls, async (rpcUrl) => {
-    const baseRpcUrl = removeTrailingSlash(rpcUrl);
+    const baseRpcUrl = rpcUrl;
     const provider = new ethers.JsonRpcProvider(baseRpcUrl, undefined, {
       batchMaxCount: 1,
       polling: false,
@@ -151,7 +152,7 @@ export const fetchMultiERC20Balances = async (
   }[]
 > => {
   return await fetchWithFailover(rpcUrls, async (rpcUrl) => {
-    const baseRpcUrl = removeTrailingSlash(rpcUrl);
+    const baseRpcUrl = rpcUrl;
     const provider = new ethers.JsonRpcProvider(baseRpcUrl, undefined, {
       polling: false,
       staticNetwork: true,

--- a/src/utils/cosmos/fetch/staking.ts
+++ b/src/utils/cosmos/fetch/staking.ts
@@ -6,8 +6,9 @@ import type { NTRNRewardsResponse } from '@/types/cosmos/contract';
 import type { DelegationPayload, KavaDelegationPayload, LcdDelegationResponse } from '@/types/cosmos/delegation';
 import type { RewardDetails, RewardPayload } from '@/types/cosmos/reward';
 import type { UnbondingPayload, UnbondingResponses } from '@/types/cosmos/undelegation';
+import { buildRequestUrl } from '@/utils/fetch';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash, toBase64 } from '@/utils/string';
+import { toBase64 } from '@/utils/string';
 
 const isKavaPayload = (payload: DelegationPayload | KavaDelegationPayload): payload is KavaDelegationPayload =>
   (payload as KavaDelegationPayload).result?.[0]?.delegation?.delegator_address !== undefined;
@@ -17,9 +18,8 @@ export const fetchCosmosDelegations = async (address: string, lcdUrls: string[])
     let nextKey: string | null = null;
     const responseDelegations: LcdDelegationResponse[][] = [];
 
-    const base = removeTrailingSlash(lcdUrl);
     const urlPath = `/cosmos/staking/v1beta1/delegations/${address}`;
-    const requestUrl = `${base}${urlPath}`;
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await axios.get<DelegationPayload | KavaDelegationPayload>(requestUrl, {
       timeout: DEFAULT_FETCH_TIME_OUT_MS,
@@ -95,9 +95,8 @@ export const fetchCosmosUnbondings = async (address: string, lcdUrls: string[]):
     let nextKey: string | null = null;
     const responseUnbondings: UnbondingResponses[][] = [];
 
-    const base = removeTrailingSlash(lcdUrl);
     const urlPath = `/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`;
-    const requestUrl = `${base}${urlPath}`;
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await axios.get<UnbondingPayload>(requestUrl, {
       timeout: DEFAULT_FETCH_TIME_OUT_MS,
@@ -161,9 +160,8 @@ export const fetchCosmosUnbondings = async (address: string, lcdUrls: string[]):
 
 export const fetchCosmosRewards = async (address: string, lcdUrls: string[]): Promise<RewardDetails> => {
   return await fetchWithFailover(lcdUrls, async (lcdUrl) => {
-    const base = removeTrailingSlash(lcdUrl);
     const urlPath = `/cosmos/distribution/v1beta1/delegators/${address}/rewards`;
-    const requestUrl = `${base}${urlPath}`;
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await axios.get<RewardPayload>(requestUrl, {
       timeout: DEFAULT_FETCH_TIME_OUT_MS,
@@ -204,9 +202,8 @@ export const fetchCosmosRewards = async (address: string, lcdUrls: string[]): Pr
 
 export const fetchNTRNRewards = async (address: string, rewardContractAddress: string, lcdUrls: string[]): Promise<RewardDetails> => {
   return await fetchWithFailover(lcdUrls, async (lcdUrl) => {
-    const base = removeTrailingSlash(lcdUrl);
-    const urlPath = `/cosmwasm/wasm/v1/contract/${rewardContractAddress}/smart/${toBase64(`{"rewards":{"user":"${address}"}}`)}`;
-    const requestUrl = `${base}${urlPath}`;
+    const urlPath = `/cosmwasm/wasm/v1/contract/${rewardContractAddress}/smart/${encodeURIComponent(toBase64(`{"rewards":{"user":"${address}"}}`))}`;
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await axios.get<NTRNRewardsResponse>(requestUrl, {
       timeout: DEFAULT_FETCH_TIME_OUT_MS,
@@ -239,9 +236,9 @@ export const fetchNTRNRewards = async (address: string, rewardContractAddress: s
 
 export const fetchCosmosCommission = async (validatorAddress: string, lcdUrls: string[]): Promise<CommissionResponse> => {
   return await fetchWithFailover(lcdUrls, async (lcdUrl) => {
-    const base = removeTrailingSlash(lcdUrl);
     const urlPath = `/cosmos/distribution/v1beta1/validators/${validatorAddress}/commission`;
-    const requestUrl = `${base}${urlPath}`;
+
+    const requestUrl = buildRequestUrl(lcdUrl, urlPath);
 
     const response = await axios.get<CommissionResponse>(requestUrl, {
       timeout: DEFAULT_FETCH_TIME_OUT_MS,

--- a/src/utils/crypto/cosmos.ts
+++ b/src/utils/crypto/cosmos.ts
@@ -1,35 +1,47 @@
 import { GRAVITY_BRDIGE_CHAINLIST_ID, KAVA_CHAINLIST_ID } from '@/constants/cosmos/chain';
 
+import { buildRequestUrl } from '../fetch';
 import { toBase64 } from '../string';
 
 export function cosmosURL(lcdURL: string, chainId: string) {
   return {
-    getNodeInfo: () => `${lcdURL}/cosmos/base/tendermint/v1beta1/node_info`,
-    getBalance: (address: string) => `${lcdURL}/cosmos/bank/v1beta1/balances/${address}?pagination.limit=10000`,
-    getDelegations: (address: string) => `${lcdURL}/cosmos/staking/v1beta1/delegations/${address}`,
-    getRewards: (address: string) => `${lcdURL}/cosmos/distribution/v1beta1/delegators/${address}/rewards`,
-    getUndelegations: (address: string) => `${lcdURL}/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`,
-    getAccount: (address: string) => `${lcdURL}/cosmos/auth/v1beta1/accounts/${address}`,
-    getIncentive: (address: string) => (chainId === KAVA_CHAINLIST_ID ? `${lcdURL}/kava/incentive/v1beta1/rewards?owner=${address}` : ''),
-    postBroadcast: () => `${lcdURL}/cosmos/tx/v1beta1/txs`,
-    getCW20TokenInfo: (contractAddress: string) => `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64('{"token_info":{}}')}`,
+    getNodeInfo: () => buildRequestUrl(lcdURL, `/cosmos/base/tendermint/v1beta1/node_info`),
+    getBalance: (address: string) => buildRequestUrl(lcdURL, `/cosmos/bank/v1beta1/balances/${address}?pagination.limit=10000`),
+    getDelegations: (address: string) => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/delegations/${address}`),
+    getRewards: (address: string) => buildRequestUrl(lcdURL, `/cosmos/distribution/v1beta1/delegators/${address}/rewards`),
+    getUndelegations: (address: string) => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`),
+    getAccount: (address: string) => buildRequestUrl(lcdURL, `/cosmos/auth/v1beta1/accounts/${address}`),
+    getIncentive: (address: string) => (chainId === KAVA_CHAINLIST_ID ? buildRequestUrl(lcdURL, `/kava/incentive/v1beta1/rewards?owner=${address}`) : ''),
+    postBroadcast: () => buildRequestUrl(lcdURL, `/cosmos/tx/v1beta1/txs`),
+    getCW20TokenInfo: (contractAddress: string) =>
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64('{"token_info":{}}'))}`),
     getCW20Balance: (contractAddress: string, address: string) =>
-      `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64(`{"balance":{"address":"${address}"}}`)}`,
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64(`{"balance":{"address":"${address}"}}`))}`),
     getCW721NFTInfo: (contractAddress: string, tokenId: string) =>
-      `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64(`{"nft_info":{"token_id":"${tokenId}"}}`)}`,
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64(`{"nft_info":{"token_id":"${tokenId}"}}`))}`),
     getCW721NFTIds: (contractAddress: string, ownerAddress: string, limit = 50) =>
-      `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64(`{"tokens":{"owner":"${ownerAddress}","limit":${limit},"start_after":"0"}}`)}`,
-    getCW721ContractInfo: (contractAddress: string) => `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64('{"contract_info":{}}')}`,
-    getCW721NumTokens: (contractAddress: string) => `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64('{"num_tokens":{}}')}`,
-    getCW721CollectionInfo: (contractAddress: string) => `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64('{"collection_info":{}}')}`,
-    getClientState: (channelId: string, port?: string) => `${lcdURL}/ibc/core/channel/v1/channels/${channelId}/ports/${port || 'transfer'}/client_state`,
-    simulate: () => `${lcdURL}/cosmos/tx/v1beta1/simulate`,
-    getTxInfo: (txHash: string) => `${lcdURL}/cosmos/tx/v1beta1/txs/${txHash}`,
-    getBlockLatest: () => (chainId === GRAVITY_BRDIGE_CHAINLIST_ID ? `${lcdURL}/blocks/latest` : `${lcdURL}/cosmos/base/tendermint/v1beta1/blocks/latest`),
-    getCommission: (validatorAddress: string) => `${lcdURL}/cosmos/distribution/v1beta1/validators/${validatorAddress}/commission`,
-    getFeemarket: (denom?: string) => `${lcdURL}/feemarket/v1/gas_prices${denom ? `/${denom}` : ''}`,
-    getValidators: () => `${lcdURL}/cosmos/staking/v1beta1/validators?pagination.limit=10000`,
+      buildRequestUrl(
+        lcdURL,
+        `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64(`{"tokens":{"owner":"${ownerAddress}","limit":${limit},"start_after":"0"}}`))}`,
+      ),
+    getCW721ContractInfo: (contractAddress: string) =>
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64('{"contract_info":{}}'))}`),
+    getCW721NumTokens: (contractAddress: string) =>
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64('{"num_tokens":{}}'))}`),
+    getCW721CollectionInfo: (contractAddress: string) =>
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64('{"collection_info":{}}'))}`),
+    getClientState: (channelId: string, port?: string) =>
+      buildRequestUrl(lcdURL, `/ibc/core/channel/v1/channels/${channelId}/ports/${port || 'transfer'}/client_state`),
+    simulate: () => buildRequestUrl(lcdURL, `/cosmos/tx/v1beta1/simulate`),
+    getTxInfo: (txHash: string) => buildRequestUrl(lcdURL, `/cosmos/tx/v1beta1/txs/${txHash}`),
+    getBlockLatest: () =>
+      chainId === GRAVITY_BRDIGE_CHAINLIST_ID
+        ? buildRequestUrl(lcdURL, `/blocks/latest`)
+        : buildRequestUrl(lcdURL, `/cosmos/base/tendermint/v1beta1/blocks/latest`),
+    getCommission: (validatorAddress: string) => buildRequestUrl(lcdURL, `/cosmos/distribution/v1beta1/validators/${validatorAddress}/commission`),
+    getFeemarket: (denom?: string) => buildRequestUrl(lcdURL, `/feemarket/v1/gas_prices${denom ? `/${denom}` : ''}`),
+    getValidators: () => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/validators?pagination.limit=10000`),
     getNTRNRewards: (contractAddress: string, address: string) =>
-      `${lcdURL}/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${toBase64(`{"rewards":{"user":"${address}"}}`)}`,
+      buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64(`{"rewards":{"user":"${address}"}}`))}`),
   };
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,3 +1,5 @@
+import { removeLeadingSlash, removeTrailingSlash } from './string';
+
 export class FetchError extends Error {
   public data: Response;
 
@@ -48,7 +50,10 @@ export async function get<T>(URL: string) {
 }
 
 export function buildRequestUrl(baseUrl: string, path?: string, queryParams?: Record<string, string | number | boolean>) {
-  const requestUrl = `${baseUrl}${path || ''}`;
+  const resolvedBaseUrl = removeTrailingSlash(baseUrl);
+  const resolvedPath = removeLeadingSlash(path);
+
+  const requestUrl = resolvedPath ? `${resolvedBaseUrl}/${resolvedPath}` : resolvedBaseUrl;
 
   if (queryParams) {
     const params = new URLSearchParams(Object.entries(queryParams).map(([key, value]) => [key, String(value)]));

--- a/src/utils/iota/fetch/balance.ts
+++ b/src/utils/iota/fetch/balance.ts
@@ -3,7 +3,6 @@ import axios from 'axios';
 import { BALANCE_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { IotaGetBalance, IotaRpcGetBalanceResponse } from '@/types/iota/api';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash } from '@/utils/string';
 
 export const fetchIotaBalances = async (address: string, rpcUrls: string[]): Promise<IotaGetBalance[]> => {
   return await fetchWithFailover(rpcUrls, async (rpcUrl) => {
@@ -14,7 +13,7 @@ export const fetchIotaBalances = async (address: string, rpcUrls: string[]): Pro
       id: 1,
     };
 
-    const baseRpcUrl = removeTrailingSlash(rpcUrl);
+    const baseRpcUrl = rpcUrl;
 
     const response = await axios.post<IotaRpcGetBalanceResponse>(baseRpcUrl, body, {
       timeout: BALANCE_FETCH_TIME_OUT_MS,

--- a/src/utils/iota/fetch/staking.ts
+++ b/src/utils/iota/fetch/staking.ts
@@ -4,11 +4,10 @@ import type { DelegatedStake as IotaDelegatedStake } from '@iota/iota-sdk/client
 import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { IotaRpcGetDelegatedStakeResponse } from '@/types/iota/api';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash } from '@/utils/string';
 
 export const fetchIotaDelegations = async (address: string, rpcUrls: string[]): Promise<IotaDelegatedStake[]> => {
   return await fetchWithFailover(rpcUrls, async (lcdUrl) => {
-    const requestUrl = removeTrailingSlash(lcdUrl);
+    const requestUrl = lcdUrl;
 
     const body = {
       jsonrpc: '2.0',

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -82,6 +82,11 @@ export function removeTrailingSlash(path: string) {
   return path.endsWith('/') ? path.slice(0, -1) : path;
 }
 
+export function removeLeadingSlash(val?: string): string {
+  if (!val) return '';
+  return val.startsWith('/') ? val.slice(1) : val;
+}
+
 export function removeTemplateLiteral(path: string) {
   return path.replace(/\$\{\w+\}/g, '');
 }

--- a/src/utils/sui/fetch/balance.ts
+++ b/src/utils/sui/fetch/balance.ts
@@ -3,7 +3,6 @@ import axios from 'axios';
 import { BALANCE_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { SuiGetBalance, SuiRpcGetBalanceResponse } from '@/types/sui/api';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash } from '@/utils/string';
 
 export const fetchSuiBalances = async (address: string, rpcUrls: string[]): Promise<SuiGetBalance[]> => {
   return await fetchWithFailover(rpcUrls, async (rpcUrl) => {
@@ -14,7 +13,7 @@ export const fetchSuiBalances = async (address: string, rpcUrls: string[]): Prom
       id: 1,
     };
 
-    const baseRpcUrl = removeTrailingSlash(rpcUrl);
+    const baseRpcUrl = rpcUrl;
 
     const response = await axios.post<SuiRpcGetBalanceResponse>(baseRpcUrl, body, {
       timeout: BALANCE_FETCH_TIME_OUT_MS * 2,

--- a/src/utils/sui/fetch/staking.ts
+++ b/src/utils/sui/fetch/staking.ts
@@ -4,11 +4,10 @@ import type { DelegatedStake as SuiDelegatedStake } from '@mysten/sui/client';
 import { DEFAULT_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { SuiRpcGetDelegatedStakeResponse } from '@/types/sui/api';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
-import { removeTrailingSlash } from '@/utils/string';
 
 export const fetchSuiDelegations = async (address: string, rpcUrls: string[]): Promise<SuiDelegatedStake[]> => {
   return await fetchWithFailover(rpcUrls, async (lcdUrl) => {
-    const requestUrl = removeTrailingSlash(lcdUrl);
+    const requestUrl = lcdUrl;
 
     const body = {
       jsonrpc: '2.0',


### PR DESCRIPTION
lcd, rpc엔드포인트들의 트래일링 슬래시를 제거하는 로직을 제거했습니다.
- api url을 생성해주는 함수를 사용하도록 리팩토링했습니다.