### PR TITLE
feat(bitcoin): Support toSignInputs option for selective PSBT signing

### DIFF
--- a/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbt/-entry.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { networks, Psbt } from 'bitcoinjs-lib';
-import { isTaprootInput } from 'bitcoinjs-lib/src/psbt/bip371';
 import { Typography } from '@mui/material';
 
 import BaseBody from '@/components/BaseLayout/components/BaseBody';
@@ -26,7 +25,7 @@ import BaseTxInfo from '@/pages/popup/-components/BaseTxInfo';
 import DappInfo from '@/pages/popup/-components/DappInfo';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignPsbt } from '@/types/message/inject/bitcoin';
-import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getTweakSigner } from '@/utils/bitcoin/tx';
+import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getInputsToSign, getTweakSigner, signAndFinalizePsbt } from '@/utils/bitcoin/tx';
 import { wait } from '@/utils/fetch/wait';
 import { gte, plus } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
@@ -79,7 +78,9 @@ export default function Entry({ request }: EntryProps) {
     return balance.data.chain_stats.funded_txo_sum - balance.data.chain_stats.spent_txo_sum - balance.data.mempool_stats.spent_txo_sum;
   }, [balance.data]);
 
-  const { params: psbtHex, origin } = request;
+  const { params, origin } = request;
+
+  const { psbtHex, options } = params;
 
   const { siteIconURL } = useSiteIconURL(origin);
   const siteTitle = getSiteTitle(origin);
@@ -157,19 +158,21 @@ export default function Entry({ request }: EntryProps) {
         network: currentBitcoinNetwork.isTestnet ? 'testnet' : 'mainnet',
       });
 
