### PR TITLE
[APIS-699] Apply Osmosis fee market

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" style="background: #1a1a1a">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" style="background: #1a1a1a">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/components/Fee/CosmosFee/components/FeeSettingBottomSheet/components/FeeCustomOverlay/index.tsx
+++ b/src/components/Fee/CosmosFee/components/FeeSettingBottomSheet/components/FeeCustomOverlay/index.tsx
@@ -40,7 +40,8 @@ type FeeCustomOverlayProps = {
   currentSelectedFeeOptionKey: number;
   open?: boolean;
   onClose: () => void;
-  onConfirm: (feeCoinId: string, gasAmount?: string, gasRate?: string) => void;
+  onChangeFeeCoin: (feeCoinId: string) => void;
+  onConfirm: (gasAmount?: string, gasRate?: string) => void;
 };
 
 export default function FeeCustomOverlay({
@@ -51,6 +52,7 @@ export default function FeeCustomOverlay({
   feeCoinId,
   currentSelectedFeeOptionKey,
   onClose,
+  onChangeFeeCoin,
   onConfirm,
 }: FeeCustomOverlayProps) {
   const { t } = useTranslation();
@@ -61,17 +63,15 @@ export default function FeeCustomOverlay({
 
   const [inputGasAmount, setInputGasAmount] = useState('');
   const [inputGasRate, setInputGasRate] = useState('');
-  const [selectedFeeCoinId, setSelectedFeeCoinId] = useState(feeCoinId);
 
-  const selectedFeeCoin = useMemo(() => feeAssets.find(({ asset }) => getCoinId(asset) === selectedFeeCoinId), [feeAssets, selectedFeeCoinId]);
+  const selectedFeeCoin = useMemo(() => feeAssets.find(({ asset }) => getCoinId(asset) === feeCoinId), [feeAssets, feeCoinId]);
 
   const coinSymbol = selectedFeeCoin?.asset.symbol;
   const decimals = selectedFeeCoin?.asset.decimals || 0;
 
-  const isFeeCoinChanged = feeCoinId !== selectedFeeCoinId;
-  const isFeeCoinOnlyChanged = isFeeCoinChanged && !inputGasRate && !inputGasAmount;
+  const gasRatePlaceHolder = selectedFeeCoin?.gasRate[currentSelectedFeeOptionKey] || baseGasRate;
 
-  const currentGasRate = inputGasRate ? inputGasRate : isFeeCoinChanged ? selectedFeeCoin?.gasRate[currentSelectedFeeOptionKey] || baseGasRate : baseGasRate;
+  const currentGasRate = inputGasRate ? inputGasRate : selectedFeeCoin?.gasRate[currentSelectedFeeOptionKey] || baseGasRate;
   const currentGas = inputGasAmount || baseGasAmount;
 
   const displayFeeAmount = useMemo(() => toDisplayDenomAmount(times(currentGasRate, currentGas), decimals), [currentGas, currentGasRate, decimals]);
@@ -101,10 +101,8 @@ export default function FeeCustomOverlay({
   };
 
   const onHandleConfirm = () => {
-    if (isFeeCoinOnlyChanged) {
-      onConfirm(selectedFeeCoinId);
-    } else {
-      onConfirm(selectedFeeCoinId, currentGas, currentGasRate);
+    if (inputGasAmount || inputGasRate) {
+      onConfirm(currentGas, currentGasRate);
     }
     reset();
   };
@@ -150,9 +148,9 @@ export default function FeeCustomOverlay({
         <InputContainer>
           <CoinSelectBox
             coinList={feeAssets}
-            currentCoinId={selectedFeeCoinId}
-            onClickCoin={(chainId) => {
-              setSelectedFeeCoinId(chainId);
+            currentCoinId={feeCoinId}
+            onClickCoin={(coinId) => {
+              onChangeFeeCoin(coinId);
             }}
             label={t('components.Fee.CosmosFee.components.FeeSettingBottomSheet.components.FeeCustomOverlay.index.feeToken')}
             bottomSheetTitle={t('components.Fee.CosmosFee.components.FeeSettingBottomSheet.components.FeeCustomOverlay.index.selectFeeToken')}
@@ -178,7 +176,7 @@ export default function FeeCustomOverlay({
           />
           <StandardInput
             label={t('components.Fee.CosmosFee.components.FeeSettingBottomSheet.components.FeeCustomOverlay.index.gasRate')}
-            placeholder={isFeeCoinChanged ? selectedFeeCoin?.gasRate[currentSelectedFeeOptionKey] : baseGasRate}
+            placeholder={gasRatePlaceHolder}
             error={!!inputGasRateErrorMsg}
             helperText={inputGasRateErrorMsg}
             value={inputGasRate}

--- a/src/components/Fee/CosmosFee/components/FeeSettingBottomSheet/index.tsx
+++ b/src/components/Fee/CosmosFee/components/FeeSettingBottomSheet/index.tsx
@@ -8,6 +8,7 @@ import TextButton from '@/components/common/TextButton';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
 import type { CosmosFeeAsset } from '@/types/cosmos/fee';
 import { times, toDisplayDenomAmount } from '@/utils/numbers';
+import { toastSuccess } from '@/utils/toast';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import { Body, Container, FeeCustomContainer, Header, HeaderTitle, StyledBottomSheet } from './styled';
@@ -153,12 +154,16 @@ export default function FeeSettingBottomSheet({
           feeAssets={availableFeeAssets}
           feeCoinId={selectedCustomFeeCoinId}
           currentSelectedFeeOptionKey={currentSelectedFeeOptionKey}
-          onConfirm={(feeCoinId, gasAmount, gasRate) => {
+          onChangeFeeCoin={(feeCoinId) => {
             onChangeFeeCoinId?.(feeCoinId);
+            toastSuccess(t('components.Fee.CosmosFee.FeeSettingBottomSheet.index.changesApplied'));
+          }}
+          onConfirm={(gasAmount, gasRate) => {
             if (gasAmount && gasRate) {
               onChangeGas?.(gasAmount);
               onChangeGasRate?.(gasRate);
               onSelectOption?.(customFeeStepKey);
+              toastSuccess(t('components.Fee.CosmosFee.FeeSettingBottomSheet.index.changesApplied'));
             }
 
             onHandelClose();

--- a/src/components/Fee/EVMFee/components/FeeSettingBottomSheet/index.tsx
+++ b/src/components/Fee/EVMFee/components/FeeSettingBottomSheet/index.tsx
@@ -12,6 +12,7 @@ import type { FeeType } from '@/types/evm/fee';
 import { times, toDisplayDenomAmount } from '@/utils/numbers';
 import { getCoinId, getUniqueChainIdWithManual, isMatchingUniqueChainId, parseCoinId } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
+import { toastSuccess } from '@/utils/toast';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import { Body, Container, FeeCustomContainer, Header, HeaderTitle, StyledBottomSheet } from './styled';
@@ -240,6 +241,8 @@ export default function FeeSettingBottomSheet({
               onChangePriorityFee?.(priorityFeeAmount);
               onSelectOption?.(customFeeStepKey);
 
+              toastSuccess(t('components.FeeSettingBottomSheet.index.changesApplied'));
+
               onHandelClose();
             }}
           />
@@ -257,6 +260,8 @@ export default function FeeSettingBottomSheet({
               onChangeGas?.(gasAmount);
               onChangeGasPrice?.(gasPrice);
               onSelectOption?.(customFeeStepKey);
+
+              toastSuccess(t('components.FeeSettingBottomSheet.index.changesApplied'));
 
               onHandelClose();
             }}

--- a/src/components/Wrapper/components/MigrationChecker/index.tsx
+++ b/src/components/Wrapper/components/MigrationChecker/index.tsx
@@ -36,6 +36,7 @@ import {
   LoadingProgressText,
   RightArrowIconContainer,
 } from './styled';
+import { Splash } from '../Init/styled';
 
 import RightArrow from '@/assets/images/icons/RightArrow14.svg';
 
@@ -138,7 +139,7 @@ export default function MigrationChecker({ children }: MigrationCheckerProps) {
   }, []);
 
   if (isMigrateComplete === undefined) {
-    return null;
+    return <Splash />;
   }
 
   if (!isMigrateComplete) {

--- a/src/components/Wrapper/components/NavigationGate/index.tsx
+++ b/src/components/Wrapper/components/NavigationGate/index.tsx
@@ -42,7 +42,8 @@ type NavigationGateProps = {
 export default function NavigationGate({ children }: NavigationGateProps) {
   const navigate = useNavigate();
 
-  const { userAccounts, requestQueue } = useExtensionStorageStore((state) => state);
+  const userAccounts = useExtensionStorageStore((state) => state.userAccounts);
+  const requestQueue = useExtensionStorageStore((state) => state.requestQueue);
 
   useEffect(() => {
     void (async () => {

--- a/src/hooks/aptos/useEstimateGasPrice.ts
+++ b/src/hooks/aptos/useEstimateGasPrice.ts
@@ -50,7 +50,7 @@ export function useEstimateGasPrice({ coinId, config }: UseEstimateGasPriceProps
     }
   };
 
-  const { data, isLoading, error, refetch } = useFetch({
+  const { data, isLoading, isFetching, error, refetch } = useFetch({
     queryKey: ['useEstimateGasPrice', coinId],
     fetchFunction: () => fetcher(),
     config: {
@@ -59,5 +59,5 @@ export function useEstimateGasPrice({ coinId, config }: UseEstimateGasPriceProps
     },
   });
 
-  return { data, error, refetch, isLoading };
+  return { data, error, refetch, isLoading, isFetching };
 }

--- a/src/hooks/cosmos/osmoEip/useOsmoEipFee.ts
+++ b/src/hooks/cosmos/osmoEip/useOsmoEipFee.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+
+import { useFetch, type UseFetchConfig } from '@/hooks/common/useFetch';
+import { useChainList } from '@/hooks/useChainList';
+import type { OsmoEipFeeResponse } from '@/types/cosmos/feemarket';
+import { get } from '@/utils/axios';
+import { buildRequestUrl } from '@/utils/fetch';
+import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
+
+type UseOsmoEipFeeProps = { config?: UseFetchConfig } | undefined;
+
+const OSMOSIS_CHAIN_ID = 'osmosis';
+
+export function useOsmoEipFee({ config }: UseOsmoEipFeeProps = {}) {
+  const { chainList } = useChainList();
+  const osmoChain = chainList.cosmosChains?.find((item) => item.id === OSMOSIS_CHAIN_ID);
+
+  const requestURLs = useMemo(() => {
+    if (!osmoChain?.lcdUrls) return [];
+
+    const feemarketEndpoints = osmoChain?.lcdUrls.map((chainEndpoint) => buildRequestUrl(chainEndpoint.url, `osmosis/txfees/v1beta1/cur_eip_base_fee`));
+
+    return feemarketEndpoints;
+  }, [osmoChain?.lcdUrls]);
+
+  const fetcher = async () => {
+    return await fetchWithFailover(requestURLs, async (url) => {
+      const response = await get<OsmoEipFeeResponse>(url);
+
+      return response;
+    });
+  };
+
+  const { data, isLoading, isFetching, error, refetch } = useFetch({
+    queryKey: ['osmoEipFee'],
+    fetchFunction: () => fetcher(),
+    config: {
+      refetchInterval: false,
+      retry: false,
+      enabled: !!requestURLs.length,
+      ...config,
+    },
+  });
+
+  return { data, error, refetch, isLoading, isFetching };
+}

--- a/src/hooks/cosmos/osmoEip/useOsmoFee.ts
+++ b/src/hooks/cosmos/osmoEip/useOsmoFee.ts
@@ -1,0 +1,110 @@
+import { useMemo } from 'react';
+
+import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
+import type { AllCosmosAccountAssets } from '@/types/accountAssets';
+import { divide, times } from '@/utils/numbers';
+import { isMatchingCoinId, parseCoinId } from '@/utils/queryParamGenerator';
+import { isEqualsIgnoringCase } from '@/utils/string';
+
+import { useOsmoEipFee } from './useOsmoEipFee';
+import { useOsmoFeeToken } from './useOsmoFeeToken';
+import { useOsmoSpotPrice } from './useOsmoSpotPrice';
+import type { UseFetchConfig } from '../../common/useFetch';
+
+type UseOsmoFeeProps =
+  | {
+      selectedFeeCoinId?: string;
+      config?: UseFetchConfig;
+    }
+  | undefined;
+
+const DEFAULT_GAS_RATES = ['0.04', '0.045', '0.05'];
+const OSMO_CHAIN_ID = 'osmosis';
+const OSMO_COIN_ID = 'uosmo';
+
+export function useOsmoFee(props: UseOsmoFeeProps = {}) {
+  const { selectedFeeCoinId, config } = props;
+
+  const { data: accountAssets, isLoading: isFetchingAccountAssets } = useAccountAllAssets({
+    disableDupeEthermint: true,
+    filterByPreferAccountType: true,
+  });
+
+  const { data: baseFeeTokens } = useOsmoFeeToken({ config });
+  const { data: osmoGasPrice, isFetching: isFetchingOsmoEipFee } = useOsmoEipFee({ config });
+
+  const isOsmoCoin = useMemo(() => {
+    if (!selectedFeeCoinId) return true;
+
+    return parseCoinId(selectedFeeCoinId).id === OSMO_COIN_ID;
+  }, [selectedFeeCoinId]);
+
+  const availableFeeTokens = useMemo(() => {
+    const osmoCoin = findOsmoCoin(accountAssets?.allCosmosAccountAssets);
+    const otherTokens = findOtherFeeTokens(accountAssets?.allCosmosAccountAssets, baseFeeTokens?.fee_tokens);
+
+    return [osmoCoin, ...otherTokens].filter((item) => !!item);
+  }, [accountAssets?.allCosmosAccountAssets, baseFeeTokens?.fee_tokens]);
+
+  const currentFeeCoin = useMemo(() => {
+    if (isOsmoCoin) return availableFeeTokens[0];
+
+    return availableFeeTokens.find((token) => token?.asset && selectedFeeCoinId && isMatchingCoinId(token.asset, selectedFeeCoinId));
+  }, [isOsmoCoin, availableFeeTokens, selectedFeeCoinId]);
+
+  const osmoGasRate = useMemo(() => {
+    return calculateOsmoGasRates(osmoGasPrice?.base_fee);
+  }, [osmoGasPrice?.base_fee]);
+
+  const { data: selectedFeeTokenGasRate, isFetching: isFetchingOsmoSpotPrice } = useOsmoSpotPrice(
+    !isOsmoCoin && selectedFeeCoinId ? { feeCoinDenom: parseCoinId(selectedFeeCoinId).id, config } : { config },
+  );
+
+  const currentFeeCoinGasRateStep = useMemo(() => {
+    if (isOsmoCoin) return osmoGasRate;
+
+    const spotPrice = selectedFeeTokenGasRate?.spot_price;
+    if (!spotPrice) return ['1', '1', '1'];
+
+    return calculateCustomTokenGasRates(osmoGasRate, spotPrice);
+  }, [isOsmoCoin, osmoGasRate, selectedFeeTokenGasRate?.spot_price]);
+
+  const isLoading = isFetchingOsmoEipFee || isFetchingOsmoSpotPrice || isFetchingAccountAssets;
+
+  return {
+    availableFeeCoin: availableFeeTokens,
+    currentFeeCoin,
+    currentFeeCoinGasRateStep,
+    isLoading,
+  };
+}
+
+function findOsmoCoin(assets: AllCosmosAccountAssets[] | undefined) {
+  return assets?.find((asset) => asset.asset.id === OSMO_COIN_ID && asset.chain.id === OSMO_CHAIN_ID);
+}
+
+function findOtherFeeTokens(
+  assets: AllCosmosAccountAssets[] | undefined,
+  feeTokens:
+    | {
+        denom: string;
+        poolID: string;
+      }[]
+    | undefined,
+) {
+  if (!feeTokens) return [];
+
+  return feeTokens.map((token) => assets?.find((asset) => asset.chain.id === OSMO_CHAIN_ID && isEqualsIgnoringCase(asset.asset.id, token.denom)));
+}
+
+function calculateOsmoGasRates(baseFee?: string) {
+  if (!baseFee) return DEFAULT_GAS_RATES;
+
+  return [times(baseFee, '1.05'), times(baseFee, '2'), times(baseFee, '3')];
+}
+
+function calculateCustomTokenGasRates(osmoGasRates: readonly string[], spotPrice: string) {
+  const priceRatio = divide('1', spotPrice);
+
+  return [times(priceRatio, osmoGasRates[0]), times(priceRatio, osmoGasRates[1]), times(priceRatio, osmoGasRates[2])];
+}

--- a/src/hooks/cosmos/osmoEip/useOsmoFee.ts
+++ b/src/hooks/cosmos/osmoEip/useOsmoFee.ts
@@ -22,24 +22,23 @@ const DEFAULT_GAS_RATES = ['0.04', '0.045', '0.05'];
 const OSMO_CHAIN_ID = 'osmosis';
 const OSMO_COIN_ID = 'uosmo';
 
-export function useOsmoFee(props: UseOsmoFeeProps = {}) {
-  const { selectedFeeCoinId, config } = props;
-
+export function useOsmoFee({ selectedFeeCoinId, config }: UseOsmoFeeProps = {}) {
   const { data: accountAssets, isLoading: isFetchingAccountAssets } = useAccountAllAssets({
     disableDupeEthermint: true,
     filterByPreferAccountType: true,
   });
 
   const { data: baseFeeTokens } = useOsmoFeeToken({ config });
-  const { data: osmoGasPrice, isFetching: isFetchingOsmoEipFee } = useOsmoEipFee({ config });
+  const { data: osmoEipFee, isFetching: isFetchingOsmoEipFee } = useOsmoEipFee({ config });
 
   const isOsmoCoin = useMemo(() => {
     if (!selectedFeeCoinId) return true;
+    const { id, chainId } = parseCoinId(selectedFeeCoinId);
 
-    return parseCoinId(selectedFeeCoinId).id === OSMO_COIN_ID;
+    return id === OSMO_COIN_ID && chainId === OSMO_CHAIN_ID;
   }, [selectedFeeCoinId]);
 
-  const availableFeeTokens = useMemo(() => {
+  const availableFeeCoin = useMemo(() => {
     const osmoCoin = findOsmoCoin(accountAssets?.allCosmosAccountAssets);
     const otherTokens = findOtherFeeTokens(accountAssets?.allCosmosAccountAssets, baseFeeTokens?.fee_tokens);
 
@@ -47,14 +46,14 @@ export function useOsmoFee(props: UseOsmoFeeProps = {}) {
   }, [accountAssets?.allCosmosAccountAssets, baseFeeTokens?.fee_tokens]);
 
   const currentFeeCoin = useMemo(() => {
-    if (isOsmoCoin) return availableFeeTokens[0];
+    if (isOsmoCoin) return availableFeeCoin[0];
 
-    return availableFeeTokens.find((token) => token?.asset && selectedFeeCoinId && isMatchingCoinId(token.asset, selectedFeeCoinId));
-  }, [isOsmoCoin, availableFeeTokens, selectedFeeCoinId]);
+    return availableFeeCoin.find((token) => token?.asset && selectedFeeCoinId && isMatchingCoinId(token.asset, selectedFeeCoinId));
+  }, [isOsmoCoin, availableFeeCoin, selectedFeeCoinId]);
 
   const osmoGasRate = useMemo(() => {
-    return calculateOsmoGasRates(osmoGasPrice?.base_fee);
-  }, [osmoGasPrice?.base_fee]);
+    return calculateOsmoGasRates(osmoEipFee?.base_fee);
+  }, [osmoEipFee?.base_fee]);
 
   const { data: selectedFeeTokenGasRate, isFetching: isFetchingOsmoSpotPrice } = useOsmoSpotPrice(
     !isOsmoCoin && selectedFeeCoinId ? { feeCoinDenom: parseCoinId(selectedFeeCoinId).id, config } : { config },
@@ -72,7 +71,7 @@ export function useOsmoFee(props: UseOsmoFeeProps = {}) {
   const isLoading = isFetchingOsmoEipFee || isFetchingOsmoSpotPrice || isFetchingAccountAssets;
 
   return {
-    availableFeeCoin: availableFeeTokens,
+    availableFeeCoin,
     currentFeeCoin,
     currentFeeCoinGasRateStep,
     isLoading,

--- a/src/hooks/cosmos/osmoEip/useOsmoFeeToken.ts
+++ b/src/hooks/cosmos/osmoEip/useOsmoFeeToken.ts
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+
+import { useFetch, type UseFetchConfig } from '@/hooks/common/useFetch';
+import { useChainList } from '@/hooks/useChainList';
+import type { OsmoFeeTokenResponse } from '@/types/cosmos/feemarket';
+import { get } from '@/utils/axios';
+import { buildRequestUrl } from '@/utils/fetch';
+import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
+
+type UseOsmoFeeTokenProps = { config?: UseFetchConfig } | undefined;
+
+const OSMOSIS_CHAIN_ID = 'osmosis';
+
+export function useOsmoFeeToken({ config }: UseOsmoFeeTokenProps = {}) {
+  const { chainList } = useChainList();
+  const osmoChain = chainList.cosmosChains?.find((item) => item.id === OSMOSIS_CHAIN_ID);
+
+  const requestURLs = useMemo(() => {
+    if (!osmoChain?.lcdUrls) return [];
+
+    const feemarketEndpoints = osmoChain?.lcdUrls.map((chainEndpoint) => buildRequestUrl(chainEndpoint.url, `osmosis/txfees/v1beta1/fee_tokens`));
+
+    return feemarketEndpoints;
+  }, [osmoChain?.lcdUrls]);
+
+  const fetcher = async () => {
+    return await fetchWithFailover(requestURLs, async (url) => {
+      const response = await get<OsmoFeeTokenResponse>(url);
+
+      return response;
+    });
+  };
+
+  const { data, isLoading, error, refetch } = useFetch({
+    queryKey: ['osmoFeeToken'],
+    fetchFunction: () => fetcher(),
+    config: {
+      refetchInterval: false,
+      retry: false,
+      enabled: !!requestURLs.length,
+      ...config,
+    },
+  });
+
+  return { data, error, refetch, isLoading };
+}

--- a/src/hooks/cosmos/osmoEip/useOsmoSpotPrice.ts
+++ b/src/hooks/cosmos/osmoEip/useOsmoSpotPrice.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+
+import { useFetch, type UseFetchConfig } from '@/hooks/common/useFetch';
+import { useChainList } from '@/hooks/useChainList';
+import type { OsmoSpotPriceResponse } from '@/types/cosmos/feemarket';
+import { get } from '@/utils/axios';
+import { buildRequestUrl } from '@/utils/fetch';
+import { fetchWithFailover } from '@/utils/fetch/fetchWithFailover';
+
+type UseOsmoEipFeeProps = { feeCoinDenom?: string; config?: UseFetchConfig } | undefined;
+
+const OSMOSIS_CHAIN_ID = 'osmosis';
+
+export function useOsmoSpotPrice({ feeCoinDenom, config }: UseOsmoEipFeeProps = {}) {
+  const { chainList } = useChainList();
+  const osmoChain = chainList.cosmosChains?.find((item) => item.id === OSMOSIS_CHAIN_ID);
+
+  const requestURLs = useMemo(() => {
+    if (!osmoChain?.lcdUrls || !feeCoinDenom) return [];
+
+    const feemarketEndpoints = osmoChain?.lcdUrls.map((chainEndpoint) =>
+      buildRequestUrl(chainEndpoint.url, `osmosis/txfees/v1beta1/spot_price_by_denom?denom=${feeCoinDenom}`),
+    );
+
+    return feemarketEndpoints;
+  }, [feeCoinDenom, osmoChain?.lcdUrls]);
+
+  const fetcher = async () => {
+    return await fetchWithFailover(requestURLs, async (url) => {
+      const response = await get<OsmoSpotPriceResponse>(url);
+
+      return response;
+    });
+  };
+
+  const { data, isLoading, isFetching, error, refetch } = useFetch({
+    queryKey: ['osmoSpotPrice', feeCoinDenom],
+    fetchFunction: () => fetcher(),
+    config: {
+      refetchInterval: false,
+      retry: false,
+      enabled: !!feeCoinDenom && !!requestURLs.length,
+      ...config,
+    },
+  });
+
+  return { data, error, refetch, isLoading, isFetching };
+}

--- a/src/hooks/cosmos/osmoEip/useOsmoSpotPrice.ts
+++ b/src/hooks/cosmos/osmoEip/useOsmoSpotPrice.ts
@@ -19,7 +19,7 @@ export function useOsmoSpotPrice({ feeCoinDenom, config }: UseOsmoEipFeeProps = 
     if (!osmoChain?.lcdUrls || !feeCoinDenom) return [];
 
     const feemarketEndpoints = osmoChain?.lcdUrls.map((chainEndpoint) =>
-      buildRequestUrl(chainEndpoint.url, `osmosis/txfees/v1beta1/spot_price_by_denom?denom=${feeCoinDenom}`),
+      buildRequestUrl(chainEndpoint.url, `osmosis/txfees/v1beta1/spot_price_by_denom?denom=${encodeURIComponent(feeCoinDenom)}`),
     );
 
     return feemarketEndpoints;

--- a/src/hooks/current/useCurrentRequestQueue.ts
+++ b/src/hooks/current/useCurrentRequestQueue.ts
@@ -17,22 +17,21 @@ export function useCurrentRequestQueue() {
   const deQueue = async (path?: string) => {
     const newQueues = requestQueue.slice(1);
 
-    await updateExtensionStorageStore('requestQueue', newQueues);
-
     if (newQueues.length === 0) {
       if (isSidePanelView()) {
         navigate({ to: path ?? Home.to });
-        return;
       } else {
-        await closePopupWindow();
-      }
-
-      if (path) {
-        navigate({
-          to: path,
-        });
+        if (path) {
+          navigate({
+            to: path,
+          });
+        } else {
+          await closePopupWindow();
+        }
       }
     }
+
+    await updateExtensionStorageStore('requestQueue', newQueues);
 
     return requestQueue.length > 0 ? requestQueue[0] : null;
   };

--- a/src/lang/translation/en.json
+++ b/src/lang/translation/en.json
@@ -155,7 +155,8 @@
       "index": {
         "title": "Select Fee Option",
         "customDescription": "Do you want a advanced setting?",
-        "custom": "Custom"
+        "custom": "Custom",
+        "changesApplied": "Changes applied"
       }
     },
     "Fee": {
@@ -275,7 +276,8 @@
           "index": {
             "title": "Select Fee Option",
             "customDescription": "Do you want a advanced setting?",
-            "custom": "Custom"
+            "custom": "Custom",
+            "changesApplied": "Changes applied"
           }
         },
         "index": {

--- a/src/lang/translation/en.json
+++ b/src/lang/translation/en.json
@@ -2913,7 +2913,8 @@
           "entry": {
             "insufficientBalance": "Insufficient balance",
             "reject": "Reject",
-            "sign": "Sign"
+            "sign": "Sign",
+            "calculatingFee": "Calculating fee"
           }
         },
         "add-chain": {
@@ -3065,7 +3066,8 @@
             "insufficientBalance": "Insufficient balance",
             "failedToSimulate": "Fail to simulate",
             "reject": "Reject",
-            "sign": "Sign"
+            "sign": "Sign",
+            "calculatingFee": "Calculating fee"
           }
         },
         "sign-message": {

--- a/src/lang/translation/en.json
+++ b/src/lang/translation/en.json
@@ -2676,7 +2676,8 @@
               "reject": "Reject",
               "sign": "Sign",
               "notSimulated": "Simulating transaction...",
-              "memoOverflow": "Memo is too long. Please shorten it."
+              "memoOverflow": "Memo is too long. Please shorten it.",
+              "calculatingFee": "Calculating fee"
             },
             "components": {
               "TxMessage": {
@@ -2779,7 +2780,8 @@
               "reject": "Reject",
               "sign": "Sign",
               "notSimulated": "Simulating transaction...",
-              "memoOverflow": "Memo is too long. Please shorten it."
+              "memoOverflow": "Memo is too long. Please shorten it.",
+              "calculatingFee": "Calculating fee"
             }
           },
           "message": {

--- a/src/lang/translation/ko.json
+++ b/src/lang/translation/ko.json
@@ -2114,7 +2114,8 @@
             "failedToSimulate": "시뮬레이션에 실패했습니다",
             "insufficientBalance": "잔액이 부족합니다",
             "reject": "거부",
-            "sign": "사인"
+            "sign": "사인",
+            "calculatingFee": "수수료를 계산중입니다"
           }
         }
       },
@@ -2525,7 +2526,8 @@
           "entry": {
             "insufficientBalance": "잔액이 부족합니다",
             "reject": "거부",
-            "sign": "사인"
+            "sign": "사인",
+            "calculatingFee": "수수료를 계산중입니다"
           }
         }
       },

--- a/src/lang/translation/ko.json
+++ b/src/lang/translation/ko.json
@@ -2319,7 +2319,8 @@
               "reject": "거부",
               "sign": "사인",
               "notSimulated": "트랜잭션 확인 중입니다.",
-              "memoOverflow": "메모를 조금 더 간단하게 입력해 주세요"
+              "memoOverflow": "메모를 조금 더 간단하게 입력해 주세요",
+              "calculatingFee": "수수료를 계산중입니다"
             }
           },
           "direct": {
@@ -2369,7 +2370,8 @@
               "reject": "거부",
               "sign": "사인",
               "notSimulated": "트랜잭션 확인 중입니다.",
-              "memoOverflow": "메모를 조금 더 간단하게 입력해 주세요"
+              "memoOverflow": "메모를 조금 더 간단하게 입력해 주세요",
+              "calculatingFee": "수수료를 계산중입니다"
             }
           },
           "entry": {

--- a/src/lang/translation/ko.json
+++ b/src/lang/translation/ko.json
@@ -456,7 +456,8 @@
           "index": {
             "custom": "사용자 지정",
             "customDescription": "고급 설정을 사용하시겠어요?",
-            "title": "수수료 옵션을 선택하세요"
+            "title": "수수료 옵션을 선택하세요",
+            "changesApplied": "변경사항이 적용되었습니다"
           }
         },
         "components": {
@@ -564,7 +565,8 @@
       "index": {
         "custom": "커스텀",
         "customDescription": "고급 설정을 사용하시겠어요?",
-        "title": "수수료 옵션을 선택하세요"
+        "title": "수수료 옵션을 선택하세요",
+        "changesApplied": "변경사항이 적용되었습니다"
       }
     },
     "FinalReviewBottomSheet": {

--- a/src/pages/popup/-components/BaseTxInfo/index.tsx
+++ b/src/pages/popup/-components/BaseTxInfo/index.tsx
@@ -28,6 +28,7 @@ import {
   RowContainer,
   RowLeftContainer,
   RowRightContainer,
+  StyledCircularProgress,
   TotalValue,
 } from './styled';
 
@@ -42,10 +43,11 @@ type BaseTxInfoProps = {
     label?: string;
   }[];
   disableFee?: boolean;
+  isLoadingFee?: boolean;
   onClickFee?: () => void;
 };
 
-export default function BaseTxInfo({ feeBaseAmount, feeCoinId, additionalFees, disableFee = false, onClickFee }: BaseTxInfoProps) {
+export default function BaseTxInfo({ feeBaseAmount, feeCoinId, additionalFees, disableFee = false, isLoadingFee = false, onClickFee }: BaseTxInfoProps) {
   const { t } = useTranslation();
 
   const { userCurrencyPreference } = useExtensionStorageStore((state) => state);
@@ -213,26 +215,30 @@ export default function BaseTxInfo({ feeBaseAmount, feeCoinId, additionalFees, d
             <FeeCustomButton disabled={disableFee} onClick={onClickFee}>
               {feeCoin &&
                 (displayFeeAmount ? (
-                  <EstimatedFeeTextContainer data-is-disabled={disableFee}>
-                    <BalanceDisplay
-                      typoOfIntegers="h5n_M"
-                      typoOfDecimals="h7n_R"
-                      currency={userCurrencyPreference}
-                      fixed={6}
-                      isDisableLeadingCurreny
-                      isDisableHidden
-                    >
-                      {displayFeeAmount}
-                    </BalanceDisplay>
-                    &nbsp;
-                    <Base1300Text variant="h7n_M">{feeCoin?.asset.symbol}</Base1300Text>
-                    &nbsp;
-                    <Base1300Text variant="b2_M">{'('}</Base1300Text>
-                    <BalanceDisplay typoOfIntegers="h5n_M" typoOfDecimals="h7n_R" currency={userCurrencyPreference} isDisableHidden>
-                      {value}
-                    </BalanceDisplay>
-                    <Base1300Text variant="b2_M">{')'}</Base1300Text>
-                  </EstimatedFeeTextContainer>
+                  isLoadingFee ? (
+                    <StyledCircularProgress size={17} />
+                  ) : (
+                    <EstimatedFeeTextContainer data-is-disabled={disableFee}>
+                      <BalanceDisplay
+                        typoOfIntegers="h5n_M"
+                        typoOfDecimals="h7n_R"
+                        currency={userCurrencyPreference}
+                        fixed={6}
+                        isDisableLeadingCurreny
+                        isDisableHidden
+                      >
+                        {displayFeeAmount}
+                      </BalanceDisplay>
+                      &nbsp;
+                      <Base1300Text variant="h7n_M">{feeCoin?.asset.symbol}</Base1300Text>
+                      &nbsp;
+                      <Base1300Text variant="b2_M">{'('}</Base1300Text>
+                      <BalanceDisplay typoOfIntegers="h5n_M" typoOfDecimals="h7n_R" currency={userCurrencyPreference} isDisableHidden>
+                        {value}
+                      </BalanceDisplay>
+                      <Base1300Text variant="b2_M">{')'}</Base1300Text>
+                    </EstimatedFeeTextContainer>
+                  )
                 ) : (
                   <Base1300Text variant="b2_M">{'-'}</Base1300Text>
                 ))}

--- a/src/pages/popup/-components/BaseTxInfo/styled.tsx
+++ b/src/pages/popup/-components/BaseTxInfo/styled.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { CircularProgress, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 import BaseChainImage from '@/components/common/BaseChainImage';
@@ -109,6 +109,12 @@ export const EstimatedFeeTextContainer = styled('div')<EstimatedFeeTextContainer
   alignItems: 'baseline',
 
   borderBottom: props['data-is-disabled'] ? 'none' : `0.1rem solid ${theme.palette.color.base1300}`,
+}));
+
+export const StyledCircularProgress = styled(CircularProgress)(({ theme }) => ({
+  '&.MuiCircularProgress-root': {
+    color: theme.palette.accentColor.purple400,
+  },
 }));
 
 export const AdditionalEstimatedFeeTextContainer = styled(EstimatedFeeTextContainer)<EstimatedFeeTextContainerProps>(({ theme, ...props }) => ({

--- a/src/pages/popup/aptos/transaction/-entry.tsx
+++ b/src/pages/popup/aptos/transaction/-entry.tsx
@@ -129,6 +129,11 @@ export default function Entry({ request }: EntryProps) {
   const simulateTransaction = useSimulateTx({ coinId: nativeAccountAssetCoinId, payload: simulationPayload });
   const estimateGasPrice = useEstimateGasPrice({ coinId: nativeAccountAssetCoinId });
 
+  const isCalculatingFee = useMemo(
+    () => simulateTransaction.isFetching || estimateGasPrice.isFetching,
+    [estimateGasPrice.isFetching, simulateTransaction.isFetching],
+  );
+
   const currentGasPrice = useMemo(() => {
     if (!estimateGasPrice.data) {
       return null;
@@ -158,11 +163,14 @@ export default function Entry({ request }: EntryProps) {
     if (gt(estimatedFeeAmount, nativeAccountAsset?.balance || '0')) {
       return t('pages.popup.aptos.transaction.entry.insufficientBalance');
     }
+    if (isCalculatingFee) {
+      return t('pages.popup.aptos.transaction.entry.calculatingFee');
+    }
     if (!simulateTransaction.data?.[0]?.success) {
       return t('pages.popup.aptos.transaction.entry.failedToSimulate');
     }
     return '';
-  }, [estimatedFeeAmount, nativeAccountAsset?.balance, simulateTransaction.data, t]);
+  }, [estimatedFeeAmount, isCalculatingFee, nativeAccountAsset?.balance, simulateTransaction.data, t]);
 
   const handleOnSign = useCallback(async () => {
     try {
@@ -251,7 +259,7 @@ export default function Entry({ request }: EntryProps) {
           <DappInfo image={siteIconURL} name={siteTitle} url={origin} />
           <Divider />
           <TxBaseInfoContainer>
-            <BaseTxInfo feeCoinId={nativeAccountAssetCoinId} feeBaseAmount={estimatedFeeAmount} disableFee />
+            <BaseTxInfo feeCoinId={nativeAccountAssetCoinId} feeBaseAmount={estimatedFeeAmount} isLoadingFee={isCalculatingFee} disableFee />
           </TxBaseInfoContainer>
           <DividerContainer>
             <Divider />

--- a/src/pages/popup/cosmos/sign/amino/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/amino/-entry.tsx
@@ -13,6 +13,7 @@ import { COSMOS_DEFAULT_GAS, DEFAULT_GAS_MULTIPLY } from '@/constants/cosmos/gas
 import { COSMOS_MEMO_MAX_BYTES } from '@/constants/cosmos/tx';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
+import { useOsmoFee } from '@/hooks/cosmos/osmoEip/useOsmoFee';
 import { useAdditionalFee } from '@/hooks/cosmos/useAdditionalFee';
 import { useFees } from '@/hooks/cosmos/useFees';
 import { useSimulate } from '@/hooks/cosmos/useSimulate';
@@ -55,6 +56,8 @@ type EntryProps = {
   chain: CosmosChain;
 };
 
+const OSMO_CHAIN_ID = 'osmosis';
+
 export default function Entry({ request, chain }: EntryProps) {
   const { t } = useTranslation();
   const { deQueue } = useCurrentRequestQueue();
@@ -95,13 +98,31 @@ export default function Entry({ request, chain }: EntryProps) {
   };
 
   const { doc, isEditFee = true, isEditMemo = true, isCheckBalance = true } = params;
+  const isNeedOsmoEip1559 = useMemo(() => chain.id === OSMO_CHAIN_ID && !doc.fee.amount.length, [chain.id, doc.fee.amount.length]);
 
   const keyPair = useMemo(() => getKeypair(resolveSeiChainConfig(chain), currentAccount, currentPassword), [chain, currentAccount, currentPassword]);
 
   const [inputMemo, setInputMemo] = useState(doc.memo);
   const signingMemo = useMemo(() => (isEditMemo ? inputMemo : doc.memo), [doc.memo, inputMemo, isEditMemo]);
 
-  const { feeAssets, defaultGasRateKey, isFeemarketActive } = useFees({ coinId: accountAssetCoinId });
+  const [customFeeCoinId, setCustomFeeCoinId] = useState('');
+
+  const osmoEipFees = useOsmoFee(isNeedOsmoEip1559 ? { selectedFeeCoinId: customFeeCoinId } : { config: { enabled: false } });
+
+  const { feeAssets: basicFeeAssets, defaultGasRateKey, isFeemarketActive } = useFees({ coinId: accountAssetCoinId });
+
+  const feeAssets = useMemo(() => {
+    if (isNeedOsmoEip1559) {
+      return osmoEipFees.availableFeeCoin.map((item) => {
+        return {
+          ...item,
+          gasRate: osmoEipFees.currentFeeCoinGasRateStep,
+        };
+      });
+    }
+
+    return basicFeeAssets;
+  }, [isNeedOsmoEip1559, basicFeeAssets, osmoEipFees.availableFeeCoin, osmoEipFees.currentFeeCoinGasRateStep]);
 
   const inputFee = useMemo(
     () =>
@@ -118,12 +139,11 @@ export default function Entry({ request, chain }: EntryProps) {
   const currentFeeStepKey = useMemo(() => {
     if (customFeeStepKey !== undefined) return customFeeStepKey;
 
+    if (isNeedOsmoEip1559) return 1;
     return isEditFee ? defaultGasRateKey + 1 : 0;
-  }, [customFeeStepKey, defaultGasRateKey, isEditFee]);
+  }, [customFeeStepKey, defaultGasRateKey, isEditFee, isNeedOsmoEip1559]);
 
   const dappFromFeeAsset = useMemo(() => feeAssets.find((item) => item.asset.id === inputFee.denom), [feeAssets, inputFee.denom]);
-
-  const [customFeeCoinId, setCustomFeeCoinId] = useState('');
 
   const alternativeFeeAsset = useMemo(() => {
     if (customFeeCoinId) {
@@ -155,7 +175,7 @@ export default function Entry({ request, chain }: EntryProps) {
   }, [alternativeFeeAsset, dappFromFeeAsset]);
 
   const memoizedProtoTx = useMemo(() => {
-    if (isEditFee && assetForSimulation?.asset.id) {
+    if (isEditFee && assetForSimulation?.asset.id && !isNeedOsmoEip1559) {
       const pTx = protoTx(
         { ...doc, fee: { amount: [{ denom: assetForSimulation.asset.id, amount: '1' }], gas: COSMOS_DEFAULT_GAS } },
         [Buffer.from(new Uint8Array(64)).toString('base64')],
@@ -165,13 +185,14 @@ export default function Entry({ request, chain }: EntryProps) {
       return pTx ? protoTxBytes({ ...pTx }) : null;
     }
     return null;
-  }, [accountAsset?.address.accountType.pubkeyType, assetForSimulation?.asset.id, doc, isEditFee]);
+  }, [accountAsset?.address.accountType.pubkeyType, assetForSimulation?.asset.id, doc, isEditFee, isNeedOsmoEip1559]);
 
   const isPossibleSimulating =
     !!accountAssetCoinId &&
     !!memoizedProtoTx?.tx_bytes &&
     !!accountAsset?.chain.lcdUrls.map((item) => item.url).length &&
-    accountAsset?.chain.feeInfo.isSimulable;
+    accountAsset?.chain.feeInfo.isSimulable &&
+    !isNeedOsmoEip1559;
 
   const simulate = useSimulate({ coinId: accountAssetCoinId, txBytes: memoizedProtoTx?.tx_bytes });
 
@@ -192,7 +213,7 @@ export default function Entry({ request, chain }: EntryProps) {
 
   const alternativeGasRate = useMemo(() => alternativeFeeAsset?.gasRate, [alternativeFeeAsset?.gasRate]);
 
-  const feeOptions = useMemo(() => {
+  const basicFeeOptions = useMemo(() => {
     const dappFromOption = {
       gas: dappFromGas,
       gasRate: dappFromGasRate,
@@ -247,6 +268,53 @@ export default function Entry({ request, chain }: EntryProps) {
     isFeemarketActive,
   ]);
 
+  const feeOptions = useMemo(() => {
+    if (isNeedOsmoEip1559) {
+      const customOption = {
+        gas: customGasAmount,
+        gasRate: customGasRate,
+        coinId: alternativeFeeCoinId,
+        decimals: alternativeFeeAsset?.asset.decimals || 0,
+        denom: alternativeFeeAsset?.asset.id,
+        coinGeckoId: alternativeFeeAsset?.asset.coinGeckoId,
+        symbol: alternativeFeeAsset?.asset.symbol || '',
+        title: 'Custom',
+      };
+
+      const currnetFeeCoin = osmoEipFees.currentFeeCoin;
+
+      const feeStepNames = getCosmosFeeStepNames(false, osmoEipFees.currentFeeCoinGasRateStep);
+
+      return [
+        ...(osmoEipFees.currentFeeCoinGasRateStep?.map((item, i) => ({
+          gas: dappFromGas || COSMOS_DEFAULT_GAS,
+          gasRate: item,
+          coinId: currnetFeeCoin?.asset ? getCoinId(currnetFeeCoin.asset) : '',
+          decimals: currnetFeeCoin?.asset.decimals || 0,
+          denom: currnetFeeCoin?.asset.id,
+          coinGeckoId: currnetFeeCoin?.asset.coinGeckoId,
+          symbol: currnetFeeCoin?.asset.symbol || '',
+          title: feeStepNames[i],
+        })) || []),
+        customOption,
+      ];
+    }
+    return basicFeeOptions;
+  }, [
+    alternativeFeeAsset?.asset.coinGeckoId,
+    alternativeFeeAsset?.asset.decimals,
+    alternativeFeeAsset?.asset.id,
+    alternativeFeeAsset?.asset.symbol,
+    alternativeFeeCoinId,
+    customGasAmount,
+    customGasRate,
+    dappFromGas,
+    isNeedOsmoEip1559,
+    basicFeeOptions,
+    osmoEipFees.currentFeeCoin,
+    osmoEipFees.currentFeeCoinGasRateStep,
+  ]);
+
   const selectedFeeOption = useMemo(() => {
     return feeOptions[currentFeeStepKey];
   }, [currentFeeStepKey, feeOptions]);
@@ -254,6 +322,8 @@ export default function Entry({ request, chain }: EntryProps) {
   const isFeeCustomed = useMemo(() => currentFeeStepKey !== 0, [currentFeeStepKey]);
 
   const isFeeUpdateAllowed = useMemo(() => isEditFee || isFeeCustomed, [isFeeCustomed, isEditFee]);
+
+  const isCalculatingFee = useMemo(() => simulate.isFetching || osmoEipFees.isLoading, [osmoEipFees.isLoading, simulate.isFetching]);
 
   const baseFee = useMemo(() => times(selectedFeeOption.gas || '0', selectedFeeOption.gasRate || '0'), [selectedFeeOption.gas, selectedFeeOption.gasRate]);
 
@@ -285,6 +355,10 @@ export default function Entry({ request, chain }: EntryProps) {
       return t('pages.popup.cosmos.sign.amino.entry.insufficientFeeAmount');
     }
 
+    if (isCalculatingFee) {
+      return t('pages.popup.cosmos.sign.amino.entry.calculatingFee');
+    }
+
     if (isEditFee && isPossibleSimulating && !simulate.isFetched) {
       return t('pages.popup.cosmos.sign.amino.entry.notSimulated');
     }
@@ -300,6 +374,7 @@ export default function Entry({ request, chain }: EntryProps) {
     isCheckBalance,
     doc.fee.granter,
     doc.fee.payer,
+    isCalculatingFee,
     isEditFee,
     isPossibleSimulating,
     simulate.isFetched,
@@ -413,6 +488,7 @@ export default function Entry({ request, chain }: EntryProps) {
               feeBaseAmount={currentFee}
               disableFee={!isEditFee}
               additionalFees={additionalFee}
+              isLoadingFee={isCalculatingFee}
               onClickFee={() => {
                 setIsOpenFeeCustomBottomSheet(true);
               }}

--- a/src/pages/popup/cosmos/sign/amino/index.tsx
+++ b/src/pages/popup/cosmos/sign/amino/index.tsx
@@ -1,6 +1,7 @@
 import { produce } from 'immer';
 import { createFileRoute } from '@tanstack/react-router';
 
+import { Splash } from '@/components/Wrapper/components/Init/styled';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import AccessRequest from '@/pages/popup/-components/requests/AccessRequest';
@@ -44,7 +45,8 @@ function CosmosSignAmino() {
       );
     }
   }
-  return null;
+
+  return <Splash />;
 }
 
 function isCosSignAmino(queue: RequestQueue): queue is CosSignAmino {

--- a/src/pages/popup/cosmos/sign/direct/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/direct/-entry.tsx
@@ -279,6 +279,8 @@ export default function Entry({ request, chain }: EntryProps) {
     isFeemarketActive,
   ]);
 
+  const isCalculatingFee = useMemo(() => simulate.isFetching, [simulate.isFetching]);
+
   const selectedFeeOption = useMemo(() => {
     return feeOptions[currentFeeStepKey];
   }, [currentFeeStepKey, feeOptions]);
@@ -359,6 +361,10 @@ export default function Entry({ request, chain }: EntryProps) {
       return t('pages.popup.cosmos.sign.direct.entry.insufficientFeeAmount');
     }
 
+    if (isCalculatingFee) {
+      return t('pages.popup.cosmos.sign.direct.entry.calculatingFee');
+    }
+
     if (isEditFee && isPossibleSimulating && !simulate.isFetched) {
       return t('pages.popup.cosmos.sign.direct.entry.notSimulated');
     }
@@ -374,6 +380,7 @@ export default function Entry({ request, chain }: EntryProps) {
     fee?.granter,
     fee?.payer,
     inputMemoErrorMessage,
+    isCalculatingFee,
     isCheckBalance,
     isEditFee,
     isPossibleSimulating,
@@ -493,6 +500,7 @@ export default function Entry({ request, chain }: EntryProps) {
               feeBaseAmount={currentFee}
               disableFee={!isEditFee}
               additionalFees={additionalFee}
+              isLoadingFee={isCalculatingFee}
               onClickFee={() => {
                 setIsOpenFeeCustomBottomSheet(true);
               }}

--- a/src/pages/popup/cosmos/sign/direct/index.tsx
+++ b/src/pages/popup/cosmos/sign/direct/index.tsx
@@ -1,6 +1,7 @@
 import { produce } from 'immer';
 import { createFileRoute } from '@tanstack/react-router';
 
+import { Splash } from '@/components/Wrapper/components/Init/styled';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import AccessRequest from '@/pages/popup/-components/requests/AccessRequest';
@@ -44,7 +45,8 @@ function CosmosSignDirect() {
       );
     }
   }
-  return null;
+
+  return <Splash />;
 }
 
 function isCosSignDirect(queue: RequestQueue): queue is CosSignDirect {

--- a/src/pages/popup/evm/transaction/-entry.tsx
+++ b/src/pages/popup/evm/transaction/-entry.tsx
@@ -339,11 +339,15 @@ export default function Entry({ request }: EntryProps) {
   );
 
   const errorMessage = useMemo(() => {
+    if (fee.isFetching) {
+      return t('pages.popup.evm.transaction.entry.calculatingFee');
+    }
+
     if (gt(totalSpendNativeCoinDisplayAmount, nativeCoinDisplayBalance)) {
       return t('pages.popup.evm.transaction.entry.insufficientBalance');
     }
     return '';
-  }, [nativeCoinDisplayBalance, t, totalSpendNativeCoinDisplayAmount]);
+  }, [fee.isFetching, nativeCoinDisplayBalance, t, totalSpendNativeCoinDisplayAmount]);
 
   const handleOnSign = async () => {
     try {
@@ -462,6 +466,7 @@ export default function Entry({ request }: EntryProps) {
             <BaseTxInfo
               feeCoinId={currentFeeOption?.coinId || ''}
               feeBaseAmount={currentBaseFee}
+              isLoadingFee={fee.isFetching}
               onClickFee={() => {
                 setIsOpenFeeCustomBottomSheet(true);
               }}

--- a/src/pages/popup/iota/transaction/-entry.tsx
+++ b/src/pages/popup/iota/transaction/-entry.tsx
@@ -117,7 +117,11 @@ export default function Entry({ request }: EntryProps) {
     return undefined;
   }, [params, request.method]);
 
-  const { data: dryRunTransaction, error: dryRunTransactionError } = useDryRunTransaction({
+  const {
+    data: dryRunTransaction,
+    error: dryRunTransactionError,
+    isFetching: isDryRunTxFetching,
+  } = useDryRunTransaction({
     coinId: nativeAccountAssetCoinId,
     transaction: parsedTx,
   });
@@ -295,7 +299,7 @@ export default function Entry({ request }: EntryProps) {
           <DappInfo image={siteIconURL} name={siteTitle} url={origin} />
           <Divider />
           <TxBaseInfoContainer>
-            <BaseTxInfo feeCoinId={nativeAccountAssetCoinId} feeBaseAmount={expectedBaseFee} disableFee />
+            <BaseTxInfo feeCoinId={nativeAccountAssetCoinId} feeBaseAmount={expectedBaseFee} isLoadingFee={isDryRunTxFetching} disableFee />
           </TxBaseInfoContainer>
           <DividerContainer>
             <Divider />

--- a/src/pages/popup/sui/transaction/-entry.tsx
+++ b/src/pages/popup/sui/transaction/-entry.tsx
@@ -117,7 +117,11 @@ export default function Entry({ request }: EntryProps) {
     return undefined;
   }, [params, request.method]);
 
-  const { data: dryRunTransaction, error: dryRunTransactionError } = useDryRunTransaction({
+  const {
+    data: dryRunTransaction,
+    error: dryRunTransactionError,
+    isFetching: isDryRunTxFetching,
+  } = useDryRunTransaction({
     coinId: nativeAccountAssetCoinId,
     transaction: parsedTx,
   });
@@ -308,7 +312,7 @@ export default function Entry({ request }: EntryProps) {
           <DappInfo image={siteIconURL} name={siteTitle} url={origin} />
           <Divider />
           <TxBaseInfoContainer>
-            <BaseTxInfo feeCoinId={nativeAccountAssetCoinId} feeBaseAmount={expectedBaseFee} disableFee />
+            <BaseTxInfo feeCoinId={nativeAccountAssetCoinId} feeBaseAmount={expectedBaseFee} isLoadingFee={isDryRunTxFetching} disableFee />
           </TxBaseInfoContainer>
           <DividerContainer>
             <Divider />

--- a/src/types/cosmos/feemarket.ts
+++ b/src/types/cosmos/feemarket.ts
@@ -3,3 +3,19 @@ import type { Amount } from './common';
 export type FeemarketResponse = {
   prices: Amount[];
 };
+
+export type OsmoEipFeeResponse = {
+  base_fee: string;
+};
+
+export type OsmoSpotPriceResponse = {
+  poolID: string;
+  spot_price: string;
+};
+
+export type OsmoFeeTokenResponse = {
+  fee_tokens: {
+    denom: string;
+    poolID: string;
+  }[];
+};

--- a/src/utils/view/controlView.ts
+++ b/src/utils/view/controlView.ts
@@ -124,10 +124,10 @@ export async function openPopupWindow(): Promise<chrome.windows.Window | browser
   try {
     const res = await extension.windows.getLastFocused();
 
-    if (res.width && res.left) {
+    if (res.width && res.left !== undefined) {
       left = Math.round(res.width - width + res.left);
     }
-    if (res.height && res.top) {
+    if (res.top !== undefined) {
       top = res.top;
     }
   } catch (e) {


### PR DESCRIPTION
- Osmosis fee market로직 적용
  - Osmosis체인의 tx를 사인하는 경우 + Amino 사인 환경에서 doc의 fee 필드 중 fee 배열이 빈 배열일때 적용
- Cosmos Fee 커스텀 방식 변경
  - fee coin의 변경이 바로 적용됩니다.
    - 기존에는 fee coin변경 후 `confirm`버튼을 클릭해야 적용되었습니다.
- dequeue 방식 변경
  -  request queue업데이트를 UI업데이트 이후로 변경 (공백화면 노출 피하기 위한 목적)
 

UI
- Bg 색상 변경
- 공백화면 노출 최소화를 위해 스플래시 화면으로 교체
- 팝업 윈도우 위치 조정
- 사인 팝업 페이지에서 fee 계산 상태값 노출 컴포넌트 추가