### PR TITLE
[APIS-687] 밸런스 갱신 UX 개선

### DIFF
--- a/src/components/MainBox/CoinDetailBox/components/ValueButtonWrapper/index.tsx
+++ b/src/components/MainBox/CoinDetailBox/components/ValueButtonWrapper/index.tsx
@@ -43,7 +43,7 @@ export default function ValueButtonWrapper({ currentCoin }: ValueButtonWrapperPr
 
     const chainId = getUniqueChainId(currentCoin.chain);
 
-    await updateChainBalance(chainId, currentCoin.address.address);
+    await updateChainBalance(chainId);
   };
 
   return (

--- a/src/components/MainBox/CoinDetailBox/index.tsx
+++ b/src/components/MainBox/CoinDetailBox/index.tsx
@@ -146,13 +146,7 @@ export default function CoinDetailBox({ coinId }: CoinDetailBoxProps) {
 
   return (
     <>
-      {currentCoin?.lastUpdatedAtMs && (
-        <StaleBalanceErrorBanner
-          chainId={getUniqueChainId(currentCoin.chain)}
-          address={currentCoin.address.address}
-          lastUpdatedAtMs={currentCoin.lastUpdatedAtMs}
-        />
-      )}
+      {currentCoin?.lastUpdatedAtMs && <StaleBalanceErrorBanner chainId={getUniqueChainId(currentCoin.chain)} lastUpdatedAtMs={currentCoin.lastUpdatedAtMs} />}
       <MainBox
         top={
           <TopContainer>

--- a/src/components/MainBox/Portfolio/components/BalanceValueWrapper/index.tsx
+++ b/src/components/MainBox/Portfolio/components/BalanceValueWrapper/index.tsx
@@ -49,8 +49,8 @@ export default function BalanceValueWrapper({ accountAssets, selectedChainId, se
   }, [selectedChainMainAsset?.chain]);
 
   const handleManualBalanceUpdate = async () => {
-    if (selectedChainId && selectedChainMainAsset?.address.address) {
-      await updateChainBalance(selectedChainId, selectedChainMainAsset.address.address);
+    if (selectedChainId) {
+      await updateChainBalance(selectedChainId);
       return;
     }
 

--- a/src/components/MainBox/Portfolio/index.tsx
+++ b/src/components/MainBox/Portfolio/index.tsx
@@ -68,11 +68,7 @@ export default function PortFolio({ selectedChainId, onChangeChaindId }: PortFol
   return (
     <>
       {selectedChainMainAsset?.lastUpdatedAtMs && (
-        <StaleBalanceErrorBanner
-          chainId={getUniqueChainId(selectedChainMainAsset.chain)}
-          address={selectedChainMainAsset.address.address}
-          lastUpdatedAtMs={selectedChainMainAsset.lastUpdatedAtMs}
-        />
+        <StaleBalanceErrorBanner chainId={getUniqueChainId(selectedChainMainAsset.chain)} lastUpdatedAtMs={selectedChainMainAsset.lastUpdatedAtMs} />
       )}
       <MainBox
         top={

--- a/src/components/MainBox/StakeDetailBox/Cosmos/index.tsx
+++ b/src/components/MainBox/StakeDetailBox/Cosmos/index.tsx
@@ -5,7 +5,6 @@ import BalanceDisplay from '@/components/BalanceDisplay';
 import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import { NEUTRON_CHAINLIST_ID, NEUTRON_TESTNET_CHAINLIST_ID } from '@/constants/cosmos/chain';
-import { useAmount } from '@/hooks/cosmos/useAmount';
 import { useDelegationInfo } from '@/hooks/cosmos/useDelegationInfo';
 import { useNTRNReward } from '@/hooks/cosmos/useNTRNReward';
 import { useReward } from '@/hooks/cosmos/useReward';
@@ -13,6 +12,7 @@ import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
 import { Route as ClaimAllRewards } from '@/pages/wallet/claim-all-rewards/$coinId';
 import { Route as Stake } from '@/pages/wallet/stake/$coinId';
 import { Route as UnStake } from '@/pages/wallet/unstake/$coinId';
+import { isStakeableAsset } from '@/utils/asset';
 import { gt, toDisplayDenomAmount } from '@/utils/numbers';
 import { parseCoinId } from '@/utils/queryParamGenerator';
 
@@ -42,14 +42,15 @@ export default function Cosmos({ coinId }: CosmosProps) {
 
   const { data: ntrnRewards } = useNTRNReward({ coinId: isNTRN ? coinId : undefined });
 
-  const { delegationAmount, rewardAmount } = useAmount(coinId);
+  const stakableCoin = currentCoin && isStakeableAsset(currentCoin) ? currentCoin : undefined;
+
   const reward = useReward({ coinId });
 
   const symbol = currentCoin?.asset.symbol;
   const decimals = currentCoin?.asset.decimals;
-  const totalStakedDisplayAmount = toDisplayDenomAmount(delegationAmount, decimals || 0);
+  const totalStakedDisplayAmount = toDisplayDenomAmount(stakableCoin?.delegation || '0', decimals || 0);
 
-  const rewardsDisplayAmount = toDisplayDenomAmount(isNTRN ? ntrnRewards?.data.pending_rewards.amount || '0' : rewardAmount, decimals || 0);
+  const rewardsDisplayAmount = toDisplayDenomAmount(isNTRN ? ntrnRewards?.data.pending_rewards.amount || '0' : stakableCoin?.reward || '0', decimals || 0);
   const rewardsCoinCounts = isNTRN ? 0 : reward?.data?.total?.length && reward.data.total.length > 1 ? reward.data.total.length - 1 : 0;
 
   return (

--- a/src/components/StaleBalanceErrorBanner/index.tsx
+++ b/src/components/StaleBalanceErrorBanner/index.tsx
@@ -18,11 +18,10 @@ import RefreshIcon from '@/assets/images/icons/Refresh18.svg';
 
 type StaleBalanceErrorBannerProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
   chainId: UniqueChainId;
-  address?: string;
   lastUpdatedAtMs?: number | null;
 };
 
-export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, address, ...remainer }: StaleBalanceErrorBannerProps) {
+export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, ...remainer }: StaleBalanceErrorBannerProps) {
   const { t } = useTranslation();
   const { updateChainBalance, isLoadingChainBalance } = useManualBalanceUpdate();
   const { isLoading: isUpdateBalanceLoading, isFetching: isUpdateBalanceFetching, isAutoRefetchPaused } = useUpdateBalance();
@@ -37,7 +36,7 @@ export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, addr
   }, [freshnessStatus, t]);
 
   const handleOnClick = async () => {
-    if (freshnessStatus === 'warning' && address) {
+    if (freshnessStatus === 'warning') {
       await updateChainBalance(chainId);
     }
   };

--- a/src/components/StaleBalanceErrorBanner/index.tsx
+++ b/src/components/StaleBalanceErrorBanner/index.tsx
@@ -38,7 +38,7 @@ export default function StaleBalanceErrorBanner({ lastUpdatedAtMs, chainId, addr
 
   const handleOnClick = async () => {
     if (freshnessStatus === 'warning' && address) {
-      await updateChainBalance(chainId, address);
+      await updateChainBalance(chainId);
     }
   };
 

--- a/src/hooks/aptos/useGetAccountTransactions.ts
+++ b/src/hooks/aptos/useGetAccountTransactions.ts
@@ -78,8 +78,8 @@ export function useGetAccountTransactions({ coinId, config }: UseGetAccountTrans
     },
     config: {
       enabled: !!coinId && !!address && !!rpcURLs.length,
-      staleTime: 1000 * 29,
-      refetchInterval: 1000 * 30,
+      staleTime: 1000 * 9,
+      refetchInterval: 1000 * 10,
       ...config,
     },
   });

--- a/src/hooks/common/useManualBalanceUpdate.ts
+++ b/src/hooks/common/useManualBalanceUpdate.ts
@@ -26,17 +26,12 @@ const throttledUpdateAllBalanceFn = throttle(
 
 const throttledUpdateChainBalanceFn = throttle(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async (accountId, chainId: UniqueChainId, address: string, callbackFunc: () => Promise<any>) => {
+  async (accountId, chainId: UniqueChainId, callbackFunc: () => Promise<any>) => {
     await Promise.all([
       sendMessage({
         target: 'SERVICE_WORKER',
-        method: 'updateChainSpecificBalance',
-        params: [accountId, chainId, address],
-      }),
-      sendMessage({
-        target: 'SERVICE_WORKER',
         method: 'updateChainSpecificStakingBalance',
-        params: [accountId, chainId, address],
+        params: [accountId, chainId],
       }),
     ]);
 
@@ -82,14 +77,14 @@ export function useManualBalanceUpdate() {
     }
   };
 
-  const updateChainBalance = async (chainId: UniqueChainId, address: string) => {
+  const updateChainBalance = async (chainId: UniqueChainId) => {
     defaultTimeout();
     if (isLoadingChainBalance) return;
 
     setIsLoadingChainBalance(true);
 
     try {
-      await throttledUpdateChainBalanceFn(currentAccount.id, chainId, address, refreshAssets);
+      await throttledUpdateChainBalanceFn(currentAccount.id, chainId, refreshAssets);
     } catch (e) {
       devLogger.error(`[useManualBalanceUpdate]  updateChainBalance`, e);
     } finally {

--- a/src/hooks/common/useTxWatcher.ts
+++ b/src/hooks/common/useTxWatcher.ts
@@ -93,17 +93,17 @@ export function useTxWatcher(config?: UseFetchConfig) {
           const isTxSuccess = response.data.tx_response.code === 0;
 
           if (isTxSuccess) {
-            await sendMessage({
-              target: 'SERVICE_WORKER',
-              method: 'updateChainSpecificBalance',
-              params: [currentAccount.id, tx.chainId, tx.address],
-            });
-
             if (tx.type === 'staking') {
               await sendMessage({
                 target: 'SERVICE_WORKER',
                 method: 'updateChainSpecificStakingBalance',
-                params: [currentAccount.id, tx.chainId, tx.address],
+                params: [currentAccount.id, tx.chainId],
+              });
+            } else {
+              await sendMessage({
+                target: 'SERVICE_WORKER',
+                method: 'updateChainSpecificBalance',
+                params: [currentAccount.id, tx.chainId],
               });
             }
 
@@ -155,7 +155,7 @@ export function useTxWatcher(config?: UseFetchConfig) {
             await sendMessage({
               target: 'SERVICE_WORKER',
               method: 'updateChainSpecificBalance',
-              params: [currentAccount.id, tx.chainId, tx.address],
+              params: [currentAccount.id, tx.chainId],
             });
 
             refreshAssets();
@@ -209,7 +209,7 @@ export function useTxWatcher(config?: UseFetchConfig) {
             await sendMessage({
               target: 'SERVICE_WORKER',
               method: 'updateChainSpecificBalance',
-              params: [currentAccount.id, tx.chainId, tx.address],
+              params: [currentAccount.id, tx.chainId],
             });
 
             refreshAssets();
@@ -273,17 +273,17 @@ export function useTxWatcher(config?: UseFetchConfig) {
           const isTxSuccess = response.result.effects.status.status === SUI_TX_RESULT.SUCCESS;
 
           if (isTxSuccess) {
-            await sendMessage({
-              target: 'SERVICE_WORKER',
-              method: 'updateChainSpecificBalance',
-              params: [currentAccount.id, tx.chainId, tx.address],
-            });
-
             if (tx.type === 'staking') {
               await sendMessage({
                 target: 'SERVICE_WORKER',
                 method: 'updateChainSpecificStakingBalance',
-                params: [currentAccount.id, tx.chainId, tx.address],
+                params: [currentAccount.id, tx.chainId],
+              });
+            } else {
+              await sendMessage({
+                target: 'SERVICE_WORKER',
+                method: 'updateChainSpecificBalance',
+                params: [currentAccount.id, tx.chainId],
               });
             }
 
@@ -314,7 +314,7 @@ export function useTxWatcher(config?: UseFetchConfig) {
           await sendMessage({
             target: 'SERVICE_WORKER',
             method: 'updateChainSpecificBalance',
-            params: [currentAccount.id, tx.chainId, tx.address],
+            params: [currentAccount.id, tx.chainId],
           });
           refreshAssets();
 
@@ -376,20 +376,19 @@ export function useTxWatcher(config?: UseFetchConfig) {
           const isTxSuccess = response.result.effects.status.status === IOTA_TX_RESULT.SUCCESS;
 
           if (isTxSuccess) {
-            await sendMessage({
-              target: 'SERVICE_WORKER',
-              method: 'updateChainSpecificBalance',
-              params: [currentAccount.id, tx.chainId, tx.address],
-            });
-
             if (tx.type === 'staking') {
               await sendMessage({
                 target: 'SERVICE_WORKER',
                 method: 'updateChainSpecificStakingBalance',
-                params: [currentAccount.id, tx.chainId, tx.address],
+                params: [currentAccount.id, tx.chainId],
+              });
+            } else {
+              await sendMessage({
+                target: 'SERVICE_WORKER',
+                method: 'updateChainSpecificBalance',
+                params: [currentAccount.id, tx.chainId],
               });
             }
-
             refreshAssets();
 
             if (tx.type === 'nft') {

--- a/src/hooks/cosmos/useAccountTxs.ts
+++ b/src/hooks/cosmos/useAccountTxs.ts
@@ -58,8 +58,8 @@ export function useAccountTxs({ coinId, config }: UseAccountTxsProps) {
     getNextPageParam: (lastPage) => lastPage?.[lastPage.length - 1]?.search_after,
     config: {
       enabled: !!address && !!chainId && isSupportHistory,
-      staleTime: 1000 * 29,
-      refetchInterval: 1000 * 30,
+      staleTime: 1000 * 9,
+      refetchInterval: 1000 * 10,
       ...config,
     },
   });

--- a/src/hooks/evm/useAccountTxs.ts
+++ b/src/hooks/evm/useAccountTxs.ts
@@ -41,8 +41,8 @@ export function useAccountTxs({ coinId, config }: UseAccountTxsProps) {
     },
     config: {
       enabled: !!address && !!chainId,
-      staleTime: 1000 * 29,
-      refetchInterval: 1000 * 30,
+      staleTime: 1000 * 9,
+      refetchInterval: 1000 * 10,
       ...config,
     },
   });

--- a/src/hooks/iota/useTransactionBlocks.ts
+++ b/src/hooks/iota/useTransactionBlocks.ts
@@ -89,8 +89,8 @@ export function useTransactionBlocks({ coinId, queryOptions, config }: UseTransa
       },
       config: {
         enabled: !!coinId && !!address && !!rpcURLs.length,
-        staleTime: 1000 * 29,
-        refetchInterval: 1000 * 30,
+        staleTime: 1000 * 9,
+        refetchInterval: 1000 * 10,
         ...config,
       },
     });

--- a/src/hooks/sui/useTransactionBlocks.ts
+++ b/src/hooks/sui/useTransactionBlocks.ts
@@ -89,8 +89,8 @@ export function useTransactionBlocks({ coinId, queryOptions, config }: UseTransa
       },
       config: {
         enabled: !!coinId && !!address && !!rpcURLs.length,
-        staleTime: 1000 * 29,
-        refetchInterval: 1000 * 30,
+        staleTime: 1000 * 9,
+        refetchInterval: 1000 * 10,
         ...config,
       },
     });

--- a/src/hooks/update/useAutoBalanceRefresh.ts
+++ b/src/hooks/update/useAutoBalanceRefresh.ts
@@ -1,13 +1,17 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { sendMessage } from '@/libs/extension';
 import type { UniqueChainId } from '@/types/chain';
-import { chunkArray } from '@/utils/array';
+import { chunkArray, removeDuplicates } from '@/utils/array';
+import { getUniqueChainIdWithManual, isMatchingUniqueChainId, parseUniqueChainId } from '@/utils/queryParamGenerator';
 
+import { useChainList } from '../useChainList';
 import { useCurrentAccount } from '../useCurrentAccount';
 import { useRefreshAccountAllAssets } from '../useRefreshAccountAllAssets';
 
 const defaultRefreshInterval = 10000;
+const defaultBitcoinRefreshInterval = 30000;
 
 const createFetcher = (uniqueChainIds: UniqueChainId[], currentAccountId: string, refreshAssets: () => void) => {
   return async () => {
@@ -36,13 +40,35 @@ const createFetcher = (uniqueChainIds: UniqueChainId[], currentAccountId: string
 export function useAutoBalanceRefresh(uniqueChainIds?: UniqueChainId[] | null, interval = defaultRefreshInterval) {
   const { currentAccount } = useCurrentAccount();
   const { refreshAssets } = useRefreshAccountAllAssets();
+  const { chainList } = useChainList();
+
+  const resolvedChainIds = useMemo(() => {
+    if (!chainList?.allEVMChains) {
+      return uniqueChainIds || [];
+    }
+
+    const evmChainIds = uniqueChainIds?.filter((item) => item && parseUniqueChainId(item).chainType === 'evm');
+
+    if (!evmChainIds || evmChainIds.length === 0) return uniqueChainIds;
+
+    const ethermints = chainList.allEVMChains.filter((item) => item.isCosmos && evmChainIds?.some((id) => isMatchingUniqueChainId(item, id)));
+    const ethermintCosmosChainIds = ethermints.map((item) => getUniqueChainIdWithManual(item.id, 'cosmos'));
+
+    return removeDuplicates([...(uniqueChainIds || []), ...ethermintCosmosChainIds], (a, b) => a === b);
+  }, [chainList.allEVMChains, uniqueChainIds]);
+
+  const resolvedRefetchInterval = useMemo(() => {
+    const isIncludedBitcoin = uniqueChainIds?.some((item) => parseUniqueChainId(item).chainType === 'bitcoin');
+
+    return isIncludedBitcoin ? defaultBitcoinRefreshInterval : interval;
+  }, [interval, uniqueChainIds]);
 
   const { data, isLoading, isFetching, error, fetchStatus } = useQuery({
-    queryKey: ['useAutoBalanceRefresh', JSON.stringify([...(uniqueChainIds ?? [])].sort()), currentAccount?.id ?? null],
+    queryKey: ['useAutoBalanceRefresh', JSON.stringify([...(resolvedChainIds ?? [])].sort()), currentAccount?.id ?? null],
     enabled: !!(uniqueChainIds?.length && currentAccount?.id),
-    queryFn: () => createFetcher(uniqueChainIds ?? [], currentAccount?.id ?? '', refreshAssets)(),
+    queryFn: () => createFetcher(resolvedChainIds ?? [], currentAccount?.id ?? '', refreshAssets)(),
     staleTime: Infinity,
-    refetchInterval: interval,
+    refetchInterval: resolvedRefetchInterval,
   });
 
   return {

--- a/src/hooks/update/useAutoBalanceRefresh.ts
+++ b/src/hooks/update/useAutoBalanceRefresh.ts
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { sendMessage } from '@/libs/extension';
+import type { UniqueChainId } from '@/types/chain';
+import { chunkArray } from '@/utils/array';
+
+import { useCurrentAccount } from '../useCurrentAccount';
+import { useRefreshAccountAllAssets } from '../useRefreshAccountAllAssets';
+
+const defaultRefreshInterval = 10000;
+
+const createFetcher = (uniqueChainIds: UniqueChainId[], currentAccountId: string, refreshAssets: () => void) => {
+  return async () => {
+    if (!uniqueChainIds || uniqueChainIds.length === 0 || !currentAccountId) return;
+
+    const chunkedChainIds = chunkArray(uniqueChainIds, 5);
+
+    for (const chunk of chunkedChainIds) {
+      await Promise.all(
+        chunk.map(async (chainId) => {
+          await sendMessage({
+            target: 'SERVICE_WORKER',
+            method: 'updateChainSpecificStakingBalance',
+            params: [currentAccountId, chainId],
+          });
+        }),
+      );
+    }
+
+    await refreshAssets();
+
+    return true;
+  };
+};
+
+export function useAutoBalanceRefresh(uniqueChainIds?: UniqueChainId[] | null, interval = defaultRefreshInterval) {
+  const { currentAccount } = useCurrentAccount();
+  const { refreshAssets } = useRefreshAccountAllAssets();
+
+  const { data, isLoading, isFetching, error, fetchStatus } = useQuery({
+    queryKey: ['useAutoBalanceRefresh', JSON.stringify(uniqueChainIds?.sort() || []), currentAccount.id],
+    enabled: !!uniqueChainIds?.length && !!currentAccount.id,
+    queryFn: () => createFetcher(uniqueChainIds || [], currentAccount.id, refreshAssets)(),
+    staleTime: Infinity,
+    refetchInterval: interval,
+  });
+
+  return {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    fetchStatus,
+  };
+}

--- a/src/hooks/update/useAutoBalanceRefresh.ts
+++ b/src/hooks/update/useAutoBalanceRefresh.ts
@@ -38,9 +38,9 @@ export function useAutoBalanceRefresh(uniqueChainIds?: UniqueChainId[] | null, i
   const { refreshAssets } = useRefreshAccountAllAssets();
 
   const { data, isLoading, isFetching, error, fetchStatus } = useQuery({
-    queryKey: ['useAutoBalanceRefresh', JSON.stringify(uniqueChainIds?.sort() || []), currentAccount.id],
-    enabled: !!uniqueChainIds?.length && !!currentAccount.id,
-    queryFn: () => createFetcher(uniqueChainIds || [], currentAccount.id, refreshAssets)(),
+    queryKey: ['useAutoBalanceRefresh', JSON.stringify([...(uniqueChainIds ?? [])].sort()), currentAccount?.id ?? null],
+    enabled: !!(uniqueChainIds?.length && currentAccount?.id),
+    queryFn: () => createFetcher(uniqueChainIds ?? [], currentAccount?.id ?? '', refreshAssets)(),
     staleTime: Infinity,
     refetchInterval: interval,
   });

--- a/src/pages/-entry.tsx
+++ b/src/pages/-entry.tsx
@@ -19,6 +19,7 @@ import SortBottomSheet from '@/components/SortBottomSheet';
 import { useScroll } from '@/components/Wrapper/components/ScrollProvider';
 import { CURRENCY_TYPE } from '@/constants/currency';
 import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useUpdateBalance } from '@/hooks/update/useUpdateBalance';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
@@ -77,6 +78,7 @@ export default function Entry() {
   const selectedChainFilterId = useExtensionStorageStore((state) => state.selectedChainFilterId);
   const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
 
+  useAutoBalanceRefresh(selectedChainFilterId && [selectedChainFilterId]);
   useCurrentAccountAddedNFTsWithMetaData();
   const [search, setSearch] = useState('');
   const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);

--- a/src/pages/coin-detail/$coinId/-entry/components/AmountDetail/Cosmos.tsx
+++ b/src/pages/coin-detail/$coinId/-entry/components/AmountDetail/Cosmos.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from '@tanstack/react-router';
 
 import BalanceDisplay from '@/components/BalanceDisplay';
 import { COREUM_CHAINLIST_ID, KAVA_CHAINLIST_ID, NEUTRON_CHAINLIST_ID, NEUTRON_TESTNET_CHAINLIST_ID } from '@/constants/cosmos/chain';
-import { useAmount } from '@/hooks/cosmos/useAmount';
 import { useCommission } from '@/hooks/cosmos/useCommission';
+import { useIncentive } from '@/hooks/cosmos/useIncentive';
 import { useReward } from '@/hooks/cosmos/useReward';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
 import { Route as ClaimCommission } from '@/pages/wallet/claim-commission/$coinId';
@@ -29,7 +29,12 @@ export default function Cosmos({ coinId }: CosmosProps) {
 
   const isNTRN = [NEUTRON_CHAINLIST_ID, NEUTRON_TESTNET_CHAINLIST_ID].some((item) => item === parseCoinId(coinId).chainId);
 
-  const { incentiveAmount } = useAmount(coinId);
+  const incentive = useIncentive({
+    coinId,
+  });
+
+  const { id: denom } = parseCoinId(coinId);
+  const incentiveAmount = incentive?.data?.[denom] || '0';
 
   const reward = useReward({
     coinId,

--- a/src/pages/coin-detail/$coinId/-entry/index.tsx
+++ b/src/pages/coin-detail/$coinId/-entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Aptos from './aptos';
 import Bitcoin from './bitcoin';
@@ -12,6 +14,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
 
   const selectedAccountAsset = getAccountAsset();

--- a/src/pages/coin-detail/$coinId/manage-stake/-Entry/index.tsx
+++ b/src/pages/coin-detail/$coinId/manage-stake/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 import Iota from './Iota';
@@ -9,6 +11,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/pages/coin-overview/$coinId/-entry.tsx
+++ b/src/pages/coin-overview/$coinId/-entry.tsx
@@ -11,6 +11,7 @@ import IntersectionObserver from '@/components/common/IntersectionObserver';
 import CoinOverViewBox from '@/components/MainBox/CoinOverviewBox';
 import Search from '@/components/Search';
 import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useUpdateBalance } from '@/hooks/update/useUpdateBalance';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
 import { useGroupAccountAssets } from '@/hooks/useGroupAccountAssets';
@@ -18,7 +19,7 @@ import { Route as CoinDetail } from '@/pages/coin-detail/$coinId';
 import type { UniqueChainId } from '@/types/chain';
 import { getFilteredAssetsByChainId, getFilteredChainsByChainId, isStakeableAsset } from '@/utils/asset';
 import { minus, times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, isMatchingUniqueChainId } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isMatchingUniqueChainId } from '@/utils/queryParamGenerator';
 import { shorterAddress } from '@/utils/string';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -98,6 +99,10 @@ export default function Entry({ coinId }: EntryProps) {
   }, [baseCoinList, coinGeckoPrice, userCurrencyPreference, currentSelectedChainId, debouncedSearch.length, search, viewLimit]);
 
   const chainList = useMemo(() => getFilteredChainsByChainId(baseCoinList), [baseCoinList]);
+
+  const chainIdList = useMemo(() => chainList.map((item) => getUniqueChainId(item)), [chainList]);
+
+  useAutoBalanceRefresh(chainIdList);
 
   const currentSelectedChain = useMemo(
     () => chainList?.find((chain) => isMatchingUniqueChainId(chain, currentSelectedChainId)),

--- a/src/pages/popup/aptos/transaction/-entry.tsx
+++ b/src/pages/popup/aptos/transaction/-entry.tsx
@@ -56,7 +56,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentAptosNetwork } = useCurrentAptosNetwork();
-  useAutoBalanceRefresh(currentAptosNetwork && [getUniqueChainId(currentAptosNetwork)]);
+  useAutoBalanceRefresh(currentAptosNetwork ? [getUniqueChainId(currentAptosNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/aptos/transaction/-entry.tsx
+++ b/src/pages/popup/aptos/transaction/-entry.tsx
@@ -16,6 +16,7 @@ import { useEstimateGasPrice } from '@/hooks/aptos/useEstimateGasPrice';
 import { useSimulateTx } from '@/hooks/aptos/useSimulateTx';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -29,7 +30,7 @@ import type { AptosSignTransaction } from '@/types/message/inject/aptos';
 import { signTxSequentially } from '@/utils/aptos/sign';
 import { getOriginalTx } from '@/utils/aptos/tx';
 import { ceil, gt, times } from '@/utils/numbers';
-import { getCoinId } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
 
@@ -55,6 +56,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentAptosNetwork } = useCurrentAptosNetwork();
+  useAutoBalanceRefresh(currentAptosNetwork && [getUniqueChainId(currentAptosNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/bitcoin/send/-entry.tsx
+++ b/src/pages/popup/bitcoin/send/-entry.tsx
@@ -23,6 +23,7 @@ import { useEstimateSmartFee } from '@/hooks/bitcoin/useEstimateSmartFee';
 import { useUtxo } from '@/hooks/bitcoin/useUtxo';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -45,7 +46,7 @@ import type { BitSendBitcoin } from '@/types/message/inject/bitcoin';
 import { executeTransactionSequentially } from '@/utils/bitcoin/sign';
 import { ecpairFromPrivateKey, getTweakSigner, initBitcoinEcc } from '@/utils/bitcoin/tx';
 import { gt, minus, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
 import {
@@ -73,6 +74,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentBitcoinNetwork } = useCurrentBitcoinNetwork();
+  useAutoBalanceRefresh(currentBitcoinNetwork && [getUniqueChainId(currentBitcoinNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/bitcoin/send/-entry.tsx
+++ b/src/pages/popup/bitcoin/send/-entry.tsx
@@ -74,7 +74,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentBitcoinNetwork } = useCurrentBitcoinNetwork();
-  useAutoBalanceRefresh(currentBitcoinNetwork && [getUniqueChainId(currentBitcoinNetwork)]);
+  useAutoBalanceRefresh(currentBitcoinNetwork ? [getUniqueChainId(currentBitcoinNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
@@ -15,6 +15,7 @@ import { useBalance } from '@/hooks/bitcoin/useBalance';
 import { useCurrentBitcoinNetwork } from '@/hooks/bitcoin/useCurrentBitcoinNetwork';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -26,7 +27,7 @@ import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignPsbt } from '@/types/message/inject/bitcoin';
 import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getTweakSigner } from '@/utils/bitcoin/tx';
 import { gte, plus } from '@/utils/numbers';
-import { getCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
 import {
@@ -51,6 +52,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentBitcoinNetwork } = useCurrentBitcoinNetwork();
+  useAutoBalanceRefresh(currentBitcoinNetwork && [getUniqueChainId(currentBitcoinNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
@@ -52,7 +52,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentBitcoinNetwork } = useCurrentBitcoinNetwork();
-  useAutoBalanceRefresh(currentBitcoinNetwork && [getUniqueChainId(currentBitcoinNetwork)]);
+  useAutoBalanceRefresh(currentBitcoinNetwork ? [getUniqueChainId(currentBitcoinNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
@@ -15,6 +15,7 @@ import { useBalance } from '@/hooks/bitcoin/useBalance';
 import { useCurrentBitcoinNetwork } from '@/hooks/bitcoin/useCurrentBitcoinNetwork';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -26,7 +27,7 @@ import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignPsbts, BitSignPsbtsResposne } from '@/types/message/inject/bitcoin';
 import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getTweakSigner } from '@/utils/bitcoin/tx';
 import { gte, plus } from '@/utils/numbers';
-import { getCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
 import {
@@ -51,6 +52,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentBitcoinNetwork } = useCurrentBitcoinNetwork();
+  useAutoBalanceRefresh(currentBitcoinNetwork && [getUniqueChainId(currentBitcoinNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
@@ -52,7 +52,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentBitcoinNetwork } = useCurrentBitcoinNetwork();
-  useAutoBalanceRefresh(currentBitcoinNetwork && [getUniqueChainId(currentBitcoinNetwork)]);
+  useAutoBalanceRefresh(currentBitcoinNetwork ? [getUniqueChainId(currentBitcoinNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/cosmos/sign/amino/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/amino/-entry.tsx
@@ -17,6 +17,7 @@ import { useAdditionalFee } from '@/hooks/cosmos/useAdditionalFee';
 import { useFees } from '@/hooks/cosmos/useFees';
 import { useSimulate } from '@/hooks/cosmos/useSimulate';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -33,7 +34,7 @@ import { getCosmosFeeStepNames } from '@/utils/cosmos/fee';
 import { getPublicKeyType, signAmino } from '@/utils/cosmos/msg';
 import { protoTx, protoTxBytes } from '@/utils/cosmos/proto';
 import { ceil, divide, gt, gte, times } from '@/utils/numbers';
-import { getCoinId, isMatchingCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isMatchingCoinId, isSameChain } from '@/utils/queryParamGenerator';
 import { getUtf8BytesLength } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
 
@@ -57,6 +58,7 @@ type EntryProps = {
 export default function Entry({ request, chain }: EntryProps) {
   const { t } = useTranslation();
   const { deQueue } = useCurrentRequestQueue();
+  useAutoBalanceRefresh([getUniqueChainId(chain)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/cosmos/sign/direct/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/direct/-entry.tsx
@@ -20,6 +20,7 @@ import { useFees } from '@/hooks/cosmos/useFees';
 import { useProtoBuilderDecoder } from '@/hooks/cosmos/useProtoBuilderDecoder';
 import { useSimulate } from '@/hooks/cosmos/useSimulate';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -39,7 +40,7 @@ import { getPublicKeyType, signDirect } from '@/utils/cosmos/msg';
 import { decodeProtobufMessage, protoTxBytes } from '@/utils/cosmos/proto';
 import { toUint8Array } from '@/utils/crypto';
 import { ceil, divide, equal, gt, gte, times } from '@/utils/numbers';
-import { getCoinId, isMatchingCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isMatchingCoinId, isSameChain } from '@/utils/queryParamGenerator';
 import { getUtf8BytesLength } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
 
@@ -55,6 +56,7 @@ type EntryProps = {
 export default function Entry({ request, chain }: EntryProps) {
   const { t } = useTranslation();
   const { deQueue } = useCurrentRequestQueue();
+  useAutoBalanceRefresh([getUniqueChainId(chain)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/evm/transaction/-entry.tsx
+++ b/src/pages/popup/evm/transaction/-entry.tsx
@@ -19,6 +19,7 @@ import { useCurrentEVMNetwork } from '@/hooks/evm/useCurrentEvmNetwork';
 import { useDetermineTxType } from '@/hooks/evm/useDetermineTxType';
 import { useFee } from '@/hooks/evm/useFee';
 import { useTransactionCount } from '@/hooks/evm/useTransactionCount';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -31,7 +32,7 @@ import type { ResponseAppMessage } from '@/types/message/content';
 import type { EthSendTransaction, EthSendTransactionResponse, EthSignTransaction, EthSignTransactionResponse } from '@/types/message/inject/evm';
 import { signAndExecuteTxSequentially, signTxSequentially } from '@/utils/ethereum/sign';
 import { ceil, gt, plus, times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { hexOrDecimalToDecimal, isEqualsIgnoringCase, toHex } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
 
@@ -56,6 +57,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentEVMNetwork } = useCurrentEVMNetwork();
+  useAutoBalanceRefresh(currentEVMNetwork && [getUniqueChainId(currentEVMNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/evm/transaction/-entry.tsx
+++ b/src/pages/popup/evm/transaction/-entry.tsx
@@ -57,7 +57,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentEVMNetwork } = useCurrentEVMNetwork();
-  useAutoBalanceRefresh(currentEVMNetwork && [getUniqueChainId(currentEVMNetwork)]);
+  useAutoBalanceRefresh(currentEVMNetwork ? [getUniqueChainId(currentEVMNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/iota/transaction/-entry.tsx
+++ b/src/pages/popup/iota/transaction/-entry.tsx
@@ -16,6 +16,7 @@ import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
 import { useCurrentIotaNetwork } from '@/hooks/iota/useCurrentIotaNetwork';
 import { useDryRunTransaction } from '@/hooks/iota/useDryRunTransaction';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -27,7 +28,7 @@ import RawTx from '@/pages/popup/-components/RawTx';
 import type { IotaSignAndExecuteTransaction, IotaSignTransaction } from '@/types/message/inject/iota';
 import { signAndExecuteTxSequentially, signTxSequentially } from '@/utils/iota/sign';
 import { gt, minus, plus } from '@/utils/numbers';
-import { getCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
 
@@ -52,6 +53,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentIotaNetwork } = useCurrentIotaNetwork();
+  useAutoBalanceRefresh(currentIotaNetwork && [getUniqueChainId(currentIotaNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/iota/transaction/-entry.tsx
+++ b/src/pages/popup/iota/transaction/-entry.tsx
@@ -53,7 +53,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentIotaNetwork } = useCurrentIotaNetwork();
-  useAutoBalanceRefresh(currentIotaNetwork && [getUniqueChainId(currentIotaNetwork)]);
+  useAutoBalanceRefresh(currentIotaNetwork ? [getUniqueChainId(currentIotaNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/sui/transaction/-entry.tsx
+++ b/src/pages/popup/sui/transaction/-entry.tsx
@@ -16,6 +16,7 @@ import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
 import { useCurrentSuiNetwork } from '@/hooks/sui/useCurrentSuiNetwork';
 import { useDryRunTransaction } from '@/hooks/sui/useDryRunTransaction';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCurrentAccount } from '@/hooks/useCurrentAccount';
 import { useCurrentPassword } from '@/hooks/useCurrentPassword';
@@ -26,7 +27,7 @@ import DappInfo from '@/pages/popup/-components/DappInfo';
 import RawTx from '@/pages/popup/-components/RawTx';
 import type { SuiSignAndExecuteTransaction, SuiSignAndExecuteTransactionBlock, SuiSignTransaction, SuiSignTransactionBlock } from '@/types/message/inject/sui';
 import { gt, minus, plus } from '@/utils/numbers';
-import { getCoinId, isSameChain } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
 import { signAndExecuteTxSequentially, signTxSequentially } from '@/utils/sui/sign';
 import { getSiteTitle } from '@/utils/website';
@@ -52,6 +53,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentSuiNetwork } = useCurrentSuiNetwork();
+  useAutoBalanceRefresh(currentSuiNetwork && [getUniqueChainId(currentSuiNetwork)]);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/popup/sui/transaction/-entry.tsx
+++ b/src/pages/popup/sui/transaction/-entry.tsx
@@ -53,7 +53,7 @@ export default function Entry({ request }: EntryProps) {
   const { deQueue } = useCurrentRequestQueue();
 
   const { currentSuiNetwork } = useCurrentSuiNetwork();
-  useAutoBalanceRefresh(currentSuiNetwork && [getUniqueChainId(currentSuiNetwork)]);
+  useAutoBalanceRefresh(currentSuiNetwork ? [getUniqueChainId(currentSuiNetwork)] : undefined);
 
   const { currentAccount, incrementTxCountForOrigin } = useCurrentAccount();
   const { currentPassword } = useCurrentPassword();

--- a/src/pages/wallet/cancel-unstaking/$coinId/-Entry/index.tsx
+++ b/src/pages/wallet/cancel-unstaking/$coinId/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 
@@ -10,6 +12,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId, validatorAddress, creationHeight, amount }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/pages/wallet/claim-all-rewards/$coinId/-Entry/index.tsx
+++ b/src/pages/wallet/claim-all-rewards/$coinId/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 
@@ -7,6 +9,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/pages/wallet/claim-commission/$coinId/-Entry/index.tsx
+++ b/src/pages/wallet/claim-commission/$coinId/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 
@@ -7,6 +9,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/pages/wallet/claim-rewards/$coinId/$validatorAddress/-Entry/index.tsx
+++ b/src/pages/wallet/claim-rewards/$coinId/$validatorAddress/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 
@@ -8,6 +10,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId, validatorAddress }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/pages/wallet/nft-send/$id/-Entry/index.tsx
+++ b/src/pages/wallet/nft-send/$id/-Entry/index.tsx
@@ -1,4 +1,8 @@
+import { useMemo } from 'react';
+
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useCurrentAccountNFT } from '@/hooks/useCurrentAccountNFT';
+import { getUniqueChainIdWithManual } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 import EVM from './EVM';
@@ -12,6 +16,12 @@ export default function Entry({ id }: EntryProps) {
   const { currentAccountNFTs } = useCurrentAccountNFT();
 
   const selectedNFT = currentAccountNFTs.flat.find((nft) => nft.id === id);
+  const uniqueChainId = useMemo(
+    () => (selectedNFT?.chainId && selectedNFT.chainType ? getUniqueChainIdWithManual(selectedNFT.chainId, selectedNFT.chainType) : undefined),
+    [selectedNFT?.chainId, selectedNFT?.chainType],
+  );
+
+  useAutoBalanceRefresh(uniqueChainId && [uniqueChainId]);
 
   if (selectedNFT?.chainType === 'cosmos') {
     return <Cosmos id={id} />;

--- a/src/pages/wallet/send/$coinId/-Entry/index.tsx
+++ b/src/pages/wallet/send/$coinId/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Aptos from './Aptos';
 import Bitcoin from './Bitcoin';
@@ -12,6 +14,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
 
   const selectedAccountAsset = getAccountAsset();

--- a/src/pages/wallet/stake/$coinId/-Entry/index.tsx
+++ b/src/pages/wallet/stake/$coinId/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 import Iota from './Iota';
@@ -10,6 +12,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId, validatorAddress }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/pages/wallet/unstake/$coinId/-Entry/index.tsx
+++ b/src/pages/wallet/unstake/$coinId/-Entry/index.tsx
@@ -1,4 +1,6 @@
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
+import { getUniqueChainIdFromCoinId } from '@/utils/queryParamGenerator';
 
 import Cosmos from './Cosmos';
 import Iota from './Iota';
@@ -11,6 +13,7 @@ type EntryProps = {
 };
 
 export default function Entry({ coinId, validatorAddress, objectId }: EntryProps) {
+  useAutoBalanceRefresh([getUniqueChainIdFromCoinId(coinId)]);
   const { getAccountAsset } = useGetAccountAsset({ coinId });
   const currentCoin = getAccountAsset();
 

--- a/src/script/service-worker/index.ts
+++ b/src/script/service-worker/index.ts
@@ -230,9 +230,9 @@ chrome.runtime.onMessage.addListener((message: ServiceWorkerMessage, sender, sen
       }
 
       if (method === 'updateChainSpecificBalance') {
-        const [id, chainId, address] = params;
+        const [id, chainId] = params;
 
-        const key = `${id}:${chainId}:${address}`;
+        const key = `${id}:${chainId}`;
         if (isInProgress(method, key)) {
           devLogger.log(`[${method}] Skipped (already in progress) for id=${key}`);
           sendResponse(null);
@@ -242,7 +242,7 @@ chrome.runtime.onMessage.addListener((message: ServiceWorkerMessage, sender, sen
         setInProgress(method, key);
 
         try {
-          await updateSpecificChainBalance(id, chainId, address);
+          await updateSpecificChainBalance(id, chainId);
         } catch (e) {
           devLogger.error(`${method} error`, e);
         } finally {
@@ -253,9 +253,9 @@ chrome.runtime.onMessage.addListener((message: ServiceWorkerMessage, sender, sen
       }
 
       if (method === 'updateChainSpecificStakingBalance') {
-        const [id, chainId, address] = params;
+        const [id, chainId] = params;
 
-        const key = `${id}:${chainId}:${address}`;
+        const key = `${id}:${chainId}`;
 
         if (isInProgress(method, key)) {
           devLogger.log(`[${method}] Skipped (already in progress) for id=${key}`);
@@ -265,8 +265,8 @@ chrome.runtime.onMessage.addListener((message: ServiceWorkerMessage, sender, sen
 
         setInProgress(method, key);
         try {
-          await updateSpecificChainBalance(id, chainId, address);
-          await updateSpecificChainStaking(id, chainId, address);
+          await updateSpecificChainBalance(id, chainId);
+          await updateSpecificChainStaking(id, chainId);
         } catch (e) {
           devLogger.error(`${method} error`, e);
         } finally {

--- a/src/script/service-worker/update/balance.ts
+++ b/src/script/service-worker/update/balance.ts
@@ -571,7 +571,6 @@ async function bitcoinBalances(id: string, { chainId }: BalanceFetchOption = {})
 
   const isUpdateSpecificAddress = !!chainId;
 
-  // FIXME 이거 chainId만 물면 4타입 다 업데이트하는거라 비효율적.
   const addressList = isUpdateSpecificAddress
     ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;

--- a/src/script/service-worker/update/balance.ts
+++ b/src/script/service-worker/update/balance.ts
@@ -12,6 +12,7 @@ import type {
   AccountAddressBalanceAptos,
   AccountAddressBalanceBitcoin,
   AccountAddressBalanceCosmos,
+  AccountAddressBalanceErc20,
   AccountAddressBalanceEvm,
   AccountAddressBalanceIota,
   AccountAddressBalanceSui,
@@ -21,9 +22,20 @@ import type { AptosResourceResponse } from '@/types/aptos/api';
 import type { AssetId } from '@/types/asset';
 import type { AccountDetail } from '@/types/bitcoin/balance';
 import type { ChainId, ChainType, UniqueChainId } from '@/types/chain';
+import type { Cw20Balance } from '@/types/cosmos/balance';
+import type { Erc20Balance } from '@/types/evm/balance';
 import type { ExtensionStorage } from '@/types/extension';
-import { upsertList } from '@/utils/array';
 import { getWithFullResponse } from '@/utils/axios';
+import {
+  upsertAptosBalance,
+  upsertBitcoinBalance,
+  upsertCosmosBalance,
+  upsertCW20Balance,
+  upsertERC20Balance,
+  upsertEVMBalance,
+  upsertIotaBalance,
+  upsertSuiBalance,
+} from '@/utils/balanceUpsert';
 import {
   fetchCoreumSpendableBalances,
   fetchCosmosBalances,
@@ -36,11 +48,9 @@ import { fetchIotaBalances } from '@/utils/iota/fetch/balance';
 import { minus } from '@/utils/numbers';
 import { getUniqueChainIdWithManual, isMatchingUniqueChainId, parseUniqueChainId } from '@/utils/queryParamGenerator';
 import { getExtensionLocalStorage } from '@/utils/storage';
-import { isEqualsIgnoringCase } from '@/utils/string';
 import { fetchSuiBalances } from '@/utils/sui/fetch/balance';
 
 export interface BalanceFetchOption {
-  address?: string;
   chainId?: UniqueChainId;
 }
 interface CosmosBalancesOption extends BalanceFetchOption {
@@ -117,12 +127,12 @@ export async function updateActiveAssetsBalance(id: string) {
   }
 }
 
-export async function updateSpecificChainBalance(id: string, chainId: UniqueChainId, address: string) {
-  console.time(`chain-balance-${id}-${chainId}-${address}`);
+export async function updateSpecificChainBalance(id: string, chainId: UniqueChainId) {
+  console.time(`chain-balance-${id}-${chainId}`);
   try {
     await getAccount(id);
 
-    await fetchChainBalanceByType(id, chainId, address);
+    await fetchChainBalanceByType(id, chainId);
   } catch (error) {
     if (axios.isAxiosError(error)) {
       console.error(`${error.request?.method} ${error.request?.url} ${error.cause?.message}`);
@@ -130,11 +140,11 @@ export async function updateSpecificChainBalance(id: string, chainId: UniqueChai
       console.error(error);
     }
   } finally {
-    console.timeEnd(`chain-balance-${id}-${chainId}-${address}`);
+    console.timeEnd(`chain-balance-${id}-${chainId}`);
   }
 }
 
-async function fetchChainBalanceByType(id: string, chainId: UniqueChainId, address: string) {
+async function fetchChainBalanceByType(id: string, chainId: UniqueChainId) {
   const addedCustomChainList = await getAddedCustomChains();
 
   const { chainType } = parseUniqueChainId(chainId);
@@ -142,33 +152,33 @@ async function fetchChainBalanceByType(id: string, chainId: UniqueChainId, addre
 
   if (isCustomChain) {
     if (chainType === 'cosmos') {
-      await Promise.all([customCosmosBalances(id, { address, chainId }), customCw20Balance(id, { address, chainId })]);
+      await Promise.all([customCosmosBalances(id, { chainId }), customCw20Balance(id, { chainId })]);
     }
 
     if (chainType === 'evm') {
-      await Promise.all([customEvmBalances(id, { address, chainId }), customErc20Balance(id, { address, chainId })]);
+      await Promise.all([customEvmBalances(id, { chainId }), customErc20Balance(id, { chainId })]);
     }
   } else {
     if (chainType === 'cosmos') {
-      await Promise.all([cosmosBalances(id, { address, chainId }), cw20Balance(id, { address, chainId }), customCw20Balance(id, { address, chainId })]);
+      await Promise.all([cosmosBalances(id, { chainId }), cw20Balance(id, { chainId }), customCw20Balance(id, { chainId })]);
     }
 
     if (chainType === 'evm') {
-      await Promise.all([evmBalances(id, { address, chainId }), erc20Balance(id, { address, chainId }), customErc20Balance(id, { address, chainId })]);
+      await Promise.all([evmBalances(id, { chainId }), erc20Balance(id, { chainId }), customErc20Balance(id, { chainId })]);
     }
 
     if (chainType === 'aptos') {
-      await Promise.all([aptosBalances(id, { address, chainId })]);
+      await Promise.all([aptosBalances(id, { chainId })]);
     }
 
     if (chainType === 'sui') {
-      await Promise.all([suiBalances(id, { address, chainId })]);
+      await Promise.all([suiBalances(id, { chainId })]);
     }
     if (chainType === 'bitcoin') {
-      await Promise.all([bitcoinBalances(id, { address, chainId })]);
+      await Promise.all([bitcoinBalances(id, { chainId })]);
     }
     if (chainType === 'iota') {
-      await Promise.all([iotaBalances(id, { address, chainId })]);
+      await Promise.all([iotaBalances(id, { chainId })]);
     }
   }
 }
@@ -310,32 +320,26 @@ export async function initAssests(id: string) {
     await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-hidden-assetIds`>>({ [`${id}-hidden-assetIds`]: hiddenAssetIds });
   }
 }
-interface UpsertItemBase {
-  address: string;
-  chainId: string | number;
-  chainType: string;
-  id: string;
-}
 
-const isSameUpsertItem = (a: UpsertItemBase, b: UpsertItemBase) =>
-  isEqualsIgnoringCase(a.address, b.address) && a.chainId === b.chainId && a.chainType === b.chainType && a.id === b.id;
+async function cosmosBalances(id: string, { isMinimal = false, chainId }: CosmosBalancesOption = {}) {
+  const startUpdateTime = Date.now();
 
-async function cosmosBalances(id: string, { isMinimal = false, address, chainId }: CosmosBalancesOption = {}) {
   const accountAddress = await getAccountAddress(id);
   const { cosmosChains } = await getChains();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-cosmos`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isMinimal
     ? accountAddress.filter((addr) => defaultCosmosCoinList.some((chain) => chain.chainId === addr.chainId && chain.chainType === addr.chainType))
     : isUpdateSpecificAddress
-      ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+      ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
       : accountAddress;
+
+  const targetChain = chainId && cosmosChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = cosmosChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || cosmosChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -373,66 +377,61 @@ async function cosmosBalances(id: string, { isMinimal = false, address, chainId 
 
             await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-locked-cosmos`>>({ [`${id}-locked-cosmos`]: [lockedResult] });
 
-            const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances: spendableBalances, lastUpdatedAtMs: Date.now() };
+            const result: AccountAddressBalanceCosmos = {
+              id,
+              chainId,
+              chainType,
+              address,
+              balances: spendableBalances,
+              lastUpdatedAtMs: startUpdateTime,
+              status: 'success',
+            };
 
             return result;
           } catch {
             await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-locked-cosmos`>>({ [`${id}-locked-cosmos`]: [] });
 
-            const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: Date.now() };
+            const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: startUpdateTime, status: 'error' };
             return result;
           }
         }
 
-        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedCosmosBalance = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balances = i.balances;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-balance-cosmos`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-cosmos`>>({ [`${id}-balance-cosmos`]: updatedCosmosBalance });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-cosmos`>>({ [`${id}-balance-cosmos`]: results });
-  }
+  const updatedCosmosBalance = upsertCosmosBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-cosmos`>>({ [`${id}-balance-cosmos`]: updatedCosmosBalance });
 }
 
-async function customCosmosBalances(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function customCosmosBalances(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const customAccountAddress = await getCustomAccountAddress(id);
   const addedCustomChains = await getAddedCustomChains();
-  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-cosmos`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? customAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? customAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : customAccountAddress;
+
+  const addedCosmosCustomChains = addedCustomChains.filter((chain) => chain.chainType === 'cosmos');
+
+  const targetChain = chainId && addedCosmosCustomChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const addedCosmosCustomChains = addedCustomChains.filter((chain) => chain.chainType === 'cosmos');
-      const chain = addedCosmosCustomChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || addedCosmosCustomChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -446,56 +445,42 @@ async function customCosmosBalances(id: string, { address, chainId }: BalanceFet
       try {
         const balances = await fetchCosmosBalances(address, lcdUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceCosmos = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedCustomCosmosBalance = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balances = i.balances;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-cosmos`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-cosmos`>>({ [`${id}-custom-balance-cosmos`]: updatedCustomCosmosBalance });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-cosmos`>>({ [`${id}-custom-balance-cosmos`]: results });
-  }
+  const updatedCustomCosmosBalance = upsertCosmosBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-cosmos`>>({ [`${id}-custom-balance-cosmos`]: updatedCustomCosmosBalance });
 }
 
-async function evmBalances(id: string, { isMinimal = false, address, chainId }: EVMBalancesOption = {}) {
+async function evmBalances(id: string, { isMinimal = false, chainId }: EVMBalancesOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { evmChains } = await getChains();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-evm`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isMinimal
     ? accountAddress.filter((addr) => defaultEvmCoinList.find((chain) => chain.chainId === addr.chainId && chain.chainType === addr.chainType))
     : isUpdateSpecificAddress
-      ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+      ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
       : accountAddress;
 
+  const targetChain = chainId && evmChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
+
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = evmChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || evmChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -510,56 +495,42 @@ async function evmBalances(id: string, { isMinimal = false, address, chainId }: 
       try {
         const balance = await fetchEVMBalances(address, rpcUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-
-        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance: '0x0', lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance: '0x0', lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedEVMBalance = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balance = i.balance;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-balance-evm`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-evm`>>({ [`${id}-balance-evm`]: updatedEVMBalance });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-evm`>>({ [`${id}-balance-evm`]: results });
-  }
+  const updatedEVMBalance = upsertEVMBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-evm`>>({ [`${id}-balance-evm`]: updatedEVMBalance });
 }
 
-async function customEvmBalances(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function customEvmBalances(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const customAccountAddress = await getCustomAccountAddress(id);
   const addedCustomChains = await getAddedCustomChains();
-  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-evm`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? customAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? customAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : customAccountAddress;
+
+  const addedEVMCustomChains = addedCustomChains.filter((chain) => chain.chainType === 'evm');
+
+  const targetChain = chainId && addedEVMCustomChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const addedEVMCustomChains = addedCustomChains.filter((chain) => chain.chainType === 'evm');
-      const chain = addedEVMCustomChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || addedEVMCustomChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
 
       return { ...addr, chain };
     })
@@ -575,54 +546,41 @@ async function customEvmBalances(id: string, { address, chainId }: BalanceFetchO
       try {
         const balance = await fetchEVMBalances(address, rpcUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance: '0x0', lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceEvm = { id, chainId, chainType, address, balance: '0x0', lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedCustomEVMBalance = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balance = i.balance;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-evm`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-evm`>>({ [`${id}-custom-balance-evm`]: updatedCustomEVMBalance });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-evm`>>({ [`${id}-custom-balance-evm`]: results });
-  }
+  const updatedCustomEVMBalance = upsertEVMBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-evm`>>({ [`${id}-custom-balance-evm`]: updatedCustomEVMBalance });
 }
 
-async function bitcoinBalances(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function bitcoinBalances(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { bitcoinChains } = await getChains();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-bitcoin`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
+  // FIXME 이거 chainId만 물면 4타입 다 업데이트하는거라 비효율적.
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
+
+  const targetChain = chainId && bitcoinChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = bitcoinChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || bitcoinChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -646,23 +604,10 @@ async function bitcoinBalances(id: string, { address, chainId }: BalanceFetchOpt
           mempoolStats: response.data?.mempool_stats || undefined,
         };
 
-        const result: AccountAddressBalanceBitcoin = { id, chainId, chainType, address, balance, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceBitcoin = { id, chainId, chainType, address, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-
         const result: AccountAddressBalanceBitcoin = {
           id,
           chainId,
@@ -672,39 +617,38 @@ async function bitcoinBalances(id: string, { address, chainId }: BalanceFetchOpt
             chainStats: undefined,
             mempoolStats: undefined,
           },
-          lastUpdatedAtMs: Date.now(),
+          lastUpdatedAtMs: startUpdateTime,
+          status: 'error',
         };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedBitcoinBalances = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balance = i.balance;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-balance-bitcoin`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-bitcoin`>>({ [`${id}-balance-bitcoin`]: updatedBitcoinBalances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-bitcoin`>>({ [`${id}-balance-bitcoin`]: results });
-  }
+  const updatedBitcoinBalances = upsertBitcoinBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-bitcoin`>>({ [`${id}-balance-bitcoin`]: updatedBitcoinBalances });
 }
 
-async function aptosBalances(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function aptosBalances(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { aptosChains } = await getChains();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-aptos`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
+
+  const targetChain = chainId && aptosChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = aptosChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || aptosChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -733,55 +677,40 @@ async function aptosBalances(id: string, { address, chainId }: BalanceFetchOptio
 
         const balances = response.filter((resource) => resource.type?.startsWith('0x1::coin::CoinStore'));
 
-        const result: AccountAddressBalanceAptos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceAptos = { id, chainId, chainType, address, balances, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-
-        const result: AccountAddressBalanceAptos = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceAptos = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedAptosBalances = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balances = i.balances;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-balance-aptos`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-aptos`>>({ [`${id}-balance-aptos`]: updatedAptosBalances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-aptos`>>({ [`${id}-balance-aptos`]: results });
-  }
+  const updatedAptosBalances = upsertAptosBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-aptos`>>({ [`${id}-balance-aptos`]: updatedAptosBalances });
 }
 
-async function suiBalances(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function suiBalances(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { suiChains } = await getChains();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-sui`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
+
+  const targetChain = chainId && suiChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = suiChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || suiChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -796,55 +725,40 @@ async function suiBalances(id: string, { address, chainId }: BalanceFetchOption 
       try {
         const balances = await fetchSuiBalances(address, rpcUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressBalanceSui = { id, chainId, chainType, address, balances, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceSui = { id, chainId, chainType, address, balances, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-
-        const result: AccountAddressBalanceSui = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceSui = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedSuiBalances = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balances = i.balances;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-balance-sui`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-sui`>>({ [`${id}-balance-sui`]: updatedSuiBalances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-sui`>>({ [`${id}-balance-sui`]: results });
-  }
+  const updatedSuiBalances = upsertSuiBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-sui`>>({ [`${id}-balance-sui`]: updatedSuiBalances });
 }
 
-async function iotaBalances(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function iotaBalances(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { iotaChains } = await getChains();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-iota`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
+
+  const targetChain = chainId && iotaChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = iotaChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || iotaChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -859,47 +773,30 @@ async function iotaBalances(id: string, { address, chainId }: BalanceFetchOption
       try {
         const balances = await fetchIotaBalances(address, rpcUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressBalanceIota = { id, chainId, chainType, address, balances, lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceIota = { id, chainId, chainType, address, balances, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
         return result;
       } catch {
-        const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-
-        if (target) {
-          if (!target.lastUpdatedAtMs) {
-            return {
-              ...target,
-              lastUpdatedAtMs: Date.now(),
-            };
-          }
-
-          return target;
-        }
-
-        const result: AccountAddressBalanceIota = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: Date.now() };
+        const result: AccountAddressBalanceIota = { id, chainId, chainType, address, balances: [], lastUpdatedAtMs: startUpdateTime, status: 'error' };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedIotaBalances = upsertList(stored, results, isSameUpsertItem, (e, i) => {
-      e.balances = i.balances;
-      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
-    });
+  const stored = (await getExtensionLocalStorage(`${id}-balance-iota`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-iota`>>({ [`${id}-balance-iota`]: updatedIotaBalances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-iota`>>({ [`${id}-balance-iota`]: results });
-  }
+  const updatedIotaBalances = upsertIotaBalance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-iota`>>({ [`${id}-balance-iota`]: updatedIotaBalances });
 }
 
-async function erc20Balance(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function erc20Balance(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const hiddenAssets = await getHiddenAssets(id);
   const { evmChains } = await getChains();
   const { erc20Assets } = await getAssets();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-erc20`)) || [];
 
   const erc20AssetsToDisplay = erc20Assets.filter((asset) => {
     const isAssetVisible = !hiddenAssets.find(
@@ -910,15 +807,17 @@ async function erc20Balance(id: string, { address, chainId }: BalanceFetchOption
     return isAssetVisible || isPreload;
   });
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
+
+  const targetChain = chainId && evmChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = evmChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || evmChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -943,43 +842,25 @@ async function erc20Balance(id: string, { address, chainId }: BalanceFetchOption
             multicallWrapperOption,
           );
 
-          const balances = allBalances.map((item) => {
-            if (item.isError) {
-              const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-              const realTarget = target?.balances.find((storedItem) => isEqualsIgnoringCase(storedItem.contract, item.contract));
-
-              if (realTarget) {
-                if (!realTarget.lastUpdatedAtMs) {
-                  return {
-                    ...realTarget,
-                    lastUpdatedAtMs: Date.now(),
-                  };
-                }
-
-                return realTarget;
-              }
-
-              return {
-                contract: item.contract,
-                balance: '0',
-                lastUpdatedAtMs: Date.now(),
-              };
-            }
-
-            return item;
+          const balances: Erc20Balance[] = allBalances.map((item) => {
+            return {
+              ...item,
+              lastUpdatedAtMs: startUpdateTime,
+            };
           });
 
-          const result = { id, chainId, chainType, address, balances };
+          const result: AccountAddressBalanceErc20 = { id, chainId, chainType, address, balances };
 
           return result;
         } catch {
-          const defaultAssets = assets.map((item) => ({
+          const defaultAssets: Erc20Balance[] = assets.map((item) => ({
             contract: item.id,
             balance: '0',
-            lastUpdatedAtMs: Date.now(),
+            lastUpdatedAtMs: startUpdateTime,
+            status: 'error',
           }));
 
-          const result = { id, chainId, chainType, address, balances: defaultAssets };
+          const result: AccountAddressBalanceErc20 = { id, chainId, chainType, address, balances: defaultAssets };
 
           return result;
         }
@@ -992,47 +873,34 @@ async function erc20Balance(id: string, { address, chainId }: BalanceFetchOption
             try {
               const balance = await fetchERC20Balances(address, contractAddress, rpcUrls.map((item) => item.url).filter(Boolean));
 
-              const result = { contract: contractAddress, balance, lastUpdatedAtMs: Date.now() };
+              const result: Erc20Balance = { contract: contractAddress, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
               return result;
             } catch {
-              const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-              const realTarget = target?.balances.find((storedItem) => isEqualsIgnoringCase(storedItem.contract, asset.id));
-
-              if (realTarget) {
-                if (!realTarget.lastUpdatedAtMs) {
-                  return {
-                    ...realTarget,
-                    lastUpdatedAtMs: Date.now(),
-                  };
-                }
-
-                return realTarget;
-              }
-
               return {
                 contract: contractAddress,
                 balance: '0',
-                lastUpdatedAtMs: Date.now(),
-              };
+                lastUpdatedAtMs: startUpdateTime,
+                status: 'error',
+              } as Erc20Balance;
             }
           });
 
-        const result = { id, chainId, chainType, address, balances: allBalances };
+        const result: AccountAddressBalanceErc20 = { id, chainId, chainType, address, balances: allBalances };
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedERC20Balances = upsertList(stored, results, isSameUpsertItem, (e, i) => (e.balances = i.balances));
+  const stored = (await getExtensionLocalStorage(`${id}-balance-erc20`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-erc20`>>({ [`${id}-balance-erc20`]: updatedERC20Balances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-erc20`>>({ [`${id}-balance-erc20`]: results });
-  }
+  const updatedERC20Balances = upsertERC20Balance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-erc20`>>({ [`${id}-balance-erc20`]: updatedERC20Balances });
 }
 
-async function customErc20Balance(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function customErc20Balance(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const allAccountAddress = await getAllAccountAddress(id);
 
   const allChain = await getAllChains();
@@ -1040,17 +908,18 @@ async function customErc20Balance(id: string, { address, chainId }: BalanceFetch
   const allEVMChains = allChain.filter((chain) => chain.chainType === 'evm');
 
   const { customErc20Assets } = await getAssets();
-  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-erc20`)) || [];
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? allAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? allAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : allAccountAddress;
+
+  const targetChain = chainId && allEVMChains.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = allEVMChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || allEVMChains.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -1076,42 +945,24 @@ async function customErc20Balance(id: string, { address, chainId }: BalanceFetch
             multicallWrapperOption,
           );
 
-          const balances = allBalances.map((item) => {
-            if (item.isError) {
-              const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-              const realTarget = target?.balances.find((storedItem) => isEqualsIgnoringCase(storedItem.contract, item.contract));
-
-              if (realTarget) {
-                if (!realTarget.lastUpdatedAtMs) {
-                  return {
-                    ...realTarget,
-                    lastUpdatedAtMs: Date.now(),
-                  };
-                }
-
-                return realTarget;
-              }
-
-              return {
-                contract: item.contract,
-                balance: '0',
-                lastUpdatedAtMs: Date.now(),
-              };
-            }
-
-            return item;
+          const balances: Erc20Balance[] = allBalances.map((item) => {
+            return {
+              ...item,
+              lastUpdatedAtMs: startUpdateTime,
+            };
           });
 
-          const result = { id, chainId, chainType, address, balances };
+          const result: AccountAddressBalanceErc20 = { id, chainId, chainType, address, balances };
           return result;
         } catch {
-          const defaultAssets = assets.map((item) => ({
+          const defaultAssets: Erc20Balance[] = assets.map((item) => ({
             contract: item.id,
             balance: '0',
-            lastUpdatedAtMs: Date.now(),
+            lastUpdatedAtMs: startUpdateTime,
+            status: 'error',
           }));
 
-          const result = { id, chainId, chainType, address, balances: defaultAssets };
+          const result: AccountAddressBalanceErc20 = { id, chainId, chainType, address, balances: defaultAssets };
 
           return result;
         }
@@ -1124,52 +975,38 @@ async function customErc20Balance(id: string, { address, chainId }: BalanceFetch
             try {
               const balance = await fetchERC20Balances(address, contractAddress, rpcUrls.map((item) => item.url).filter(Boolean));
 
-              const result = { contract: contractAddress, balance, lastUpdatedAtMs: Date.now() };
+              const result: Erc20Balance = { contract: contractAddress, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
               return result;
             } catch {
-              const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-              const realTarget = target?.balances.find((storedItem) => isEqualsIgnoringCase(storedItem.contract, asset.id));
-
-              if (realTarget) {
-                if (!realTarget.lastUpdatedAtMs) {
-                  return {
-                    ...realTarget,
-                    lastUpdatedAtMs: Date.now(),
-                  };
-                }
-
-                return realTarget;
-              }
-
               return {
                 contract: asset.id,
                 balance: '0',
-                lastUpdatedAtMs: Date.now(),
-              };
+                lastUpdatedAtMs: startUpdateTime,
+                status: 'error',
+              } as Erc20Balance;
             }
           });
 
-        const result = { id, chainId, chainType, address, balances: allBalances };
+        const result: AccountAddressBalanceErc20 = { id, chainId, chainType, address, balances: allBalances };
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedCustomERC20Balances = upsertList(stored, results, isSameUpsertItem, (e, i) => (e.balances = i.balances));
+  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-erc20`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-erc20`>>({ [`${id}-custom-balance-erc20`]: updatedCustomERC20Balances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-erc20`>>({ [`${id}-custom-balance-erc20`]: results });
-  }
+  const updatedCustomERC20Balances = upsertERC20Balance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-erc20`>>({ [`${id}-custom-balance-erc20`]: updatedCustomERC20Balances });
 }
 
-async function cw20Balance(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function cw20Balance(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const hiddenAssets = await getHiddenAssets(id);
   const { cosmosChains } = await getChains();
   const { cw20Assets } = await getAssets();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-cw20`)) || [];
 
   const cw20AssetsWithoutHidden = cw20Assets.filter((asset) => {
     const isAssetVisible = !hiddenAssets.find(
@@ -1182,15 +1019,17 @@ async function cw20Balance(id: string, { address, chainId }: BalanceFetchOption 
 
   const cosmosChainsWithCosmwasm = cosmosChains.filter((chain) => chain.isCosmwasm);
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
+
+  const targetChain = chainId && cosmosChainsWithCosmwasm.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = cosmosChainsWithCosmwasm.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || cosmosChainsWithCosmwasm.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -1210,29 +1049,16 @@ async function cw20Balance(id: string, { address, chainId }: BalanceFetchOption 
           try {
             const balance = await fetchCW20Balances(address, contractAddress, lcdUrls.map((item) => item.url).filter(Boolean));
 
-            const result = { contract: contractAddress, balance, lastUpdatedAtMs: Date.now() };
+            const result: Cw20Balance = { contract: contractAddress, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
             return result;
           } catch {
-            const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-            const realTarget = target?.balances.find((storedItem) => isEqualsIgnoringCase(storedItem.contract, asset.id));
-
-            if (realTarget) {
-              if (!realTarget.lastUpdatedAtMs) {
-                return {
-                  ...realTarget,
-                  lastUpdatedAtMs: Date.now(),
-                };
-              }
-
-              return realTarget;
-            }
-
             return {
               contract: contractAddress,
               balance: '0',
-              lastUpdatedAtMs: Date.now(),
-            };
+              lastUpdatedAtMs: startUpdateTime,
+              status: 'error',
+            } as Cw20Balance;
           }
         });
 
@@ -1240,16 +1066,16 @@ async function cw20Balance(id: string, { address, chainId }: BalanceFetchOption 
       return result;
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedCW20Balances = upsertList(stored, results, isSameUpsertItem, (e, i) => (e.balances = i.balances));
+  const stored = (await getExtensionLocalStorage(`${id}-balance-cw20`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-cw20`>>({ [`${id}-balance-cw20`]: updatedCW20Balances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-cw20`>>({ [`${id}-balance-cw20`]: results });
-  }
+  const updatedCW20Balances = upsertCW20Balance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-balance-cw20`>>({ [`${id}-balance-cw20`]: updatedCW20Balances });
 }
 
-async function customCw20Balance(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function customCw20Balance(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const allAccountAddress = await getAllAccountAddress(id);
 
   const allChain = await getAllChains();
@@ -1257,19 +1083,20 @@ async function customCw20Balance(id: string, { address, chainId }: BalanceFetchO
   const allCosmosChains = allChain.filter((chain) => chain.chainType === 'cosmos');
 
   const { customCw20Assets } = await getAssets();
-  const stored = (await getExtensionLocalStorage(`${id}-balance-cw20`)) || [];
 
   const cosmosChainsWithCosmwasm = allCosmosChains.filter((chain) => chain.isCosmwasm);
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? allAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? allAccountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : allAccountAddress;
+
+  const targetChain = chainId && cosmosChainsWithCosmwasm.find((chain) => isMatchingUniqueChainId(chain, chainId));
 
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = cosmosChainsWithCosmwasm.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || cosmosChainsWithCosmwasm.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -1289,29 +1116,16 @@ async function customCw20Balance(id: string, { address, chainId }: BalanceFetchO
           try {
             const balance = await fetchCW20Balances(address, contractAddress, lcdUrls.map((item) => item.url).filter(Boolean));
 
-            const result = { contract: contractAddress, balance, lastUpdatedAtMs: Date.now() };
+            const result: Cw20Balance = { contract: contractAddress, balance, lastUpdatedAtMs: startUpdateTime, status: 'success' };
 
             return result;
           } catch {
-            const target = stored.find((store) => store.chainId === chainId && store.chainType === chainType && isEqualsIgnoringCase(store.address, address));
-            const realTarget = target?.balances.find((storedItem) => isEqualsIgnoringCase(storedItem.contract, asset.id));
-
-            if (realTarget) {
-              if (!realTarget.lastUpdatedAtMs) {
-                return {
-                  ...realTarget,
-                  lastUpdatedAtMs: Date.now(),
-                };
-              }
-
-              return realTarget;
-            }
-
             return {
               contract: contractAddress,
               balance: '0',
-              lastUpdatedAtMs: Date.now(),
-            };
+              lastUpdatedAtMs: startUpdateTime,
+              status: 'error',
+            } as Cw20Balance;
           }
         });
 
@@ -1319,11 +1133,9 @@ async function customCw20Balance(id: string, { address, chainId }: BalanceFetchO
       return result;
     });
 
-  if (isUpdateSpecificAddress) {
-    const updatedCustomCW20Balances = upsertList(stored, results, isSameUpsertItem, (e, i) => (e.balances = i.balances));
+  const stored = (await getExtensionLocalStorage(`${id}-custom-balance-cw20`)) || [];
 
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-cw20`>>({ [`${id}-custom-balance-cw20`]: updatedCustomCW20Balances });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-cw20`>>({ [`${id}-custom-balance-cw20`]: results });
-  }
+  const updatedCustomCW20Balances = upsertCW20Balance(stored, results);
+
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-custom-balance-cw20`>>({ [`${id}-custom-balance-cw20`]: updatedCustomCW20Balances });
 }

--- a/src/script/service-worker/update/staking.ts
+++ b/src/script/service-worker/update/staking.ts
@@ -15,12 +15,19 @@ import type {
 } from '@/types/account';
 import type { UniqueChainId } from '@/types/chain';
 import type { ExtensionStorage } from '@/types/extension';
-import { upsertList } from '@/utils/array';
+import {
+  upsertCosmosCommission,
+  upsertCosmosDelegation,
+  upsertCosmosReward,
+  upsertCosmosUndelegation,
+  upsertIotaDelegation,
+  upsertSuiDelegation,
+} from '@/utils/balanceUpsert';
 import { convertToValidatorAddress, isValidatorAddress } from '@/utils/cosmos/address';
 import { fetchCosmosCommission, fetchCosmosDelegations, fetchCosmosRewards, fetchCosmosUnbondings, fetchNTRNRewards } from '@/utils/cosmos/fetch/staking';
 import { fetchIotaDelegations } from '@/utils/iota/fetch/staking';
-import { getUniqueChainIdWithManual, parseUniqueChainId } from '@/utils/queryParamGenerator';
-import { isEqualsIgnoringCase } from '@/utils/string';
+import { getUniqueChainIdWithManual, isMatchingUniqueChainId, parseUniqueChainId } from '@/utils/queryParamGenerator';
+import { getExtensionLocalStorage } from '@/utils/storage';
 import { fetchSuiDelegations } from '@/utils/sui/fetch/staking';
 
 import type { BalanceFetchOption } from './balance';
@@ -42,12 +49,12 @@ export async function updateStakingRelatedBalance(id: string) {
   }
 }
 
-export async function updateSpecificChainStaking(id: string, chainId: UniqueChainId, address: string) {
-  console.time(`chain-staking-balance-${id}-${chainId}-${address}`);
+export async function updateSpecificChainStaking(id: string, chainId: UniqueChainId) {
+  console.time(`chain-staking-balance-${id}-${chainId}`);
   try {
     await getAccount(id);
 
-    await fetchStakingByChainType(id, chainId, address);
+    await fetchStakingByChainType(id, chainId);
   } catch (error) {
     if (axios.isAxiosError(error)) {
       console.error(`${error.request?.method} ${error.request?.url} ${error.cause?.message}`);
@@ -55,66 +62,54 @@ export async function updateSpecificChainStaking(id: string, chainId: UniqueChai
       console.error(error);
     }
   } finally {
-    console.timeEnd(`chain-staking-balance-${id}-${chainId}-${address}`);
+    console.timeEnd(`chain-staking-balance-${id}-${chainId}`);
   }
 }
 
-async function fetchStakingByChainType(id: string, chainId: UniqueChainId, address: string) {
+async function fetchStakingByChainType(id: string, chainId: UniqueChainId) {
   const { chainType } = parseUniqueChainId(chainId);
 
   if (chainType === 'cosmos') {
-    await cosmosStaking(id, { chainId, address });
+    await cosmosStaking(id, { chainId });
   }
 
   if (chainType === 'sui') {
-    await suiStaking(id, { chainId, address });
+    await suiStaking(id, { chainId });
   }
 
   if (chainType === 'iota') {
-    await iotaStaking(id, { chainId, address });
+    await iotaStaking(id, { chainId });
   }
 }
 
-async function cosmosStaking(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function cosmosStaking(id: string, { chainId }: BalanceFetchOption = {}) {
   await Promise.all([
-    cosmosDelegations(id, { chainId, address }),
-    cosmosUnbondings(id, { chainId, address }),
-    cosmosRewards(id, { chainId, address }),
-    cosmosCommissions(id, { chainId, address }),
+    cosmosDelegations(id, { chainId }),
+    cosmosUnbondings(id, { chainId }),
+    cosmosRewards(id, { chainId }),
+    cosmosCommissions(id, { chainId }),
   ]);
 }
 
-interface UpsertItemBase {
-  address: string;
-  chainId: string | number;
-  chainType: string;
-  id: string;
-}
+async function cosmosDelegations(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
 
-interface UpsertItemWithAssetId extends UpsertItemBase {
-  assetId: string;
-}
-
-const isSameUpsertItemWithAssetId = (a: UpsertItemWithAssetId, b: UpsertItemWithAssetId) =>
-  isEqualsIgnoringCase(a.address, b.address) && a.chainId === b.chainId && a.chainType === b.chainType && a.assetId === b.assetId && a.id === b.id;
-
-const isSameUpsertItemWithoutAssetId = (a: UpsertItemBase, b: UpsertItemBase) =>
-  isEqualsIgnoringCase(a.address, b.address) && a.chainId === b.chainId && a.chainType === b.chainType && a.id === b.id;
-
-async function cosmosDelegations(id: string, { address, chainId }: BalanceFetchOption = {}) {
   const accountAddress = await getAccountAddress(id);
   const { cosmosChains } = await getChains();
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
 
   const stakingEnabledChain = cosmosChains.filter((chain) => chain.isSupportStaking);
+
+  const targetChain = chainId && stakingEnabledChain.find((chain) => isMatchingUniqueChainId(chain, chainId));
+
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -127,43 +122,58 @@ async function cosmosDelegations(id: string, { address, chainId }: BalanceFetchO
 
       try {
         const delegations = await fetchCosmosDelegations(address, lcdUrls.map((item) => item.url).filter(Boolean));
-        const result: AccountAddressDelegationsCosmos = { id, assetId: chain.mainAssetDenom, chainId, chainType, address, delegations };
+        const result: AccountAddressDelegationsCosmos = {
+          id,
+          assetId: chain.mainAssetDenom,
+          chainId,
+          chainType,
+          address,
+          delegations,
+          lastUpdatedAtMs: startUpdateTime,
+        };
 
         return result;
       } catch {
-        const result: AccountAddressDelegationsCosmos = { id, assetId: chain.mainAssetDenom, chainId, chainType, address, delegations: [] };
+        const result: AccountAddressDelegationsCosmos = {
+          id,
+          assetId: chain.mainAssetDenom,
+          chainId,
+          chainType,
+          address,
+          delegations: [],
+          lastUpdatedAtMs: startUpdateTime,
+        };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const storage = await chrome.storage.local.get<ExtensionStorage>([`${id}-delegation-cosmos`]);
+  const storage = (await getExtensionLocalStorage(`${id}-delegation-cosmos`)) || [];
 
-    const storedCosmosDelegations = storage[`${id}-delegation-cosmos`] || [];
+  const updatedCosmosDelegations = upsertCosmosDelegation(storage, results);
 
-    const updatedCosmosDelegations = upsertList(storedCosmosDelegations, results, isSameUpsertItemWithAssetId, (e, i) => (e.delegations = i.delegations));
-
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-cosmos`>>({ [`${id}-delegation-cosmos`]: updatedCosmosDelegations });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-cosmos`>>({ [`${id}-delegation-cosmos`]: results });
-  }
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-cosmos`>>({ [`${id}-delegation-cosmos`]: updatedCosmosDelegations });
 }
 
-async function cosmosUnbondings(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function cosmosUnbondings(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { cosmosChains } = await getChains();
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
 
   const stakingEnabledChain = cosmosChains.filter((chain) => chain.isSupportStaking);
+
+  const targetChain = chainId && stakingEnabledChain.find((chain) => isMatchingUniqueChainId(chain, chainId));
+
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -178,43 +188,58 @@ async function cosmosUnbondings(id: string, { address, chainId }: BalanceFetchOp
       try {
         const unbondings = await fetchCosmosUnbondings(address, lcdUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressUnbondingsCosmos = { id, assetId: chain.mainAssetDenom, chainId, chainType, address, unbondings };
+        const result: AccountAddressUnbondingsCosmos = {
+          id,
+          assetId: chain.mainAssetDenom,
+          chainId,
+          chainType,
+          address,
+          unbondings,
+          lastUpdatedAtMs: startUpdateTime,
+        };
 
         return result;
       } catch {
-        const result: AccountAddressUnbondingsCosmos = { id, assetId: chain.mainAssetDenom, chainId, chainType, address, unbondings: [] };
+        const result: AccountAddressUnbondingsCosmos = {
+          id,
+          assetId: chain.mainAssetDenom,
+          chainId,
+          chainType,
+          address,
+          unbondings: [],
+          lastUpdatedAtMs: startUpdateTime,
+        };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const storage = await chrome.storage.local.get<ExtensionStorage>([`${id}-undelegation-cosmos`]);
+  const stored = (await getExtensionLocalStorage(`${id}-undelegation-cosmos`)) || [];
 
-    const storedCosmosUndelegations = storage[`${id}-undelegation-cosmos`] || [];
+  const updatedCosmosUndelegations = upsertCosmosUndelegation(stored, results);
 
-    const updatedCosmosUndelegations = upsertList(storedCosmosUndelegations, results, isSameUpsertItemWithAssetId, (e, i) => (e.unbondings = i.unbondings));
-
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-undelegation-cosmos`>>({ [`${id}-undelegation-cosmos`]: updatedCosmosUndelegations });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-undelegation-cosmos`>>({ [`${id}-undelegation-cosmos`]: results });
-  }
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-undelegation-cosmos`>>({ [`${id}-undelegation-cosmos`]: updatedCosmosUndelegations });
 }
 
-async function cosmosRewards(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function cosmosRewards(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { cosmosChains } = await getChains();
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
 
   const stakingEnabledChain = cosmosChains.filter((chain) => chain.isSupportStaking);
+
+  const targetChain = chainId && stakingEnabledChain.find((chain) => isMatchingUniqueChainId(chain, chainId));
+
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -241,7 +266,15 @@ async function cosmosRewards(id: string, { address, chainId }: BalanceFetchOptio
         };
 
         const rewards = await getRewards();
-        const result: AccountAddressRewardsCosmos = { id, assetId: chain.mainAssetDenom, chainId, chainType, address, rewards };
+        const result: AccountAddressRewardsCosmos = {
+          id,
+          assetId: chain.mainAssetDenom,
+          chainId,
+          chainType,
+          address,
+          rewards,
+          lastUpdatedAtMs: startUpdateTime,
+        };
 
         return result;
       } catch {
@@ -255,23 +288,18 @@ async function cosmosRewards(id: string, { address, chainId }: BalanceFetchOptio
             rewards: [],
             total: [],
           },
+          lastUpdatedAtMs: startUpdateTime,
         };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const storage = await chrome.storage.local.get<ExtensionStorage>([`${id}-reward-cosmos`]);
+  const stored = (await getExtensionLocalStorage(`${id}-reward-cosmos`)) || [];
 
-    const storedCosmosRewards = storage[`${id}-reward-cosmos`] || [];
+  const updatedCosmosRewards = upsertCosmosReward(stored, results);
 
-    const updatedCosmosRewards = upsertList(storedCosmosRewards, results, isSameUpsertItemWithAssetId, (e, i) => (e.rewards = i.rewards));
-
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-reward-cosmos`>>({ [`${id}-reward-cosmos`]: updatedCosmosRewards });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-reward-cosmos`>>({ [`${id}-reward-cosmos`]: results });
-  }
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-reward-cosmos`>>({ [`${id}-reward-cosmos`]: updatedCosmosRewards });
 }
 
 const validatorAddressCache = new Map<string, boolean>();
@@ -289,20 +317,25 @@ async function isValidatorCached(address: string, lcdUrl: string, validatorPrefi
   return isValidator;
 }
 
-async function cosmosCommissions(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function cosmosCommissions(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { cosmosChains } = await getChains();
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
 
   const stakingEnabledChain = cosmosChains.filter((chain) => chain.isSupportStaking);
+
+  const targetChain = chainId && stakingEnabledChain.find((chain) => isMatchingUniqueChainId(chain, chainId));
+
   const addressWithChain = addressList
     .map((addr) => {
-      const chain = stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
+      const chain = targetChain || stakingEnabledChain.find((chain) => chain.chainType === addr.chainType && chain.id === addr.chainId)!;
       return { ...addr, chain };
     })
     .filter((addr) => addr.chain);
@@ -328,7 +361,15 @@ async function cosmosCommissions(id: string, { address, chainId }: BalanceFetchO
 
         const commissions = await fetchCosmosCommission(validatorAddress, lcdUrls.map((item) => item.url).filter(Boolean));
 
-        const result: AccountAddressCommissionsCosmos = { id, assetId: chain.mainAssetDenom, chainId, chainType, address, commissions };
+        const result: AccountAddressCommissionsCosmos = {
+          id,
+          assetId: chain.mainAssetDenom,
+          chainId,
+          chainType,
+          address,
+          commissions,
+          lastUpdatedAtMs: startUpdateTime,
+        };
 
         return result;
       } catch {
@@ -339,33 +380,30 @@ async function cosmosCommissions(id: string, { address, chainId }: BalanceFetchO
           chainType,
           address,
           commissions: undefined,
+          lastUpdatedAtMs: startUpdateTime,
         };
 
         return result;
       }
     });
 
-  if (isUpdateSpecificAddress) {
-    const storage = await chrome.storage.local.get<ExtensionStorage>([`${id}-commission-cosmos`]);
+  const stored = (await getExtensionLocalStorage(`${id}-commission-cosmos`)) || [];
 
-    const storedCosmosCommission = storage[`${id}-commission-cosmos`] || [];
+  const updatedCosmosCommission = upsertCosmosCommission(stored, results);
 
-    const updatedCosmosCommission = upsertList(storedCosmosCommission, results, isSameUpsertItemWithAssetId, (e, i) => (e.commissions = i.commissions));
-
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-commission-cosmos`>>({ [`${id}-commission-cosmos`]: updatedCosmosCommission });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-commission-cosmos`>>({ [`${id}-commission-cosmos`]: results });
-  }
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-commission-cosmos`>>({ [`${id}-commission-cosmos`]: updatedCosmosCommission });
 }
 
-async function suiStaking(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function suiStaking(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { suiChains } = await getChains();
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
 
   const addressWithChain = addressList
@@ -382,36 +420,38 @@ async function suiStaking(id: string, { address, chainId }: BalanceFetchOption =
 
       const { rpcUrls } = chain;
 
-      const response = await fetchSuiDelegations(address, rpcUrls.map((item) => item.url).filter(Boolean));
+      try {
+        const response = await fetchSuiDelegations(address, rpcUrls.map((item) => item.url).filter(Boolean));
 
-      const delegations = response ?? [];
+        const delegations = response ?? [];
 
-      const result: AccountAddressDelegationsSui = { id, chainId, chainType, address, delegations };
+        const result: AccountAddressDelegationsSui = { id, chainId, chainType, address, delegations, lastUpdatedAtMs: startUpdateTime };
 
-      return result;
+        return result;
+      } catch {
+        const result: AccountAddressDelegationsSui = { id, chainId, chainType, address, delegations: [], lastUpdatedAtMs: startUpdateTime };
+
+        return result;
+      }
     });
 
-  if (isUpdateSpecificAddress) {
-    const storage = await chrome.storage.local.get<ExtensionStorage>([`${id}-delegation-sui`]);
+  const stored = (await getExtensionLocalStorage(`${id}-delegation-sui`)) || [];
 
-    const storedSuiDelegations = storage[`${id}-delegation-sui`] || [];
+  const updatedSuiDelegations = upsertSuiDelegation(stored, results);
 
-    const updatedSuiDelegations = upsertList(storedSuiDelegations, results, isSameUpsertItemWithoutAssetId, (e, i) => (e.delegations = i.delegations));
-
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-sui`>>({ [`${id}-delegation-sui`]: updatedSuiDelegations });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-sui`>>({ [`${id}-delegation-sui`]: results });
-  }
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-sui`>>({ [`${id}-delegation-sui`]: updatedSuiDelegations });
 }
 
-async function iotaStaking(id: string, { address, chainId }: BalanceFetchOption = {}) {
+async function iotaStaking(id: string, { chainId }: BalanceFetchOption = {}) {
+  const startUpdateTime = Date.now();
+
   const accountAddress = await getAccountAddress(id);
   const { iotaChains } = await getChains();
 
-  const isUpdateSpecificAddress = !!address && !!chainId;
+  const isUpdateSpecificAddress = !!chainId;
 
   const addressList = isUpdateSpecificAddress
-    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId && isEqualsIgnoringCase(addr.address, address))
+    ? accountAddress.filter((addr) => getUniqueChainIdWithManual(addr.chainId, addr.chainType) === chainId)
     : accountAddress;
 
   const addressWithChain = addressList
@@ -428,24 +468,24 @@ async function iotaStaking(id: string, { address, chainId }: BalanceFetchOption 
 
       const { rpcUrls } = chain;
 
-      const response = await fetchIotaDelegations(address, rpcUrls.map((item) => item.url).filter(Boolean));
+      try {
+        const response = await fetchIotaDelegations(address, rpcUrls.map((item) => item.url).filter(Boolean));
 
-      const delegations = response ?? [];
+        const delegations = response ?? [];
 
-      const result: AccountAddressDelegationsIota = { id, chainId, chainType, address, delegations };
+        const result: AccountAddressDelegationsIota = { id, chainId, chainType, address, delegations, lastUpdatedAtMs: startUpdateTime };
 
-      return result;
+        return result;
+      } catch {
+        const result: AccountAddressDelegationsIota = { id, chainId, chainType, address, delegations: [], lastUpdatedAtMs: startUpdateTime };
+
+        return result;
+      }
     });
 
-  if (isUpdateSpecificAddress) {
-    const storage = await chrome.storage.local.get<ExtensionStorage>([`${id}-delegation-iota`]);
+  const stored = (await getExtensionLocalStorage(`${id}-delegation-iota`)) || [];
 
-    const storedIotaDelegations = storage[`${id}-delegation-iota`] || [];
+  const updatedIotaDelegations = upsertIotaDelegation(stored, results);
 
-    const updatedIotaDelegations = upsertList(storedIotaDelegations, results, isSameUpsertItemWithoutAssetId, (e, i) => (e.delegations = i.delegations));
-
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-iota`>>({ [`${id}-delegation-iota`]: updatedIotaDelegations });
-  } else {
-    await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-iota`>>({ [`${id}-delegation-iota`]: results });
-  }
+  await chrome.storage.local.set<Pick<ExtensionStorage, `${string}-delegation-iota`>>({ [`${id}-delegation-iota`]: updatedIotaDelegations });
 }

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -57,6 +57,8 @@ export interface AccountAddress {
   accountType: ChainAccountType;
 }
 
+export type RequestStatus = 'error' | 'success';
+
 export interface AccountAddressBalanceCosmos {
   id: Chain['id'];
   chainId: Chain['chainId'];
@@ -64,6 +66,7 @@ export interface AccountAddressBalanceCosmos {
   address: string;
   balances: CosmosBalance[];
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export interface AccountAddressDelegationsCosmos {
@@ -73,6 +76,7 @@ export interface AccountAddressDelegationsCosmos {
   chainType: ChainType;
   address: string;
   delegations: LcdDelegationResponse[];
+  lastUpdatedAtMs?: number | null;
 }
 export interface AccountAddressUnbondingsCosmos {
   id: Chain['id'];
@@ -81,6 +85,7 @@ export interface AccountAddressUnbondingsCosmos {
   chainType: ChainType;
   address: string;
   unbondings: UnbondingResponses[];
+  lastUpdatedAtMs?: number | null;
 }
 export interface AccountAddressRewardsCosmos {
   id: Chain['id'];
@@ -89,6 +94,7 @@ export interface AccountAddressRewardsCosmos {
   chainType: ChainType;
   address: string;
   rewards: RewardDetails;
+  lastUpdatedAtMs?: number | null;
 }
 export interface AccountAddressCommissionsCosmos {
   id: Chain['id'];
@@ -97,6 +103,7 @@ export interface AccountAddressCommissionsCosmos {
   chainType: ChainType;
   address: string;
   commissions?: CommissionResponse;
+  lastUpdatedAtMs?: number | null;
 }
 
 export interface AccountAddressLockedBalanceCosmos {
@@ -105,6 +112,7 @@ export interface AccountAddressLockedBalanceCosmos {
   chainType: ChainType;
   address: string;
   lockedBalances: CosmosBalance[];
+  lastUpdatedAtMs?: number | null;
 }
 export interface AccountAddressAccountInfoCosmos {
   id: Chain['id'];
@@ -112,6 +120,7 @@ export interface AccountAddressAccountInfoCosmos {
   chainType: ChainType;
   address: string;
   accountInfo: AuthAccountsPayload;
+  lastUpdatedAtMs?: number | null;
 }
 
 export interface AccountAddressBalanceEvm {
@@ -121,6 +130,7 @@ export interface AccountAddressBalanceEvm {
   address: string;
   balance: string;
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export interface AccountAddressBalanceAptos {
@@ -130,6 +140,7 @@ export interface AccountAddressBalanceAptos {
   address: string;
   balances: AptosResourceResponse[];
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export interface AccountAddressDelegationsSui {
@@ -148,6 +159,7 @@ export interface AccountAddressBalanceSui {
   address: string;
   balances: SuiGetBalance[];
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export interface AccountAddressBalanceIota {
@@ -157,6 +169,7 @@ export interface AccountAddressBalanceIota {
   address: string;
   balances: IotaGetBalance[];
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export interface AccountAddressDelegationsIota {
@@ -165,6 +178,7 @@ export interface AccountAddressDelegationsIota {
   chainType: ChainType;
   address: string;
   delegations: IotaDelegatedStake[];
+  lastUpdatedAtMs?: number | null;
 }
 export interface AccountAddressBalanceBitcoin {
   id: Chain['id'];
@@ -173,6 +187,7 @@ export interface AccountAddressBalanceBitcoin {
   address: string;
   balance: BitcoinBalance;
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export interface AccountAddressBalanceErc20 {

--- a/src/types/cosmos/balance.ts
+++ b/src/types/cosmos/balance.ts
@@ -1,9 +1,11 @@
 import type { Amount } from './common';
+import type { RequestStatus } from '../account';
 
 export interface Cw20Balance {
   contract: string;
   balance: string;
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }
 
 export type CommissionResponse = {

--- a/src/types/evm/balance.ts
+++ b/src/types/evm/balance.ts
@@ -1,5 +1,8 @@
+import type { RequestStatus } from '../account';
+
 export interface Erc20Balance {
   contract: string;
   balance: string;
   lastUpdatedAtMs?: number | null;
+  status?: RequestStatus;
 }

--- a/src/types/message/service-worker/index.ts
+++ b/src/types/message/service-worker/index.ts
@@ -37,13 +37,13 @@ export interface UpdateAccountInfoMessage extends MessageBase {
 export interface UpdateChainSpecificBalanceMessage extends MessageBase {
   target: Extract<TargetType, 'SERVICE_WORKER'>;
   method: 'updateChainSpecificBalance';
-  params: [string, UniqueChainId, string];
+  params: [string, UniqueChainId];
 }
 
 export interface UpdateChainSpecificStakingBalanceMessage extends MessageBase {
   target: Extract<TargetType, 'SERVICE_WORKER'>;
   method: 'updateChainSpecificStakingBalance';
-  params: [string, UniqueChainId, string];
+  params: [string, UniqueChainId];
 }
 
 export interface RequestAppMessage extends MessageBase {

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,27 +1,5 @@
-import type { Draft } from 'immer';
-import { produce } from 'immer';
-
 export function chunkArray<T>(data: T[], chunkSize: number) {
   return Array.from({ length: Math.ceil(data.length / chunkSize) }, (_, i) => data.slice(i * chunkSize, i * chunkSize + chunkSize));
-}
-
-export function upsertList<T>(
-  originalList: T[],
-  incomingList: T[],
-  isEqual: (a: Draft<T>, b: T) => boolean,
-  merge: (existing: Draft<T>, incoming: T) => void,
-): T[] {
-  return produce(originalList, (draft) => {
-    incomingList.forEach((incomingItem) => {
-      const existing = draft.find((item) => isEqual(item, incomingItem));
-
-      if (existing) {
-        merge(existing, incomingItem);
-      } else {
-        draft.push(incomingItem as Draft<T>);
-      }
-    });
-  });
 }
 
 export function removeDuplicates<T>(list: T[], isDuplicate: (a: T, b: T) => boolean): T[] {

--- a/src/utils/balanceUpsert.ts
+++ b/src/utils/balanceUpsert.ts
@@ -1,0 +1,245 @@
+import type { Draft } from 'immer';
+import { produce } from 'immer';
+
+import type {
+  AccountAddressBalanceAptos,
+  AccountAddressBalanceBitcoin,
+  AccountAddressBalanceCosmos,
+  AccountAddressBalanceCw20,
+  AccountAddressBalanceErc20,
+  AccountAddressBalanceEvm,
+  AccountAddressBalanceIota,
+  AccountAddressBalanceSui,
+  AccountAddressCommissionsCosmos,
+  AccountAddressDelegationsCosmos,
+  AccountAddressDelegationsIota,
+  AccountAddressDelegationsSui,
+  AccountAddressRewardsCosmos,
+  AccountAddressUnbondingsCosmos,
+} from '@/types/account';
+
+interface UpsertItemBase {
+  address: string;
+  chainId: string | number;
+  chainType: string;
+  id: string;
+  lastUpdatedAtMs?: number | null;
+}
+
+interface UpsertItemWithAssetId extends UpsertItemBase {
+  assetId: string;
+}
+
+const getUpsertItemKey = (item: UpsertItemBase) => {
+  const { address, chainId, chainType, id } = item;
+
+  return `${address}--${chainId}--${chainType}--${id}`;
+};
+
+const getUpsertItemKeyWithAssetId = (item: UpsertItemWithAssetId) => {
+  const { address, chainId, chainType, assetId, id } = item;
+
+  return `${address}--${chainId}--${chainType}--${id}--${assetId}`;
+};
+
+function shouldUpdateByTime(e: { lastUpdatedAtMs?: number | null }, i: { lastUpdatedAtMs?: number | null }) {
+  if (!!e.lastUpdatedAtMs && !!i.lastUpdatedAtMs) {
+    return e.lastUpdatedAtMs < i.lastUpdatedAtMs;
+  }
+  return true;
+}
+
+export function upsertList<T>(
+  originalList: T[],
+  incomingList: T[],
+  getKey: (item: T) => string,
+  shouldUpdate: (existing: T, incoming: T) => boolean,
+  merge: (existing: Draft<T>, incoming: T) => void,
+): T[] {
+  return produce(originalList, (draft) => {
+    const existingMap = new Map<string | number, Draft<T>>();
+    draft.forEach((item) => {
+      existingMap.set(getKey(item as T), item);
+    });
+
+    incomingList.forEach((incomingItem) => {
+      const key = getKey(incomingItem);
+      const existing = existingMap.get(key);
+
+      if (existing) {
+        if (shouldUpdate(existing as T, incomingItem)) {
+          merge(existing as Draft<T>, incomingItem);
+        }
+      } else {
+        const newItem = incomingItem as Draft<T>;
+        draft.push(newItem);
+      }
+    });
+  });
+}
+
+export function upsertStakingList<T extends { lastUpdatedAtMs?: number | null }>(
+  originalList: T[],
+  incomingList: T[],
+  getKey: (item: T) => string,
+  merge: (existing: Draft<T>, incoming: T) => void,
+): T[] {
+  return upsertList(originalList, incomingList, getKey, shouldUpdateByTime, merge);
+}
+
+export const upsertCosmosDelegation = <T extends AccountAddressDelegationsCosmos>(originalList: T[], incomingList: T[]) => {
+  return upsertStakingList(originalList, incomingList, getUpsertItemKeyWithAssetId, (e, i) => {
+    e.delegations = i.delegations;
+    e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+  });
+};
+
+export const upsertCosmosUndelegation = <T extends AccountAddressUnbondingsCosmos>(originalList: T[], incomingList: T[]) => {
+  return upsertStakingList(originalList, incomingList, getUpsertItemKeyWithAssetId, (e, i) => {
+    e.unbondings = i.unbondings;
+    e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+  });
+};
+
+export const upsertCosmosReward = <T extends AccountAddressRewardsCosmos>(originalList: T[], incomingList: T[]) => {
+  return upsertStakingList(originalList, incomingList, getUpsertItemKeyWithAssetId, (e, i) => {
+    e.rewards = i.rewards;
+    e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+  });
+};
+
+export const upsertCosmosCommission = <T extends AccountAddressCommissionsCosmos>(originalList: T[], incomingList: T[]) => {
+  return upsertStakingList(originalList, incomingList, getUpsertItemKeyWithAssetId, (e, i) => {
+    e.commissions = i.commissions;
+    e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+  });
+};
+
+export const upsertSuiDelegation = <T extends AccountAddressDelegationsSui>(originalList: T[], incomingList: T[]) => {
+  return upsertStakingList(originalList, incomingList, getUpsertItemKey, (e, i) => {
+    e.delegations = i.delegations;
+    e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+  });
+};
+
+export const upsertIotaDelegation = <T extends AccountAddressDelegationsIota>(originalList: T[], incomingList: T[]) => {
+  return upsertStakingList(originalList, incomingList, getUpsertItemKey, (e, i) => {
+    e.delegations = i.delegations;
+    e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+  });
+};
+
+export function upsertBalanceList<T extends UpsertItemBase>(originalList: T[], incomingList: T[], merge: (existing: Draft<T>, incoming: T) => void): T[] {
+  return upsertList(originalList, incomingList, getUpsertItemKey, shouldUpdateByTime, merge);
+}
+
+export const upsertCosmosBalance = <T extends AccountAddressBalanceCosmos>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balances = i.balances;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+
+    if (e.status !== i.status) {
+      e.status = i.status;
+    }
+  });
+};
+
+export const upsertCustomCosmosBalance = <T extends AccountAddressBalanceCosmos>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balances = i.balances;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+
+    if (e.status !== i.status) {
+      e.status = i.status;
+    }
+  });
+};
+
+export const upsertEVMBalance = <T extends AccountAddressBalanceEvm>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balance = i.balance;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+  });
+};
+
+export const upsertBitcoinBalance = <T extends AccountAddressBalanceBitcoin>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balance = i.balance;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+
+    if (e.status !== i.status) {
+      e.status = i.status;
+    }
+  });
+};
+
+export const upsertAptosBalance = <T extends AccountAddressBalanceAptos>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balances = i.balances;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+
+    if (e.status !== i.status) {
+      e.status = i.status;
+    }
+  });
+};
+
+export const upsertSuiBalance = <T extends AccountAddressBalanceSui>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balances = i.balances;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+
+    if (e.status !== i.status) {
+      e.status = i.status;
+    }
+  });
+};
+
+export const upsertIotaBalance = <T extends AccountAddressBalanceIota>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    if (i.status !== 'error') {
+      e.balances = i.balances;
+      e.lastUpdatedAtMs = i.lastUpdatedAtMs;
+    }
+
+    if (e.status !== i.status) {
+      e.status = i.status;
+    }
+  });
+};
+
+export const upsertERC20Balance = <T extends AccountAddressBalanceErc20>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    const resovled = i.balances.map((incoming) => {
+      if (incoming.status !== 'error') return incoming;
+
+      return e.balances.find((exsist) => exsist.contract === incoming.contract) || incoming;
+    });
+
+    e.balances = resovled;
+  });
+};
+
+export const upsertCW20Balance = <T extends AccountAddressBalanceCw20>(originalList: T[], incomingList: T[]) => {
+  return upsertBalanceList(originalList, incomingList, (e, i) => {
+    const resovled = i.balances.map((incoming) => {
+      if (incoming.status !== 'error') return incoming;
+
+      return e.balances.find((exsist) => exsist.contract === incoming.contract) || incoming;
+    });
+
+    e.balances = resovled;
+  });
+};

--- a/src/utils/balanceUpsert.ts
+++ b/src/utils/balanceUpsert.ts
@@ -18,6 +18,8 @@ import type {
   AccountAddressUnbondingsCosmos,
 } from '@/types/account';
 
+import { isEqualsIgnoringCase } from './string';
+
 interface UpsertItemBase {
   address: string;
   chainId: string | number;
@@ -222,24 +224,24 @@ export const upsertIotaBalance = <T extends AccountAddressBalanceIota>(originalL
 
 export const upsertERC20Balance = <T extends AccountAddressBalanceErc20>(originalList: T[], incomingList: T[]) => {
   return upsertBalanceList(originalList, incomingList, (e, i) => {
-    const resovled = i.balances.map((incoming) => {
+    const resolved = i.balances.map((incoming) => {
       if (incoming.status !== 'error') return incoming;
 
-      return e.balances.find((exsist) => exsist.contract === incoming.contract) || incoming;
+      return e.balances.find((exsist) => isEqualsIgnoringCase(exsist.contract, incoming.contract)) || incoming;
     });
 
-    e.balances = resovled;
+    e.balances = resolved;
   });
 };
 
 export const upsertCW20Balance = <T extends AccountAddressBalanceCw20>(originalList: T[], incomingList: T[]) => {
   return upsertBalanceList(originalList, incomingList, (e, i) => {
-    const resovled = i.balances.map((incoming) => {
+    const resolved = i.balances.map((incoming) => {
       if (incoming.status !== 'error') return incoming;
 
-      return e.balances.find((exsist) => exsist.contract === incoming.contract) || incoming;
+      return e.balances.find((exsist) => isEqualsIgnoringCase(exsist.contract, incoming.contract)) || incoming;
     });
 
-    e.balances = resovled;
+    e.balances = resolved;
   });
 };

--- a/src/utils/balanceUpsert.ts
+++ b/src/utils/balanceUpsert.ts
@@ -227,7 +227,7 @@ export const upsertERC20Balance = <T extends AccountAddressBalanceErc20>(origina
     const resolved = i.balances.map((incoming) => {
       if (incoming.status !== 'error') return incoming;
 
-      return e.balances.find((exsist) => isEqualsIgnoringCase(exsist.contract, incoming.contract)) || incoming;
+      return e.balances.find((exist) => isEqualsIgnoringCase(exist.contract, incoming.contract)) || incoming;
     });
 
     e.balances = resolved;
@@ -239,7 +239,7 @@ export const upsertCW20Balance = <T extends AccountAddressBalanceCw20>(originalL
     const resolved = i.balances.map((incoming) => {
       if (incoming.status !== 'error') return incoming;
 
-      return e.balances.find((exsist) => isEqualsIgnoringCase(exsist.contract, incoming.contract)) || incoming;
+      return e.balances.find((exist) => isEqualsIgnoringCase(exist.contract, incoming.contract)) || incoming;
     });
 
     e.balances = resolved;

--- a/src/utils/cosmos/fetch/balance.ts
+++ b/src/utils/cosmos/fetch/balance.ts
@@ -4,6 +4,7 @@ import { MulticallWrapper } from 'ethers-multicall-provider';
 import { BALANCE_FETCH_TIME_OUT_MS } from '@/constants/common';
 import type { CosmosBalance, CosmosBalanceResponse, CosmosCw20BalanceResponse } from '@/types/cosmos/api';
 import type { EvmRpcGetBalanceResponse } from '@/types/evm/api';
+import type { Erc20Balance } from '@/types/evm/balance';
 import { getWithFullResponse, postWithFullResponse } from '@/utils/axios';
 import { buildRequestUrl } from '@/utils/fetch';
 import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
@@ -139,14 +140,7 @@ export const fetchMultiERC20Balances = async (
   multicallWrapperOption?: {
     maxMulticallDataLength: number;
   },
-): Promise<
-  {
-    contract: string;
-    balance: string;
-    lastUpdatedAtMs?: number | null;
-    isError?: boolean;
-  }[]
-> => {
+): Promise<Erc20Balance[]> => {
   const { maxMulticallDataLength } = multicallWrapperOption || {};
 
   return await fetchWithFailover(rpcUrls, async (rpcUrl) => {
@@ -175,11 +169,11 @@ export const fetchMultiERC20Balances = async (
 
             const balance = response.toString();
 
-            const result = { contract: contractAddress, balance, lastUpdatedAtMs: Date.now() };
+            const result: Erc20Balance = { contract: contractAddress, balance, status: 'success' };
 
             return result;
           } catch {
-            const result = { contract: contractAddress, balance: '0', isError: true };
+            const result: Erc20Balance = { contract: contractAddress, balance: '0', status: 'error' };
 
             return result;
           }

--- a/src/utils/queryParamGenerator.ts
+++ b/src/utils/queryParamGenerator.ts
@@ -39,6 +39,14 @@ export function getUniqueChainIdWithManual(id: string, chainType: ChainType): Un
   return `${id}__${chainType}`;
 }
 
+export function getUniqueChainIdFromCoinId(coinId: string): UniqueChainId {
+  const { chainId, chainType } = parseCoinId(coinId);
+  return getUniqueChainId({
+    id: chainId,
+    chainType,
+  });
+}
+
 export function parseUniqueChainId(chainId: UniqueChainId) {
   const [id, chainType] = chainId.split('__');
   return { id, chainType } as ChainId;


### PR DESCRIPTION
1차 작업
- 주요 페이지별 체인 밸런스 데이터 갱신 로직 추가
- 밸런스, 스테이킹 관련 데이터 스토리지 업데이트 함수 리팩토링
  - 요청 상태값 필드 추가 
  
  
 필요 후속 작업
- 디앱 요청 사인 처리 후 체인 밸런스 업데이트 로직
- ~~이더민트 체인의 경우 evm, cosmos체인 모두 밸런스 업데이트되도록 변경~~
  - 작업 완료
- 밸런스 전체 갱신 로직을 비롯해 밸런스, 스테이킹 데이터 업데이트 로직의 세분화
  - 각 요청별로  부하정도를 파악 후, 전체 병렬요청이 아닌 순차 요청으로 변경