### PR TITLE
[APIS-677] Change simulation in direct sign popup

### DIFF
--- a/src/hooks/cosmos/useSimulate.ts
+++ b/src/hooks/cosmos/useSimulate.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { SimulateResponse } from '@/types/cosmos/simulate';
 import { isAxiosError, post } from '@/utils/axios';
@@ -16,6 +16,8 @@ type UseSimulateProps = {
 };
 
 export function useSimulate({ coinId, txBytes, config }: UseSimulateProps) {
+  const [hasFailedPermanently, setHasFailedPermanently] = useState(false);
+
   const { getCosmosAccountAsset } = useGetAccountAsset({ coinId });
 
   const asset = getCosmosAccountAsset();
@@ -59,20 +61,29 @@ export function useSimulate({ coinId, txBytes, config }: UseSimulateProps) {
     queryKey: ['cosmosSimulate', coinId, txBytes],
     fetchFunction: () => fetcher(),
     config: {
-      enabled: !!coinId && !!txBytes && !!requestURLs.length && asset?.chain.feeInfo.isSimulable,
-      refetchInterval: 1000 * 15,
+      ...config,
+      enabled: !!coinId && !!txBytes && !!requestURLs.length && Boolean(asset?.chain.feeInfo?.isSimulable),
+      refetchInterval: hasFailedPermanently ? false : (config?.refetchInterval ?? 1000 * 15),
       retry: (failureCount, error) => {
         if (isAxiosError(error)) {
           if (error.response?.status === 404) {
             return false;
           }
         }
-        return failureCount < 3;
+
+        const shouldRetry = failureCount < 3;
+        if (!shouldRetry) {
+          setHasFailedPermanently(true);
+        }
+        return shouldRetry;
       },
-      retryDelay: 1000 * 5,
-      ...config,
+      retryDelay: config?.retryDelay ?? 1000 * 5,
     },
   });
+
+  useEffect(() => {
+    setHasFailedPermanently(false);
+  }, [coinId, txBytes]);
 
   return { data, error, refetch, isLoading, isFetching, isFetched };
 }

--- a/src/pages/popup/cosmos/sign/direct/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/direct/-entry.tsx
@@ -157,14 +157,44 @@ export default function Entry({ request, chain }: EntryProps) {
     if (isEditFee) {
       const signatures = signer_infos.map(() => Buffer.from(new Uint8Array(64)).toString('base64'));
 
+      const encodedAuthInfoBytesForSimul = (() => {
+        const defaultFeeCoinDenom = feeAssets[0]?.asset.id || chain.mainAssetDenom;
+        const defaultFeeRate = feeAssets[0]?.gasRate[defaultGasRateKey] || '0';
+
+        const defaultGas = gt(fee?.gas_limit || '0', chain.feeInfo.defaultGasLimit) ? fee?.gas_limit || '0' : chain.feeInfo.defaultGasLimit;
+
+        const defaultFeeAmount = ceil(times(defaultGas, defaultFeeRate));
+        const appliedFeeAmount = gt(inputFee.amount || '0', defaultFeeAmount) ? inputFee.amount : defaultFeeAmount;
+
+        return cosmos.tx.v1beta1.AuthInfo.encode({
+          ...decodedAuthInfoBytes,
+          fee: {
+            ...fee,
+            amount: [{ denom: defaultFeeCoinDenom, amount: appliedFeeAmount }],
+            gas_limit: Number(defaultGas),
+          },
+        }).finish();
+      })();
+
       return protoTxBytes({
         signatures,
         txBodyBytes: body_bytes,
-        authInfoBytes: auth_info_bytes,
+        authInfoBytes: encodedAuthInfoBytesForSimul,
       });
     }
     return null;
-  }, [auth_info_bytes, body_bytes, isEditFee, signer_infos]);
+  }, [
+    body_bytes,
+    chain.feeInfo.defaultGasLimit,
+    chain.mainAssetDenom,
+    decodedAuthInfoBytes,
+    defaultGasRateKey,
+    fee,
+    feeAssets,
+    inputFee.amount,
+    isEditFee,
+    signer_infos,
+  ]);
 
   const isPossibleSimulating =
     !!accountAssetCoinId &&


### PR DESCRIPTION
- tx 시뮬레이션 에러 재시도까지 모두 실패한 경우 재요청하지 않도록 변경
- 다이렉트 사인 팝업 페이지에서 익스텐션이 계산한 디폴트 fee값으로 시뮬레이션하도록 변경