### PR TITLE
[APIS-647] Fix Cosmos inApp Sign func

### DIFF
--- a/src/utils/aptos/sign.ts
+++ b/src/utils/aptos/sign.ts
@@ -18,7 +18,7 @@ export async function signAndExecuteTxSequentially(
 
     try {
       if (option?.asFeePayer) {
-        const senderAuthenticator = aptosClient.transaction.signAsFeePayer({
+        const senderAuthenticator = await aptosClient.transaction.signAsFeePayer({
           signer: signer,
           transaction,
         });
@@ -30,7 +30,7 @@ export async function signAndExecuteTxSequentially(
 
         return submittedTransaction;
       } else {
-        const senderAuthenticator = aptosClient.transaction.sign({
+        const senderAuthenticator = await aptosClient.transaction.sign({
           signer: signer,
           transaction,
         });
@@ -49,7 +49,7 @@ export async function signAndExecuteTxSequentially(
   throw new Error('All RPC URLs failed');
 }
 
-export function signTxSequentially(
+export async function signTxSequentially(
   signer: Ed25519Account,
   transaction: AnyRawTransaction,
   urls: string[],
@@ -66,14 +66,14 @@ export function signTxSequentially(
 
     try {
       if (option?.asFeePayer) {
-        const senderAuthenticator = aptosClient.transaction.signAsFeePayer({
+        const senderAuthenticator = await aptosClient.transaction.signAsFeePayer({
           signer: signer,
           transaction,
         });
 
         return senderAuthenticator;
       } else {
-        const senderAuthenticator = aptosClient.transaction.sign({
+        const senderAuthenticator = await aptosClient.transaction.sign({
           signer: signer,
           transaction,
         });

--- a/src/utils/cosmos/sign.ts
+++ b/src/utils/cosmos/sign.ts
@@ -26,11 +26,12 @@ export async function signDirectAndexecuteTxSequentially({ privateKey, directDoc
 
   for (const url of urls) {
     try {
-      const response = post<SendTransactionPayload>(url, pTxBytes);
+      const response = await post<SendTransactionPayload>(url, pTxBytes);
 
       return response;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-empty
-    } catch (_) {}
+    } catch {
+      continue;
+    }
   }
   throw new Error('All RPC URLs failed');
 }


### PR DESCRIPTION
비동기 함수 호출에 await를 붙이지 않아 에러가 리턴되는게 아닌 프로미스객체가 리턴되어 lcd순회 로직이 동작하지 않는 문제를 수정했습니다.