### PR TITLE
[APIS-713] handling connect request

### DIFF
--- a/src/components/Wrapper/components/Init/index.tsx
+++ b/src/components/Wrapper/components/Init/index.tsx
@@ -7,6 +7,7 @@ import type { LanguageType } from '@/types/language';
 import { extension } from '@/utils/browser';
 import { getExtensionLocalStorage, initExtensionLocalStorage, setExtensionLocalStorage } from '@/utils/storage';
 import { loadExtensionSessionStorageStoreFromStorage } from '@/zustand/hooks/useExtensionSessionStorageStore';
+import { loadExtensionStorageStoreFromStorageByKey } from '@/zustand/hooks/useExtensionStorageStore';
 import { loadAllStoreFromStorage } from '@/zustand/utils';
 
 import { Splash } from './styled';
@@ -33,7 +34,7 @@ export default function Init({ children }: InitProps) {
             key === 'approvedIotaPermissions' ||
             key.includes('visible-assetIds')
           ) {
-            await loadAllStoreFromStorage();
+            await loadExtensionStorageStoreFromStorageByKey(key);
           }
         }
       }

--- a/src/components/Wrapper/components/NavigationGate/index.tsx
+++ b/src/components/Wrapper/components/NavigationGate/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from '@tanstack/react-router';
 
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
 import { Route as Initial } from '@/pages/account/initial';
+import { Route as Home } from '@/pages/index';
 import { Route as AptosSignMessage } from '@/pages/popup/aptos/sign-message';
 import { Route as AptosTransaction } from '@/pages/popup/aptos/transaction';
 import { Route as BitcoinSend } from '@/pages/popup/bitcoin/send';
@@ -35,6 +36,7 @@ import type { CosmosRequest } from '@/types/message/inject/cosmos';
 import type { EvmRequest } from '@/types/message/inject/evm';
 import type { IotaRequest } from '@/types/message/inject/iota';
 import type { SuiRequest } from '@/types/message/inject/sui';
+import { isSidePanelView } from '@/utils/view/sidepanel';
 import { getSiteTitle } from '@/utils/website';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -44,14 +46,22 @@ type NavigationGateProps = {
 
 export default function NavigationGate({ children }: NavigationGateProps) {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const userAccounts = useExtensionStorageStore((state) => state.userAccounts);
-  const requestQueue = useExtensionStorageStore((state) => state.requestQueue);
-
-  const { currentRequestQueue } = useCurrentRequestQueue();
+  const { requestQueue, currentRequestQueue } = useCurrentRequestQueue();
 
   useSiteIconURL(currentRequestQueue?.origin);
   getSiteTitle(currentRequestQueue?.origin);
+
+  const isInSidePanel = isSidePanelView();
+
+  const shouldExitPopupState = useMemo(() => {
+    const isEmptyRequestQueue = requestQueue.length === 0;
+    const isInPopupPage = location.pathname.startsWith('/popup');
+
+    return isEmptyRequestQueue && isInPopupPage && isInSidePanel;
+  }, [isInSidePanel, location.pathname, requestQueue.length]);
 
   useEffect(() => {
     void (async () => {
@@ -94,8 +104,11 @@ export default function NavigationGate({ children }: NavigationGateProps) {
           });
         }
       }
+      if (shouldExitPopupState) {
+        navigate({ to: Home.to });
+      }
     })();
-  }, [userAccounts.length, navigate, requestQueue]);
+  }, [navigate, requestQueue, shouldExitPopupState, userAccounts.length]);
 
   return <>{children}</>;
 }

--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -38,3 +38,5 @@ export const DATA_FRESHNESS = {
   WARNING: 'warning',
   STALE: 'stale',
 } as const;
+
+export const POPUP_DISMISS_DELAY_MS = 500;

--- a/src/hooks/current/useCurrentRequestQueue.ts
+++ b/src/hooks/current/useCurrentRequestQueue.ts
@@ -1,7 +1,9 @@
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 
 import { Route as Home } from '@/pages/index';
 import type { RequestQueue } from '@/types/extension';
+import { setExtensionLocalStorage } from '@/utils/storage';
 import { closePopupWindow } from '@/utils/view/controlView';
 import { isSidePanelView } from '@/utils/view/sidepanel';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
