### PR TITLE
Fix getPublicKeyType to handle additional pubkey types for Ethermint

### DIFF
--- a/src/utils/cosmos/msg.ts
+++ b/src/utils/cosmos/msg.ts
@@ -73,7 +73,10 @@ export const getPublicKeyType = (pubkeyType: string) => {
     return PUBLIC_KEY_TYPE.INJ_SECP256K1;
   }
 
-  if (pubkeyType === '/ethermint.crypto.v1.ethsecp256k1.PubKey') {
+  if (
+    pubkeyType === '/ethermint.crypto.v1.ethsecp256k1.PubKey' ||
+    pubkeyType === '/cosmos.evm.crypto.v1.ethsecp256k1.PubKey'
+  ) {
     return PUBLIC_KEY_TYPE.ETH_SECP256K1;
   }
 


### PR DESCRIPTION
## Fix Mantra Testnet pubkeyType Edge Case

This PR updates the logic in `patchDukongPreferAccountTypeMismatching` to ensure that the `pubkeyType` for the `mantra-testnet` chain is set to `/cosmos.evm.crypto.v1.ethsecp256k1.PubKey` instead of `/ethermint.crypto.v1.ethsecp256k1.PubKey`.  
This fixes an edge case for Mantra testnet accounts where the wrong pubkey type could cause compatibility issues.

**Context:**  
- Ensures correct account type mapping for Mantra testnet.
- Prevents issues with signing and address derivation for affected accounts.