### PR TITLE
[APIS-726] Wrap inject script in IIFE to prevent global scope pollution

### DIFF
--- a/vite.config.chrome.inject.ts
+++ b/vite.config.chrome.inject.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vite';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+import { wrapInjectScriptPlugin } from './vite.plugin/wrapInjectScript';
+
 export default defineConfig(({ mode }) => {
   const isProduction = mode === 'production';
 
@@ -25,6 +27,7 @@ export default defineConfig(({ mode }) => {
       nodePolyfills({
         include: ['stream', 'assert', 'os', 'url', 'http', 'https', 'crypto'],
       }),
+      wrapInjectScriptPlugin(),
     ],
     build: {
       outDir,

--- a/vite.plugin/wrapInjectScript.ts
+++ b/vite.plugin/wrapInjectScript.ts
@@ -1,0 +1,17 @@
+import type { PluginOption } from 'vite';
+
+export function wrapInjectScriptPlugin(): PluginOption {
+  return {
+    name: 'wrap-inject-script',
+    enforce: 'post',
+    generateBundle(_, bundle) {
+      const injectFile = bundle['js/inject.js'];
+
+      if (injectFile && injectFile.type === 'chunk') {
+        const originalCode = injectFile.code;
+
+        injectFile.code = `(function() {\n${originalCode}\n})();`;
+      }
+    },
+  };
+}


### PR DESCRIPTION
- Move esbuild helpers (__defProp, etc.) inside a top-level IIFE