-      parsedPsbt.data.inputs.forEach((input, index) => {
-        if (isTaprootInput(input)) {
-          if (input.tapLeafScript && input.tapLeafScript?.length > 0 && !input.tapMerkleRoot) {
-            parsedPsbt.signInput(index, signer);
-          } else {
-            parsedPsbt.signInput(index, tweakSigner!);
-          }
-        } else {
-          parsedPsbt.signInput(index, signer);
-        }
+      const inputsToSign = getInputsToSign({
+        psbt: parsedPsbt,
+        options,
+        keyPairPublicKey: keyPair?.publicKey,
+        accountAddress: nativeAccountAsset?.address.address,
+        bitcoinNetwork,
       });
 
-      const result = parsedPsbt.finalizeAllInputs().toHex();
+      const result = signAndFinalizePsbt({
+        psbt: parsedPsbt,
+        inputsToSign,
+        signer,
+        tweakSigner,
+        autoFinalized: options?.autoFinalized !== false,
+      });
 
       if (!result) {
         throw new Error('Failed to sign transaction');

--- a/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
+++ b/src/pages/popup/bitcoin/sign-psbts/-entry.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { networks, Psbt } from 'bitcoinjs-lib';
-import { isTaprootInput } from 'bitcoinjs-lib/src/psbt/bip371';
 import { Typography } from '@mui/material';
 
 import BaseBody from '@/components/BaseLayout/components/BaseBody';
@@ -26,7 +25,7 @@ import BaseTxInfo from '@/pages/popup/-components/BaseTxInfo';
 import DappInfo from '@/pages/popup/-components/DappInfo';
 import type { ResponseAppMessage } from '@/types/message/content';
 import type { BitSignPsbts, BitSignPsbtsResposne } from '@/types/message/inject/bitcoin';
-import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getTweakSigner } from '@/utils/bitcoin/tx';
+import { decodedPsbt, ecpairFromPrivateKey, formatPsbtHex, getInputsToSign, getTweakSigner, signAndFinalizePsbt } from '@/utils/bitcoin/tx';
 import { wait } from '@/utils/fetch/wait';
 import { gte, plus } from '@/utils/numbers';
 import { getCoinId, getUniqueChainId, isSameChain } from '@/utils/queryParamGenerator';
@@ -79,7 +78,8 @@ export default function Entry({ request }: EntryProps) {
     return balance.data.chain_stats.funded_txo_sum - balance.data.chain_stats.spent_txo_sum - balance.data.mempool_stats.spent_txo_sum;
   }, [balance.data]);
 
-  const { params: psbtHexes, origin } = request;
+  const { params, origin } = request;
+  const { psbtHexes, options } = params;
 
   const { siteIconURL } = useSiteIconURL(origin);
   const siteTitle = getSiteTitle(origin);
@@ -178,19 +178,21 @@ export default function Entry({ request }: EntryProps) {
       });
 
       const result: BitSignPsbtsResposne = parsedPsbts.map((parsedPsbt) => {
-        parsedPsbt.data.inputs.forEach((input, index) => {
-          if (isTaprootInput(input)) {
-            if (input.tapLeafScript && input.tapLeafScript?.length > 0 && !input.tapMerkleRoot) {
-              parsedPsbt.signInput(index, signer);
-            } else {
-              parsedPsbt.signInput(index, tweakSigner!);
-            }
-          } else {
-            parsedPsbt.signInput(index, signer);
-          }
+        const inputsToSign = getInputsToSign({
+          psbt: parsedPsbt,
+          options,
+          keyPairPublicKey: keyPair?.publicKey,
+          accountAddress: nativeAccountAsset?.address.address,
+          bitcoinNetwork,
         });
 
-        const txHex = parsedPsbt.finalizeAllInputs().toHex();
+        const txHex = signAndFinalizePsbt({
+          psbt: parsedPsbt,
+          inputsToSign,
+          signer,
+          tweakSigner,
+          autoFinalized: options?.autoFinalized !== false,
+        });
 
         if (!txHex) {
           throw new Error('Failed to sign transaction');

--- a/src/script/inject/bitcoin/provider/bitcoin.ts
+++ b/src/script/inject/bitcoin/provider/bitcoin.ts
@@ -10,6 +10,7 @@ import type {
   BitSendBitcoinResponse,
   BitSignPsbtResposne,
   BitSignPsbtsResposne,
+  SignPsbtOptions,
 } from '@/types/message/inject/bitcoin';
 
 import { bitcoinRequestApp } from '../request';
@@ -45,17 +46,29 @@ const getPublicKey = async () => {
   return publicKeyHex;
 };
 
-const signPsbt = async (psbtHex: string) => {
+const signPsbt = async (psbtHex: string, options?: SignPsbtOptions) => {
   const formattedPsbt = formatPsbtHex(psbtHex);
 
-  const signedPsbt = (await bitcoinRequestApp({ method: 'bit_signPsbt', params: formattedPsbt })) as BitSignPsbtResposne;
+  const signedPsbt = (await bitcoinRequestApp({
+    method: 'bit_signPsbt',
+    params: {
+      psbtHex: formattedPsbt,
+      options,
+    },
+  })) as BitSignPsbtResposne;
   return signedPsbt;
 };
 
-const signPsbts = async (psbtsHexes: string[]) => {
+const signPsbts = async (psbtsHexes: string[], options?: SignPsbtOptions) => {
   const formattedPsbts = psbtsHexes.map((psbtHex) => formatPsbtHex(psbtHex));
 
-  const signedPsbts = (await bitcoinRequestApp({ method: 'bit_signPsbts', params: formattedPsbts })) as BitSignPsbtsResposne;
+  const signedPsbts = (await bitcoinRequestApp({
+    method: 'bit_signPsbts',
+    params: {
+      psbtHexes: formattedPsbts,
+      options,
+    },
+  })) as BitSignPsbtsResposne;
   return signedPsbts;
 };
 

--- a/src/types/message/inject/bitcoin.ts
+++ b/src/types/message/inject/bitcoin.ts
@@ -119,7 +119,22 @@ export interface BitSignMessage extends RequestBase {
   params: BitSignMessageParams;
 }
 
-export type BitSignPsbtParams = string;
+export interface SignPsbtOptions {
+  autoFinalized?: boolean;
+  toSignInputs?: {
+    index: number;
+    address?: string;
+    publicKey?: string;
+    sighashTypes?: number[];
+    disableTweakSigner?: boolean;
+    useTweakedSigner?: boolean;
+  }[];
+}
+
+export type BitSignPsbtParams = {
+  psbtHex: string;
+  options?: SignPsbtOptions;
+};
 export type BitSignPsbtResposne = string;
 
 export interface BitSignPsbt extends RequestBase {
@@ -128,7 +143,10 @@ export interface BitSignPsbt extends RequestBase {
   params: BitSignPsbtParams;
 }
 
-export type BitSignPsbtsParams = string[];
+export type BitSignPsbtsParams = {
+  psbtHexes: string[];
+  options?: SignPsbtOptions;
+};
 export type BitSignPsbtsResposne = string[];
 
 export interface BitSignPsbts extends RequestBase {

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -22,9 +22,8 @@ import type {
   BitSendBitcoinResponse,
   BitSignPsbtResposne,
   BitSignPsbtsResposne,
-  BitSignPsbtsResposne,
+  SignPsbtOptions,
 } from '@/types/message/inject/bitcoin';
-import type { CommonRequest } from '@/types/message/inject/common';
 import type {
   GnoConnectResponse,
   GnoSignAndSendTransactionResponse,
@@ -136,8 +135,8 @@ declare global {
     getBalance: () => Promise<BitGetBalanceResponse>;
     getPublicKey: () => Promise<string>;
     getPublicKeyHex: () => Promise<string>;
-    signPsbt: (psbtHex: string) => Promise<BitSignPsbtResposne>;
-    signPsbts: (psbtHexs: string[]) => Promise<BitSignPsbtsResposne>;
+    signPsbt: (psbtHex: string, options?: SignPsbtOptions) => Promise<BitSignPsbtResposne>;
+    signPsbts: (psbtHexes: string[], options?: SignPsbtOptions) => Promise<BitSignPsbtsResposne>;
     getNetwork: () => Promise<Network>;
     signMessage: (message: string, type?: 'ecdsa' | 'bip322-simple') => Promise<string>;
     signMessageBIP322: (message: string) => Promise<string>;
@@ -179,7 +178,7 @@ declare global {
   }
 
   interface SolanaProvider {
-    request?: (BaseRequest) => Promise<Unknown>;
+    request?: (message: BaseRequest) => Promise<unknown>;
     connect?: () => Promise<SolanaConnectResponse>;
     disconnect?: () => Promise<void>;
     signMessage: (message: Uint8Array, display: 'utf8' | 'hex') => Promise<SolanaSignMessageResponse>;

--- a/src/utils/bitcoin/tx.ts
+++ b/src/utils/bitcoin/tx.ts
@@ -2,14 +2,16 @@ import BIP32Factory from 'bip32';
 import * as bip39 from 'bip39';
 import type { networks as BitcoinNetwork, Signer as BitcoinLibSigner } from 'bitcoinjs-lib';
 import { address as addressConverter, crypto, initEccLib, Psbt, Transaction } from 'bitcoinjs-lib';
-import { toXOnly } from 'bitcoinjs-lib/src/psbt/bip371';
+import { isTaprootInput, toXOnly } from 'bitcoinjs-lib/src/psbt/bip371';
 import { ECPairFactory, networks } from 'ecpair';
 import * as ecc from '@bitcoinerlab/secp256k1';
 
 import type { Account } from '@/types/account';
 import type { Chain } from '@/types/chain';
+import type { SignPsbtOptions } from '@/types/message/inject/bitcoin';
 
 import { aesDecrypt } from '../crypto';
+import { devLogger } from '../devLogger';
 import { minus, plus } from '../numbers';
 
 let isEccInit = false;
@@ -248,5 +250,167 @@ export function isValidBitcoinTx(txHex: string) {
     return true;
   } catch {
     return false;
+  }
+}
+
+const isTaprootAddress = (address: string): boolean => address.startsWith('bc1p') || address.startsWith('tb1p');
+
+export function getInputsToSign({
+  psbt,
+  options,
+  keyPairPublicKey,
+  accountAddress,
+  bitcoinNetwork,
+}: {
+  psbt: Psbt;
+  options?: SignPsbtOptions;
+  keyPairPublicKey?: string;
+  accountAddress?: string;
+  bitcoinNetwork: BitcoinNetwork.Network;
+}): {
+  index: number;
+  publicKey: string;
+  address: string;
+  sighashTypes?: number[];
+  disableTweakSigner?: boolean;
+  useTweakedSigner?: boolean;
+}[] {
+  if (Array.isArray(options?.toSignInputs) && options.toSignInputs.length > 0) {
+    return options.toSignInputs.map((input) => ({
+      index: input.index,
+      publicKey: input.publicKey || keyPairPublicKey || '',
+      address: input.address || accountAddress || '',
+      sighashTypes: input.sighashTypes,
+      disableTweakSigner: input.disableTweakSigner,
+      useTweakedSigner: input.useTweakedSigner,
+    }));
+  }
+
+  const result: {
+    index: number;
+    publicKey: string;
+    address: string;
+    sighashTypes?: number[];
+    disableTweakSigner?: boolean;
+    useTweakedSigner?: boolean;
+  }[] = [];
+
+  psbt.data.inputs.forEach((input, index) => {
+    let inputAddress = '';
+
+    if (input.witnessUtxo) {
+      const scriptPubKey = input.witnessUtxo.script;
+      try {
+        inputAddress = addressConverter.fromOutputScript(scriptPubKey, bitcoinNetwork);
+      } catch {
+        // empty
+      }
+    } else if (input.nonWitnessUtxo) {
+      const tx = Transaction.fromBuffer(input.nonWitnessUtxo);
+      const output = tx.outs[psbt.txInputs[index].index];
+      try {
+        inputAddress = addressConverter.fromOutputScript(output.script, bitcoinNetwork);
+      } catch {
+        // empty
+      }
+    }
+
+    const isSigned = input.finalScriptSig || input.finalScriptWitness;
+
+    if (inputAddress === accountAddress && !isSigned && keyPairPublicKey && accountAddress) {
+      result.push({
+        index,
+        publicKey: keyPairPublicKey,
+        address: accountAddress,
+        sighashTypes: input.sighashType ? [input.sighashType] : undefined,
+      });
+
+      if (isTaprootAddress(accountAddress) && !input.tapInternalKey) {
+        input.tapInternalKey = toXOnly(Buffer.from(keyPairPublicKey, 'hex'));
+      }
+    }
+  });
+
+  return result;
+}
+
+export function signPsbtInputs({
+  psbt,
+  inputsToSign,
+  signer,
+  tweakSigner,
+}: {
+  psbt: Psbt;
+  inputsToSign: {
+    index: number;
+    sighashTypes?: number[];
+    disableTweakSigner?: boolean;
+    useTweakedSigner?: boolean;
+  }[];
+  signer: BitcoinLibSigner;
+  tweakSigner: BitcoinLibSigner | null;
+}): void {
+  inputsToSign.forEach((inputToSign) => {
+    const { index, disableTweakSigner, useTweakedSigner, sighashTypes } = inputToSign;
+    const input = psbt.data.inputs[index];
+
+    if (!input) {
+      devLogger.warn(`Input at index ${index} not found`);
+      return;
+    }
+
+    if (isTaprootInput(input)) {
+      let needTweak = true;
+
+      if (typeof useTweakedSigner === 'boolean') {
+        needTweak = useTweakedSigner;
+      } else if (disableTweakSigner) {
+        needTweak = false;
+      } else if (input.tapLeafScript && input.tapLeafScript?.length > 0 && !input.tapMerkleRoot) {
+        input.tapLeafScript.forEach((e) => {
+          if (e.controlBlock && e.script) {
+            needTweak = false;
+          }
+        });
+      }
+
+      if (needTweak) {
+        if (!tweakSigner) {
+          throw new Error('Tweak signer is required for taproot input');
+        }
+        psbt.signInput(index, tweakSigner, sighashTypes);
+      } else {
+        psbt.signInput(index, signer, sighashTypes);
+      }
+    } else {
+      psbt.signInput(index, signer, sighashTypes);
+    }
+  });
+}
+
+export function signAndFinalizePsbt({
+  psbt,
+  inputsToSign,
+  signer,
+  tweakSigner,
+  autoFinalized = true,
+}: {
+  psbt: Psbt;
+  inputsToSign: {
+    index: number;
+    sighashTypes?: number[];
+    disableTweakSigner?: boolean;
+    useTweakedSigner?: boolean;
+  }[];
+  signer: BitcoinLibSigner;
+  tweakSigner: BitcoinLibSigner | null;
+  autoFinalized?: boolean;
+}): string {
+  signPsbtInputs({ psbt, inputsToSign, signer, tweakSigner });
+
+  if (autoFinalized) {
+    return psbt.finalizeAllInputs().toHex();
+  } else {
+    return psbt.toHex();
   }
 }


### PR DESCRIPTION
  - Add SignPsbtOptions interface with toSignInputs and autoFinalized options
  - Extract signing logic into getInputsToSign, signPsbtInputs, signAndFinalizePsbt utils
  - Update signPsbt/signPsbts APIs to accept optional parameters
  - Enable selective input signing for multi-sig and complex transaction scenarios
  - Maintain backward compatibility with existing dApps