@@ -12,33 +14,40 @@ export function useCurrentRequestQueue() {
 
   const navigate = useNavigate();
 
-  const currentRequestQueue = requestQueue.length > 0 ? requestQueue[0] : null;
+  const currentRequestQueue = useMemo(() => (requestQueue.length > 0 ? requestQueue[0] : null), [requestQueue]);
 
-  const deQueue = async (path?: string) => {
-    const newQueues = requestQueue.slice(1);
+  const deQueue = useCallback(
+    async (path?: string) => {
+      const newQueues = requestQueue.slice(1);
+      const isQueueEmpty = newQueues.length === 0;
+      const isSidePanel = isSidePanelView();
 
-    if (newQueues.length === 0) {
-      if (isSidePanelView()) {
-        navigate({ to: path ?? Home.to });
-      } else {
-        if (path) {
-          navigate({
-            to: path,
-          });
+      await setExtensionLocalStorage('requestQueue', newQueues);
+
+      if (isQueueEmpty) {
+        const shouldNavigate = isSidePanel || path;
+
+        if (shouldNavigate) {
+          const destination = path || Home.to;
+
+          await navigate({ to: destination });
         } else {
           await closePopupWindow();
         }
       }
-    }
 
-    await updateExtensionStorageStore('requestQueue', newQueues);
+      return newQueues.length > 0 ? newQueues[0] : null;
+    },
+    [navigate, requestQueue],
+  );
 
-    return requestQueue.length > 0 ? requestQueue[0] : null;
-  };
+  const enQueue = useCallback(
+    async (queue: RequestQueue) => {
+      await updateExtensionStorageStore('requestQueue', [...requestQueue, queue]);
+    },
+    [requestQueue, updateExtensionStorageStore],
+  );
 
-  const enQueue = async (queue: RequestQueue) => {
-    await updateExtensionStorageStore('requestQueue', [...requestQueue, queue]);
-  };
   return {
     requestQueue,
     currentRequestQueue,

--- a/src/hooks/useCurrentPassword.ts
+++ b/src/hooks/useCurrentPassword.ts
@@ -1,10 +1,12 @@
+import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { aesDecrypt, aesEncrypt } from '@/utils/crypto';
 import { useExtensionSessionStorageStore } from '@/zustand/hooks/useExtensionSessionStorageStore';
 
 export function useCurrentPassword() {
-  const { sessionPassword, updateExtensionSessionStorageStore } = useExtensionSessionStorageStore((state) => state);
+  const sessionPassword = useExtensionSessionStorageStore((state) => state.sessionPassword);
+  const updateExtensionSessionStorageStore = useExtensionSessionStorageStore((state) => state.updateExtensionSessionStorageStore);
 
   const setCurrentPassword = async (password: string | null) => {
     const timestamp = new Date().getTime();
@@ -22,7 +24,10 @@ export function useCurrentPassword() {
     );
   };
 
-  const currentPassword = sessionPassword ? aesDecrypt(sessionPassword.encryptedPassword, `${sessionPassword.key}${sessionPassword.timestamp}`) : null;
+  const currentPassword = useMemo(
+    () => (sessionPassword ? aesDecrypt(sessionPassword.encryptedPassword, `${sessionPassword.key}${sessionPassword.timestamp}`) : null),
+    [sessionPassword],
+  );
 
   return { currentPassword, setCurrentPassword };
 }

--- a/src/pages/popup/-components/requests/AccessRequest/index.tsx
+++ b/src/pages/popup/-components/requests/AccessRequest/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Typography } from '@mui/material';
 
@@ -55,28 +56,41 @@ export default function AccessRequest({ children }: AccessRequestProps) {
   const { siteIconURL } = useSiteIconURL(currentRequestQueue?.origin);
   const siteTitle = getSiteTitle(currentRequestQueue?.origin);
 
-  const currentAccountSuiPermissionTypes = currentAccountApprovedSuiPermissions
-    .filter((permission) => permission.origin === currentRequestQueue?.origin)
-    .map((permission) => permission.permission);
+  const currentAccountSuiPermissionTypes = useMemo(
+    () =>
+      currentAccountApprovedSuiPermissions.filter((permission) => permission.origin === currentRequestQueue?.origin).map((permission) => permission.permission),
+    [currentAccountApprovedSuiPermissions, currentRequestQueue?.origin],
+  );
 
-  const isSuiApporved =
-    currentRequestQueue &&
-    currentRequestQueue.method === 'sui_connect' &&
-    !currentRequestQueue.params.every((permission) => currentAccountSuiPermissionTypes.includes(permission));
+  const needSuiApproval = useMemo(
+    () =>
+      currentRequestQueue &&
+      currentRequestQueue.method === 'sui_connect' &&
+      !currentRequestQueue.params.every((permission) => currentAccountSuiPermissionTypes.includes(permission)),
+    [currentAccountSuiPermissionTypes, currentRequestQueue],
+  );
 
-  const currentAccountIotaPermissionTypes = currentAccountApprovedIotaPermissions
-    .filter((permission) => permission.origin === currentRequestQueue?.origin)
-    .map((permission) => permission.permission);
+  const currentAccountIotaPermissionTypes = useMemo(
+    () =>
+      currentAccountApprovedIotaPermissions
+        .filter((permission) => permission.origin === currentRequestQueue?.origin)
+        .map((permission) => permission.permission),
+    [currentAccountApprovedIotaPermissions, currentRequestQueue?.origin],
+  );
 
-  const isIotaApporved =
-    currentRequestQueue &&
-    currentRequestQueue.method === 'iota_connect' &&
-    !currentRequestQueue.params.every((permission) => currentAccountIotaPermissionTypes.includes(permission));
+  const needIotaApporved = useMemo(
+    () =>
+      currentRequestQueue &&
+      currentRequestQueue.method === 'iota_connect' &&
+      !currentRequestQueue.params.every((permission) => currentAccountIotaPermissionTypes.includes(permission)),
+    [currentAccountIotaPermissionTypes, currentRequestQueue],
+  );
 
   if (
-    (currentRequestQueue?.origin && !currentAccountApporvedOrigins.map((item) => item.origin).includes(currentRequestQueue.origin)) ||
-    isSuiApporved ||
-    isIotaApporved
+    currentRequestQueue &&
+    ((currentRequestQueue?.origin && !currentAccountApporvedOrigins.map((item) => item.origin).includes(currentRequestQueue.origin)) ||
+      needSuiApproval ||
+      needIotaApporved)
   ) {
     return (
       <Layout>

--- a/src/pages/popup/aptos/sign-message/-entry.tsx
+++ b/src/pages/popup/aptos/sign-message/-entry.tsx
@@ -8,6 +8,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useCurrentAptosNetwork } from '@/hooks/aptos/useCurrentAptosNetwork';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
@@ -19,6 +20,7 @@ import { sendMessage } from '@/libs/extension';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { AptosSignMessage, AptosSignMessageResponse } from '@/types/message/inject/aptos';
 import { signMessage } from '@/utils/aptos/sign';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
@@ -100,6 +102,8 @@ export default function Entry({ request }: EntryProps) {
       serializer.serialize(response);
       const serializedSignature = Buffer.from(serializer.toUint8Array()).toString('hex');
 
+      await wait(POPUP_DISMISS_DELAY_MS);
+
       const result: AptosSignMessageResponse = {
         address: address || '',
         application: origin,
@@ -180,6 +184,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/aptos/transaction/-entry.tsx
+++ b/src/pages/popup/aptos/transaction/-entry.tsx
@@ -10,6 +10,7 @@ import { FilledTab, FilledTabs } from '@/components/common/FilledTab';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
 import { APTOS_COIN_TYPE } from '@/constants/aptos/coin';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useCurrentAptosNetwork } from '@/hooks/aptos/useCurrentAptosNetwork';
 import { useEstimateGasPrice } from '@/hooks/aptos/useEstimateGasPrice';
@@ -29,6 +30,7 @@ import type { ResponseAppMessage } from '@/types/message/content';
 import type { AptosSignTransaction } from '@/types/message/inject/aptos';
 import { signTxSequentially } from '@/utils/aptos/sign';
 import { getOriginalTx } from '@/utils/aptos/tx';
+import { wait } from '@/utils/fetch/wait';
 import { ceil, gt, times } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
@@ -206,6 +208,8 @@ export default function Entry({ request }: EntryProps) {
       serializer.serialize(response);
       const serializedAccountAuthenticator = Buffer.from(serializer.toUint8Array()).toString('hex');
 
+      await wait(POPUP_DISMISS_DELAY_MS);
+
       await incrementTxCountForOrigin(request.origin);
 
       sendMessage<ResponseAppMessage<AptosSignTransaction>>({
@@ -289,6 +293,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/bitcoin/send/-entry.tsx
+++ b/src/pages/popup/bitcoin/send/-entry.tsx
@@ -16,6 +16,7 @@ import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
 import EmptyAsset from '@/components/EmptyAsset';
 import { P2PKH__V_BYTES, P2SH__V_BYTES, P2TR__V_BYTES, P2WPKH__V_BYTES } from '@/constants/bitcoin/tx';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useBalance } from '@/hooks/bitcoin/useBalance';
 import { useCurrentBitcoinNetwork } from '@/hooks/bitcoin/useCurrentBitcoinNetwork';
@@ -45,6 +46,7 @@ import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSendBitcoin } from '@/types/message/inject/bitcoin';
 import { executeTransactionSequentially } from '@/utils/bitcoin/sign';
 import { ecpairFromPrivateKey, getTweakSigner, initBitcoinEcc } from '@/utils/bitcoin/tx';
+import { wait } from '@/utils/fetch/wait';
 import { gt, minus, toDisplayDenomAmount } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
@@ -354,6 +356,8 @@ export default function Entry({ request }: EntryProps) {
 
       const { result } = response;
 
+      await wait(POPUP_DISMISS_DELAY_MS);
+
       await incrementTxCountForOrigin(request.origin);
 
       sendMessage<ResponseAppMessage<BitSendBitcoin>>({
@@ -500,6 +504,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/bitcoin/send/-entry.tsx
+++ b/src/pages/popup/bitcoin/send/-entry.tsx
@@ -86,7 +86,9 @@ export default function Entry({ request }: EntryProps) {
     disableDupeEthermint: true,
   });
 
-  const { to, satAmount } = request.params;
+  const { params, origin } = request;
+
+  const { to, satAmount } = params;
 
   const nativeAccountAsset = useMemo(
     () => currentBitcoinNetwork && accountAllAssets?.bitcoinAccountAssets.find((item) => isSameChain(item.chain, currentBitcoinNetwork)),

--- a/src/pages/popup/bitcoin/sign-message/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-message/-entry.tsx
@@ -9,6 +9,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useCurrentBitcoinNetwork } from '@/hooks/bitcoin/useCurrentBitcoinNetwork';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
@@ -23,6 +24,7 @@ import RequestMethodTitle from '@/pages/popup/-components/RequestMethodTitle';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignMessage, BitSignMessageResposne } from '@/types/message/inject/bitcoin';
 import { ecpairInstanceFromPrivateKey } from '@/utils/bitcoin/tx';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
@@ -106,6 +108,8 @@ export default function Entry({ request }: EntryProps) {
         throw new Error('Failed to sign message');
       }
 
+      await wait(POPUP_DISMISS_DELAY_MS);
+
       sendMessage<ResponseAppMessage<BitSignMessage>>({
         target: 'CONTENT',
         method: 'responseApp',
@@ -175,6 +179,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
@@ -79,6 +79,8 @@ export default function Entry({ request }: EntryProps) {
     return balance.data.chain_stats.funded_txo_sum - balance.data.chain_stats.spent_txo_sum - balance.data.mempool_stats.spent_txo_sum;
   }, [balance.data]);
 
+  const { params: psbtHex, origin } = request;
+
   const { siteIconURL } = useSiteIconURL(origin);
   const siteTitle = getSiteTitle(origin);
 
@@ -93,8 +95,6 @@ export default function Entry({ request }: EntryProps) {
   );
 
   const bitcoinNetwork = useMemo(() => (nativeAccountAsset?.chain.isTestnet ? networks.testnet : networks.bitcoin), [nativeAccountAsset?.chain.isTestnet]);
-
-  const psbtHex = request.params;
 
   const parsedPsbt = useMemo(() => {
     const formattedPsbtHex = formatPsbtHex(psbtHex);

--- a/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/common/Button';
 import { FilledTab, FilledTabs } from '@/components/common/FilledTab';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useBalance } from '@/hooks/bitcoin/useBalance';
 import { useCurrentBitcoinNetwork } from '@/hooks/bitcoin/useCurrentBitcoinNetwork';
@@ -26,6 +27,7 @@ import DappInfo from '@/pages/popup/-components/DappInfo';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignPsbt } from '@/types/message/inject/bitcoin';
 import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getTweakSigner } from '@/utils/bitcoin/tx';
+import { wait } from '@/utils/fetch/wait';
 import { gte, plus } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
@@ -118,20 +120,10 @@ export default function Entry({ request }: EntryProps) {
     [decodedPsbtData.inputInfos],
   );
 
-  const totalOutputAmount = useMemo(
-    () => decodedPsbtData.outputInfos.reduce((totalVal, cur) => plus(totalVal, cur?.value || '0'), '0'),
-    [decodedPsbtData.outputInfos],
-  );
-
   const fee = useMemo(() => decodedPsbtData.fee, [decodedPsbtData.fee]);
 
-  const canSendTx = useMemo(
-    () => gte(nativeCoinAvailableAmount, plus(totalOutputAmount, decodedPsbtData.fee)),
-    [nativeCoinAvailableAmount, totalOutputAmount, decodedPsbtData.fee],
-  );
-
   const errorMessage = useMemo(() => {
-    if (gte('0', nativeCoinAvailableAmount) || !canSendTx) {
+    if (gte('0', nativeCoinAvailableAmount)) {
       return t('pages.popup.bitcoin.sign-psbt.entry.noAvailableAmount');
     }
 
@@ -144,7 +136,7 @@ export default function Entry({ request }: EntryProps) {
     }
 
     return '';
-  }, [canSendTx, nativeCoinAvailableAmount, psbtHex, t, totalInputAmount]);
+  }, [nativeCoinAvailableAmount, psbtHex, t, totalInputAmount]);
 
   const handleChange = (_: React.SyntheticEvent, newTabValue: number) => {
     setTabValue(newTabValue);
@@ -182,6 +174,8 @@ export default function Entry({ request }: EntryProps) {
       if (!result) {
         throw new Error('Failed to sign transaction');
       }
+
+      await wait(POPUP_DISMISS_DELAY_MS);
 
       await incrementTxCountForOrigin(request.origin);
 
@@ -255,6 +249,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/common/Button';
 import { FilledTab, FilledTabs } from '@/components/common/FilledTab';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useBalance } from '@/hooks/bitcoin/useBalance';
 import { useCurrentBitcoinNetwork } from '@/hooks/bitcoin/useCurrentBitcoinNetwork';
@@ -26,6 +27,7 @@ import DappInfo from '@/pages/popup/-components/DappInfo';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignPsbts, BitSignPsbtsResposne } from '@/types/message/inject/bitcoin';
 import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getTweakSigner } from '@/utils/bitcoin/tx';
+import { wait } from '@/utils/fetch/wait';
 import { gte, plus } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
@@ -201,6 +203,8 @@ export default function Entry({ request }: EntryProps) {
         throw new Error('Failed to sign transaction');
       }
 
+      await wait(POPUP_DISMISS_DELAY_MS);
+
       await incrementTxCountForOrigin(request.origin);
 
       sendMessage<ResponseAppMessage<BitSignPsbts>>({
@@ -281,6 +285,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
@@ -79,6 +79,8 @@ export default function Entry({ request }: EntryProps) {
     return balance.data.chain_stats.funded_txo_sum - balance.data.chain_stats.spent_txo_sum - balance.data.mempool_stats.spent_txo_sum;
   }, [balance.data]);
 
+  const { params: psbtHexes, origin } = request;
+
   const { siteIconURL } = useSiteIconURL(origin);
   const siteTitle = getSiteTitle(origin);
 
@@ -95,8 +97,6 @@ export default function Entry({ request }: EntryProps) {
   );
 
   const bitcoinNetwork = useMemo(() => (nativeAccountAsset?.chain.isTestnet ? networks.testnet : networks.bitcoin), [nativeAccountAsset?.chain.isTestnet]);
-
-  const psbtHexes = request.params;
 
   const parsedPsbts = useMemo(
     () =>

--- a/src/pages/popup/cosmos/sign/amino/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/amino/-entry.tsx
@@ -8,6 +8,7 @@ import { FilledTab, FilledTabs } from '@/components/common/FilledTab';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
 import FeeSettingBottomSheet from '@/components/Fee/CosmosFee/components/FeeSettingBottomSheet';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { PUBLIC_KEY_TYPE } from '@/constants/cosmos';
 import { COSMOS_DEFAULT_GAS, DEFAULT_GAS_MULTIPLY } from '@/constants/cosmos/gas';
 import { COSMOS_MEMO_MAX_BYTES } from '@/constants/cosmos/tx';
@@ -34,6 +35,7 @@ import { resolvePubkeyType, resolveSeiChainConfig } from '@/utils/cosmos/execute
 import { getCosmosFeeStepNames } from '@/utils/cosmos/fee';
 import { getPublicKeyType, signAmino } from '@/utils/cosmos/msg';
 import { protoTx, protoTxBytes } from '@/utils/cosmos/proto';
+import { wait } from '@/utils/fetch/wait';
 import { ceil, divide, gt, gte, times } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isMatchingCoinId, isSameChain } from '@/utils/queryParamGenerator';
 import { getUtf8BytesLength } from '@/utils/string';
@@ -435,6 +437,7 @@ export default function Entry({ request, chain }: EntryProps) {
         signed_doc: tx,
       };
 
+      await wait(POPUP_DISMISS_DELAY_MS);
       await incrementTxCountForOrigin(request.origin);
 
       sendMessage({
@@ -545,6 +548,7 @@ export default function Entry({ request, chain }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/cosmos/sign/direct/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/direct/-entry.tsx
@@ -10,6 +10,7 @@ import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
 import FeeSettingBottomSheet from '@/components/Fee/CosmosFee/components/FeeSettingBottomSheet';
 import InformationPanel from '@/components/InformationPanel';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { PUBLIC_KEY_TYPE } from '@/constants/cosmos';
 import { COSMOS_DEFAULT_GAS, DEFAULT_GAS_MULTIPLY } from '@/constants/cosmos/gas';
 import { COSMOS_MEMO_MAX_BYTES } from '@/constants/cosmos/tx';
@@ -39,6 +40,7 @@ import { getCosmosFeeStepNames } from '@/utils/cosmos/fee';
 import { getPublicKeyType, signDirect } from '@/utils/cosmos/msg';
 import { decodeProtobufMessage, protoTxBytes } from '@/utils/cosmos/proto';
 import { toUint8Array } from '@/utils/crypto';
+import { wait } from '@/utils/fetch/wait';
 import { ceil, divide, equal, gt, gte, times } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isMatchingCoinId, isSameChain } from '@/utils/queryParamGenerator';
 import { getUtf8BytesLength } from '@/utils/string';
@@ -437,6 +439,7 @@ export default function Entry({ request, chain }: EntryProps) {
         signed_doc: signedDocArray,
       };
 
+      await wait(POPUP_DISMISS_DELAY_MS);
       await incrementTxCountForOrigin(request.origin);
 
       sendMessage({
@@ -563,6 +566,7 @@ export default function Entry({ request, chain }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/cosmos/sign/message/-entry.tsx
+++ b/src/pages/popup/cosmos/sign/message/-entry.tsx
@@ -7,6 +7,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { PUBLIC_KEY_TYPE } from '@/constants/cosmos';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
@@ -24,6 +25,7 @@ import type { ResponseAppMessage } from '@/types/message/content';
 import type { CosSignMessage } from '@/types/message/inject/cosmos';
 import { getPublicKeyType, signAmino } from '@/utils/cosmos/msg';
 import { getMsgSignData } from '@/utils/cosmos/msgParse';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
@@ -100,6 +102,8 @@ export default function Entry({ request, chain }: EntryProps) {
         signature: base64Signature,
         pub_key: pubKey,
       };
+
+      await wait(POPUP_DISMISS_DELAY_MS);
 
       sendMessage<ResponseAppMessage<CosSignMessage>>({
         target: 'CONTENT',
@@ -196,6 +200,7 @@ export default function Entry({ request, chain }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/evm/sign/eth-sign/-entry.tsx
+++ b/src/pages/popup/evm/sign/eth-sign/-entry.tsx
@@ -7,6 +7,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
@@ -22,6 +23,7 @@ import RequestMethodTitle from '@/pages/popup/-components/RequestMethodTitle';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { EthSign } from '@/types/message/inject/evm';
 import { signMessage } from '@/utils/ethereum/sign';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { toHex, toUTF8 } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
@@ -82,6 +84,8 @@ export default function Entry({ request }: EntryProps) {
       })();
 
       const result = signature;
+
+      await wait(POPUP_DISMISS_DELAY_MS);
 
       sendMessage<ResponseAppMessage<EthSign>>({
         target: 'CONTENT',
@@ -178,6 +182,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/evm/sign/personal-sign/-entry.tsx
+++ b/src/pages/popup/evm/sign/personal-sign/-entry.tsx
@@ -7,6 +7,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
@@ -22,6 +23,7 @@ import RequestMethodTitle from '@/pages/popup/-components/RequestMethodTitle';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { PersonalSign } from '@/types/message/inject/evm';
 import { personalSign } from '@/utils/ethereum/sign';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { toHex, toUTF8 } from '@/utils/string';
 import { getSiteTitle } from '@/utils/website';
@@ -81,6 +83,8 @@ export default function Entry({ request }: EntryProps) {
       })();
 
       const result = signature;
+
+      await wait(POPUP_DISMISS_DELAY_MS);
 
       sendMessage<ResponseAppMessage<PersonalSign>>({
         target: 'CONTENT',
@@ -177,6 +181,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/evm/sign/sign-typed-data/-entry.tsx
+++ b/src/pages/popup/evm/sign/sign-typed-data/-entry.tsx
@@ -9,6 +9,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
@@ -24,6 +25,7 @@ import RequestMethodTitle from '@/pages/popup/-components/RequestMethodTitle';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { CustomTypedMessage, EthSignTypedData } from '@/types/message/inject/evm';
 import { signTypedData } from '@/utils/ethereum/sign';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
@@ -88,6 +90,7 @@ export default function Entry({ request }: EntryProps) {
       })();
 
       const result = signature;
+      await wait(POPUP_DISMISS_DELAY_MS);
 
       sendMessage<ResponseAppMessage<EthSignTypedData>>({
         target: 'CONTENT',
@@ -200,6 +203,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/evm/transaction/-entry.tsx
+++ b/src/pages/popup/evm/transaction/-entry.tsx
@@ -9,6 +9,7 @@ import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
 import type { BasicFeeOption, EIP1559FeeOption } from '@/components/Fee/EVMFee/components/FeeSettingBottomSheet';
 import FeeSettingBottomSheet from '@/components/Fee/EVMFee/components/FeeSettingBottomSheet';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
 import { DEFAULT_GAS_MULTIPLY, EVM_DEFAULT_GAS } from '@/constants/evm/fee';
@@ -31,6 +32,7 @@ import RawTx from '@/pages/popup/-components/RawTx';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { EthSendTransaction, EthSendTransactionResponse, EthSignTransaction, EthSignTransactionResponse } from '@/types/message/inject/evm';
 import { signAndExecuteTxSequentially, signTxSequentially } from '@/utils/ethereum/sign';
+import { wait } from '@/utils/fetch/wait';
 import { ceil, gt, plus, times, toDisplayDenomAmount } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { hexOrDecimalToDecimal, isEqualsIgnoringCase, toHex } from '@/utils/string';
@@ -375,7 +377,7 @@ export default function Entry({ request }: EntryProps) {
           raw: response,
           tx: ethereumTx,
         };
-
+        await wait(POPUP_DISMISS_DELAY_MS);
         await incrementTxCountForOrigin(request.origin);
 
         sendMessage<ResponseAppMessage<EthSignTransaction>>({
@@ -394,6 +396,9 @@ export default function Entry({ request }: EntryProps) {
         const response = await signAndExecuteTxSequentially(privateKey, ethereumTx, rpcURLs);
 
         const result: EthSendTransactionResponse = response.hash;
+
+        await wait(POPUP_DISMISS_DELAY_MS);
+        await incrementTxCountForOrigin(request.origin);
 
         sendMessage<ResponseAppMessage<EthSendTransaction>>({
           target: 'CONTENT',
@@ -498,6 +503,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/iota/sign-message/-entry.tsx
+++ b/src/pages/popup/iota/sign-message/-entry.tsx
@@ -8,6 +8,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
@@ -17,6 +18,7 @@ import { useCurrentPassword } from '@/hooks/useCurrentPassword';
 import { getKeypair } from '@/libs/address';
 import { sendMessage } from '@/libs/extension';
 import type { IotaSignPersonalMessage } from '@/types/message/inject/iota';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
@@ -83,6 +85,8 @@ export default function Entry({ request }: EntryProps) {
       if (!result) {
         throw new Error('Failed to sign message');
       }
+
+      await wait(POPUP_DISMISS_DELAY_MS);
 
       sendMessage({
         target: 'CONTENT',
@@ -153,6 +157,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/iota/transaction/-entry.tsx
+++ b/src/pages/popup/iota/transaction/-entry.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/common/Button';
 import { FilledTab, FilledTabs } from '@/components/common/FilledTab';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { IOTA_COIN_TYPE } from '@/constants/iota';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
@@ -26,6 +27,7 @@ import BaseTxInfo from '@/pages/popup/-components/BaseTxInfo';
 import DappInfo from '@/pages/popup/-components/DappInfo';
 import RawTx from '@/pages/popup/-components/RawTx';
 import type { IotaSignAndExecuteTransaction, IotaSignTransaction } from '@/types/message/inject/iota';
+import { wait } from '@/utils/fetch/wait';
 import { signAndExecuteTxSequentially, signTxSequentially } from '@/utils/iota/sign';
 import { gt, minus, plus } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
@@ -200,6 +202,7 @@ export default function Entry({ request }: EntryProps) {
         if (!result) {
           throw new Error('Failed to sign transaction');
         }
+        await wait(POPUP_DISMISS_DELAY_MS);
 
         await incrementTxCountForOrigin(request.origin);
 
@@ -244,6 +247,7 @@ export default function Entry({ request }: EntryProps) {
         if (!result) {
           throw new Error('Failed to sign and execute transaction');
         }
+        await wait(POPUP_DISMISS_DELAY_MS);
 
         await incrementTxCountForOrigin(request.origin);
 
@@ -327,6 +331,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/request-account/-entry.tsx
+++ b/src/pages/popup/request-account/-entry.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { produce } from 'immer';
 
@@ -28,7 +28,33 @@ import { addHexPrefix } from '@/utils/string';
 import { ContentsContainer, StyledCircularProgress, TextWrapper } from './-styled';
 
 export default function Entry() {
+  return (
+    <>
+      <LoadingSpinner />
+      <BusinessLogic />
+    </>
+  );
+}
+
+const LoadingSpinner = memo(function LoadingSpinner() {
+  const { t } = useTranslation();
+
+  return (
+    <BaseBody>
+      <ContentsContainer>
+        <StyledCircularProgress size={50} />
+        <TextWrapper>
+          <Base1300Text variant="b1_B">{t('pages.popup.request-account.entry.connecting')}</Base1300Text>
+        </TextWrapper>
+      </ContentsContainer>
+    </BaseBody>
+  );
+});
+
+function BusinessLogic() {
   const { requestQueue, currentRequestQueue, deQueue } = useCurrentRequestQueue();
+  const [processedRequestIds, setProcessedRequestIds] = useState<Set<string>>(new Set());
+
   const { currentPreferAccountType } = useCurrentPreferAccountTypes();
   const { chainList } = useChainList();
 
@@ -37,6 +63,14 @@ export default function Entry() {
 
   useEffect(() => {
     const handleRequestAccount = async () => {
+      if (!currentRequestQueue) return;
+
+      if (processedRequestIds.has(currentRequestQueue.requestId)) {
+        return;
+      }
+
+      setProcessedRequestIds((prev) => new Set(prev).add(currentRequestQueue.requestId));
+
       try {
         if (currentRequestQueue?.method === 'cos_requestAccount' && currentPassword) {
           const { tabId, requestId, origin, params } = currentRequestQueue;
@@ -96,7 +130,7 @@ export default function Entry() {
                 },
               });
 
-              void deQueue();
+              await deQueue();
 
               return;
             }
@@ -126,7 +160,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
 
@@ -241,7 +275,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
 
@@ -270,7 +304,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           } else {
             sendMessage<ResponseAppMessage<EthRequestAccounts>>({
               target: 'CONTENT',
@@ -284,7 +318,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
 
@@ -306,7 +340,7 @@ export default function Entry() {
               result,
             },
           });
-          void deQueue();
+          await deQueue();
         }
 
         if (currentRequestQueue?.method === 'sui_getAccount' && currentPassword) {
@@ -339,7 +373,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           } else {
             const { tabId, requestId, origin } = currentRequestQueue;
 
@@ -355,7 +389,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
 
@@ -384,7 +418,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
 
@@ -413,7 +447,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
 
@@ -435,7 +469,7 @@ export default function Entry() {
               result,
             },
           });
-          void deQueue();
+          await deQueue();
         }
 
         if (currentRequestQueue?.method === 'iota_getAccount' && currentPassword) {
@@ -468,7 +502,7 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           } else {
             const { tabId, requestId, origin } = currentRequestQueue;
 
@@ -484,17 +518,38 @@ export default function Entry() {
               },
             });
 
-            void deQueue();
+            await deQueue();
           }
         }
       } catch (error) {
+        if (currentRequestQueue) {
+          sendMessage({
+            target: 'CONTENT',
+            method: 'responseApp',
+            origin: currentRequestQueue.origin,
+            requestId: currentRequestQueue.requestId,
+            tabId: currentRequestQueue.tabId,
+            params: {
+              id: currentRequestQueue.requestId,
+              error: {
+                code: RPC_ERROR.INTERNAL,
+                message: `${RPC_ERROR_MESSAGE[RPC_ERROR.INTERNAL]}`,
+              },
+            },
+          });
+
+          await deQueue();
+        }
+
         console.error('Error fetching data:', error);
       }
     };
 
     if (!currentRequestQueue) return;
 
-    if (requestQueue.length === 1) {
+    const shouldApplyPopdownDelay = processedRequestIds.size < 5 && requestQueue.length === 1;
+
+    if (shouldApplyPopdownDelay) {
       const timer = setTimeout(() => {
         handleRequestAccount();
       }, 1000);
@@ -511,24 +566,11 @@ export default function Entry() {
     currentPreferAccountType,
     currentRequestQueue,
     deQueue,
+    processedRequestIds,
     refreshOriginConnectionTime,
+    currentRequestQueue?.requestId,
     requestQueue.length,
   ]);
 
-  return <LoadingSpinner />;
+  return null;
 }
-
-const LoadingSpinner = memo(function LoadingSpinner() {
-  const { t } = useTranslation();
-
-  return (
-    <BaseBody>
-      <ContentsContainer>
-        <StyledCircularProgress size={50} />
-        <TextWrapper>
-          <Base1300Text variant="b1_B">{t('pages.popup.request-account.entry.connecting')}</Base1300Text>
-        </TextWrapper>
-      </ContentsContainer>
-    </BaseBody>
-  );
-});

--- a/src/pages/popup/sui/sign-message/-entry.tsx
+++ b/src/pages/popup/sui/sign-message/-entry.tsx
@@ -8,6 +8,7 @@ import Base1000Text from '@/components/common/Base1000Text';
 import Base1300Text from '@/components/common/Base1300Text';
 import Button from '@/components/common/Button';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
 import { useCurrentRequestQueue } from '@/hooks/current/useCurrentRequestQueue';
@@ -17,6 +18,7 @@ import { useCurrentPassword } from '@/hooks/useCurrentPassword';
 import { getKeypair } from '@/libs/address';
 import { sendMessage } from '@/libs/extension';
 import type { SuiSignMessage, SuiSignPersonalMessage } from '@/types/message/inject/sui';
+import { wait } from '@/utils/fetch/wait';
 import { getUniqueChainId } from '@/utils/queryParamGenerator';
 import { getSiteTitle } from '@/utils/website';
 
@@ -91,6 +93,8 @@ export default function Entry({ request }: EntryProps) {
         throw new Error('Failed to sign message');
       }
 
+      await wait(POPUP_DISMISS_DELAY_MS);
+
       sendMessage({
         target: 'CONTENT',
         method: 'responseApp',
@@ -160,6 +164,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/pages/popup/sui/transaction/-entry.tsx
+++ b/src/pages/popup/sui/transaction/-entry.tsx
@@ -10,6 +10,7 @@ import Button from '@/components/common/Button';
 import { FilledTab, FilledTabs } from '@/components/common/FilledTab';
 import SplitButtonsLayout from '@/components/common/SplitButtonsLayout';
 import Tooltip from '@/components/common/Tooltip';
+import { POPUP_DISMISS_DELAY_MS } from '@/constants/common';
 import { RPC_ERROR, RPC_ERROR_MESSAGE } from '@/constants/error';
 import { SUI_COIN_TYPE } from '@/constants/sui';
 import { useSiteIconURL } from '@/hooks/common/useSiteIconURL';
@@ -26,6 +27,7 @@ import BaseTxInfo from '@/pages/popup/-components/BaseTxInfo';
 import DappInfo from '@/pages/popup/-components/DappInfo';
 import RawTx from '@/pages/popup/-components/RawTx';
 import type { SuiSignAndExecuteTransaction, SuiSignAndExecuteTransactionBlock, SuiSignTransaction, SuiSignTransactionBlock } from '@/types/message/inject/sui';
+import { wait } from '@/utils/fetch/wait';
 import { gt, minus, plus } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
@@ -208,6 +210,8 @@ export default function Entry({ request }: EntryProps) {
           throw new Error('Failed to sign transaction');
         }
 
+        await wait(POPUP_DISMISS_DELAY_MS);
+
         await incrementTxCountForOrigin(request.origin);
 
         sendMessage({
@@ -257,6 +261,7 @@ export default function Entry({ request }: EntryProps) {
         if (!result) {
           throw new Error('Failed to sign and execute transaction');
         }
+        await wait(POPUP_DISMISS_DELAY_MS);
 
         await incrementTxCountForOrigin(request.origin);
 
@@ -340,6 +345,7 @@ export default function Entry({ request }: EntryProps) {
         <SplitButtonsLayout
           cancelButton={
             <Button
+              disabled={isProcessing}
               onClick={async () => {
                 sendMessage({
                   target: 'CONTENT',

--- a/src/script/inject/cosmos/provider/keplr.ts
+++ b/src/script/inject/cosmos/provider/keplr.ts
@@ -1,9 +1,10 @@
 import Long from 'long';
-import type { KeplrMode } from '@keplr-wallet/types';
+import type { KeplrMode, Key, SettledResponses } from '@keplr-wallet/types';
 
 import type { SignAminoDoc } from '@/types/cosmos/amino';
 import type {
   CosRequestAccountResponse,
+  CosRequestAccountsSettledResponse,
   CosSendTransactionResponse,
   CosSignAminoResponse,
   CosSignDirectResponse,
@@ -52,6 +53,43 @@ const keplrGetKey: KeplrInterface['getKey'] = async (chainId) => {
       isKeystone: false,
       ethereumHexAddress: '',
     };
+  } catch (e) {
+    throw new Error((e as { message?: string }).message || 'Unknown Error');
+  }
+};
+
+const keplrGetKeySettled: KeplrInterface['getKeysSettled'] = async (chainIds) => {
+  try {
+    const accounts = (await wrappedCosmosRequestApp({
+      method: 'cos_requestAccountsSettled',
+      params: { chainIds: chainIds },
+    })) as CosRequestAccountsSettledResponse;
+
+    const maps: SettledResponses<Key> = accounts.map((account) => {
+      if (account.status === 'fulfilled') {
+        const resolvedValue = {
+          isNanoLedger: account.value.isLedger,
+          algo: account.value.isEthermint ? 'ethsecp256k1' : 'secp256k1',
+          pubKey: new Uint8Array(Buffer.from(account.value.publicKey, 'hex')),
+          bech32Address: account.value.address,
+          name: account.value.name,
+          address: new Uint8Array(),
+          isKeystone: false,
+          ethereumHexAddress: '',
+        };
+
+        return {
+          status: account.status,
+          value: resolvedValue,
+        };
+      }
+      return {
+        status: account.status,
+        reason: account.reason,
+      };
+    });
+
+    return maps;
   } catch (e) {
     throw new Error((e as { message?: string }).message || 'Unknown Error');
   }
@@ -242,6 +280,7 @@ export class CosmostationKeplr implements KeplrInterface {
   }
   enable = keplrEnable;
   getKey = keplrGetKey;
+  getKeysSettled = keplrGetKeySettled;
   experimentalSuggestChain = keplrExperimentalSuggestChain;
   getOfflineSigner = keplrGetOfflineSigner;
   getOfflineSignerAuto = keplrGetOfflineSignerAuto;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -51,7 +51,6 @@ declare global {
     | 'getSecret20ViewingKey'
     | 'signEthereum'
     | 'disable'
-    | 'getKeysSettled'
     | 'signICNSAdr36'
     | 'experimentalSignEIP712CosmosTx_v0'
     | 'getChainInfosWithoutEndpoints'

--- a/src/utils/requestApp.ts
+++ b/src/utils/requestApp.ts
@@ -60,7 +60,7 @@ export const setQueues = debounce(
     }
   },
   500,
-  { edges: ['leading'] },
+  { edges: ['leading', 'trailing'] },
 );
 
 export function enqueueRequest(queue: RequestQueue) {


### PR DESCRIPTION
- 스토리지 변경 이벤트 리스닝 후 전체 하이드레이션 대신 변경된 키에 대해서만 하이드레이션하도록 변경
- 조건에 따라서 디앱 트랜잭션 처리 후 루트 페이지로 라우팅되도록 기능 추가
- 모든 체인 사인 팝업에 사인 후 팝다운 딜레이 추가 및 사인중에는 "취소"버튼도 비활성화
- 지갑 연결 요청이 과도하게 큐에 쌓였을때 큐 처리가 되지 않는 오류 수정
- 케플러 프로바이더 getKeysSettled추가
- sign-psbt 요청 에러 조건 변경
  - 예상 지출 fee amount 계산 조건식 변경