### PR TITLE
[APIS-669] Hide balance error banner on idle

### DIFF
--- a/src/components/BalanceSyncStatusIcon/index.tsx
+++ b/src/components/BalanceSyncStatusIcon/index.tsx
@@ -18,7 +18,7 @@ export type BalanceSyncStatusIconProps = React.DetailedHTMLProps<React.HTMLAttri
 
 export default function BalanceSyncStatusIcon({ lastUpdatedAtMs, tooltipProps, ...remainder }: BalanceSyncStatusIconProps) {
   const { t } = useTranslation();
-  const { isLoading: isUpdateBalanceLoading, fetchStatus } = useUpdateBalance();
+  const { isLoading: isUpdateBalanceLoading, isFetching: isUpdateBalanceFetching, isAutoRefetchPaused } = useUpdateBalance();
   const [freshnessStatus, setFreshnessStatus] = useState<DataFreshnessType | undefined>();
 
   const tooltipMessage = useMemo(() => {
@@ -48,7 +48,7 @@ export default function BalanceSyncStatusIcon({ lastUpdatedAtMs, tooltipProps, .
     return () => clearInterval(interval);
   }, [lastUpdatedAtMs]);
 
-  if (!tooltipMessage || isUpdateBalanceLoading || fetchStatus === 'idle') return null;
+  if (!tooltipMessage || isUpdateBalanceLoading || isUpdateBalanceFetching || isAutoRefetchPaused) return null;
 
   return (
     <Tooltip title={tooltipMessage} varient={tooltipVarient} placement="top" style={{ height: '1.6rem' }} {...tooltipProps}>

--- a/src/components/BalanceSyncStatusIcon/index.tsx
+++ b/src/components/BalanceSyncStatusIcon/index.tsx
@@ -18,7 +18,7 @@ export type BalanceSyncStatusIconProps = React.DetailedHTMLProps<React.HTMLAttri
 
 export default function BalanceSyncStatusIcon({ lastUpdatedAtMs, tooltipProps, ...remainder }: BalanceSyncStatusIconProps) {
   const { t } = useTranslation();
-  const { isLoading: isUpdateBalanceLoading } = useUpdateBalance();
+  const { isLoading: isUpdateBalanceLoading, fetchStatus } = useUpdateBalance();
   const [freshnessStatus, setFreshnessStatus] = useState<DataFreshnessType | undefined>();
 
   const tooltipMessage = useMemo(() => {
@@ -48,7 +48,7 @@ export default function BalanceSyncStatusIcon({ lastUpdatedAtMs, tooltipProps, .
     return () => clearInterval(interval);
   }, [lastUpdatedAtMs]);
 
-  if (!tooltipMessage || isUpdateBalanceLoading) return null;
+  if (!tooltipMessage || isUpdateBalanceLoading || fetchStatus === 'idle') return null;
 
   return (
     <Tooltip title={tooltipMessage} varient={tooltipVarient} placement="top" style={{ height: '1.6rem' }} {...tooltipProps}>

--- a/src/components/StaleBalanceErrorBanner/index.tsx
+++ b/src/components/StaleBalanceErrorBanner/index.tsx
@@ -24,7 +24,8 @@ type StaleBalanceErrorBannerProps = React.DetailedHTMLProps<React.HTMLAttributes
 export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, address, ...remainer }: StaleBalanceErrorBannerProps) {
   const { t } = useTranslation();
   const { updateChainBalance, isLoadingChainBalance } = useManualBalanceUpdate();
-  const { isLoading: isUpdateBalanceLoading, fetchStatus } = useUpdateBalance();
+  const { isLoading: isUpdateBalanceLoading, isFetching: isUpdateBalanceFetching, isAutoRefetchPaused } = useUpdateBalance();
+
   const [freshnessStatus, setFreshnessStatus] = useState<DataFreshnessType | undefined>();
 
   const title = useMemo(() => {
@@ -54,7 +55,11 @@ export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, addr
   }, [lastUpdatedAtMs]);
 
   return (
-    <Collapse in={!!title && !isUpdateBalanceLoading && fetchStatus !== 'idle' && (freshnessStatus === 'warning' || freshnessStatus === 'stale')}>
+    <Collapse
+      in={
+        !!title && !isUpdateBalanceLoading && !isUpdateBalanceFetching && !isAutoRefetchPaused && (freshnessStatus === 'warning' || freshnessStatus === 'stale')
+      }
+    >
       <Container data-variant={freshnessStatus} {...remainer}>
         <TitleTextContainer>
           <CautionIcon />

--- a/src/components/StaleBalanceErrorBanner/index.tsx
+++ b/src/components/StaleBalanceErrorBanner/index.tsx
@@ -24,7 +24,7 @@ type StaleBalanceErrorBannerProps = React.DetailedHTMLProps<React.HTMLAttributes
 export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, address, ...remainer }: StaleBalanceErrorBannerProps) {
   const { t } = useTranslation();
   const { updateChainBalance, isLoadingChainBalance } = useManualBalanceUpdate();
-  const { isLoading: isUpdateBalanceLoading } = useUpdateBalance();
+  const { isLoading: isUpdateBalanceLoading, fetchStatus } = useUpdateBalance();
   const [freshnessStatus, setFreshnessStatus] = useState<DataFreshnessType | undefined>();
 
   const title = useMemo(() => {
@@ -54,7 +54,7 @@ export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, addr
   }, [lastUpdatedAtMs]);
 
   return (
-    <Collapse in={!!title && !isUpdateBalanceLoading && (freshnessStatus === 'warning' || freshnessStatus === 'stale')}>
+    <Collapse in={!!title && !isUpdateBalanceLoading && fetchStatus !== 'idle' && (freshnessStatus === 'warning' || freshnessStatus === 'stale')}>
       <Container data-variant={freshnessStatus} {...remainer}>
         <TitleTextContainer>
           <CautionIcon />

--- a/src/hooks/update/useUpdateBalance.ts
+++ b/src/hooks/update/useUpdateBalance.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { sendMessage } from '@/libs/extension';
@@ -8,6 +9,29 @@ import { useCurrentAccount } from '../useCurrentAccount';
 export function useUpdateBalance() {
   const { currentAccount } = useCurrentAccount();
   const { refetch: refetchAccountAllAssets } = useAccountAllAssets();
+  const [isBackground, setIsBackground] = useState<boolean>(document.hidden);
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+
+    const handleVisibilityChange = (): void => {
+      if (document.hidden) {
+        clearTimeout(timeoutId);
+        setIsBackground(true);
+      } else {
+        timeoutId = setTimeout(() => {
+          setIsBackground(false);
+        }, 5000);
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      clearTimeout(timeoutId);
+    };
+  }, []);
 
   const fetcher = async () => {
     const response = await sendMessage({ target: 'SERVICE_WORKER', method: 'updateBalance', params: [currentAccount.id] });
@@ -16,7 +40,7 @@ export function useUpdateBalance() {
     return response;
   };
 
-  const { data, isLoading, error, fetchStatus } = useQuery({
+  const { data, isLoading, isFetching, error, fetchStatus } = useQuery({
     queryKey: ['updateBalance', currentAccount.id],
     enabled: !!currentAccount.id,
     queryFn: fetcher,
@@ -24,5 +48,15 @@ export function useUpdateBalance() {
     refetchInterval: 1000 * 60 * 5,
   });
 
-  return { data, isLoading, error, fetchStatus };
+  const isAutoRefetchPaused = isBackground;
+
+  return {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    fetchStatus,
+    isAutoRefetchPaused,
+    isBackground,
+  };
 }

--- a/src/hooks/update/useUpdateBalance.ts
+++ b/src/hooks/update/useUpdateBalance.ts
@@ -16,7 +16,7 @@ export function useUpdateBalance() {
     return response;
   };
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, fetchStatus } = useQuery({
     queryKey: ['updateBalance', currentAccount.id],
     enabled: !!currentAccount.id,
     queryFn: fetcher,
@@ -24,5 +24,5 @@ export function useUpdateBalance() {
     refetchInterval: 1000 * 60 * 5,
   });
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, fetchStatus };
 }

--- a/src/hooks/useLastUpdateChecker.ts
+++ b/src/hooks/useLastUpdateChecker.ts
@@ -7,10 +7,10 @@ export function useLastUpdateChecker(lastUpdate?: number | null) {
   const [status, setStatus] = useState<string>('');
 
   const { t } = useTranslation();
-  const { isLoading: isUpdateBalanceLoading } = useUpdateBalance();
+  const { isLoading: isUpdateBalanceLoading, isFetching: isUpdateBalanceFetching, isAutoRefetchPaused } = useUpdateBalance();
 
   useEffect(() => {
-    if (!lastUpdate || isUpdateBalanceLoading) {
+    if (!lastUpdate || isUpdateBalanceLoading || isUpdateBalanceFetching || isAutoRefetchPaused) {
       setStatus('');
       return;
     }
@@ -38,7 +38,7 @@ export function useLastUpdateChecker(lastUpdate?: number | null) {
     const intervalId = setInterval(updateStatus, 60000);
 
     return () => clearInterval(intervalId);
-  }, [isUpdateBalanceLoading, lastUpdate, t]);
+  }, [isAutoRefetchPaused, isUpdateBalanceFetching, isUpdateBalanceLoading, lastUpdate, t]);
 
   return status;
 }


### PR DESCRIPTION
useUpdateBalance가 백그라운드에서 idel상태일때는 밸런스 데이터 에러 배너를 노출하지않도록 변경했습니다.