### PR TITLE
[API-735] Refactor asset listing page structure

### DIFF
--- a/src/components/AccountTxHistory/components/Gno/index.tsx
+++ b/src/components/AccountTxHistory/components/Gno/index.tsx
@@ -2,8 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 import Base1300Text from '@/components/common/Base1300Text';
 import EmptyAsset from '@/components/EmptyAsset';
-import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import { isMatchingCoinId } from '@/utils/queryParamGenerator';
+import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
 
 import { Container, EmptyAssetContainer, IconContainer } from './styled';
 
@@ -16,14 +15,12 @@ type GnoAccountTxHistory = {
 
 export default function GnoAccountTxHistory({ coinId }: GnoAccountTxHistory) {
   const { t } = useTranslation();
-  const { data: accountAllAssets } = useAccountAllAssets({
-    filterByPreferAccountType: true,
-  });
 
-  const selectedAsset = accountAllAssets?.allGnoAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId));
+  const { getGnoAccountAsset } = useGetAccountAsset({ coinId });
+  const selectedAsset = getGnoAccountAsset();
 
-  const accountExplorerUrl = selectedAsset?.chain.explorer.account
-    ? selectedAsset.chain.explorer.account.replace('${address}', selectedAsset.address.address)
+  const accountExplorerUrl = selectedAsset?.chain?.explorer?.account
+    ? selectedAsset.chain.explorer.account.replace('${address}', selectedAsset.address?.address ?? '')
     : '';
 
   return (

--- a/src/components/AccountTxHistory/components/Solana/index.tsx
+++ b/src/components/AccountTxHistory/components/Solana/index.tsx
@@ -2,8 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 import Base1300Text from '@/components/common/Base1300Text';
 import EmptyAsset from '@/components/EmptyAsset';
-import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import { isMatchingCoinId } from '@/utils/queryParamGenerator';
+import { useGetAccountAsset } from '@/hooks/useGetAccountAsset';
 
 import { Container, EmptyAssetContainer, IconContainer } from './styled';
 
@@ -16,11 +15,9 @@ type SolanaAccountTxHistory = {
 
 export default function SolanaAccountTxHistory({ coinId }: SolanaAccountTxHistory) {
   const { t } = useTranslation();
-  const { data: accountAllAssets } = useAccountAllAssets({
-    filterByPreferAccountType: true,
-  });
 
-  const selectedAsset = accountAllAssets?.allSolanaAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId));
+  const { getSolanaAccountAsset } = useGetAccountAsset({ coinId });
+  const selectedAsset = getSolanaAccountAsset();
 
   const accountExplorerUrl = selectedAsset?.chain.explorer.account
     ? selectedAsset.chain.explorer.account.replace('${address}', selectedAsset.address.address)

--- a/src/components/CoinSelect/index.tsx
+++ b/src/components/CoinSelect/index.tsx
@@ -11,15 +11,15 @@ import { COIN_SELECT_SORT_KEY, DASHBOARD_COIN_SORT_KEY } from '@/constants/sortK
 import { useGetAverageAPY as useIotaGetAverageAPY } from '@/hooks/iota/useGetAverageAPY';
 import { useGetAverageAPY } from '@/hooks/sui/useGetAverageAPY';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
+import { useAssetPricing } from '@/hooks/useAssetPricing';
 import type { AccountCosmosAsset } from '@/types/account';
 import type { FlatAccountAssets } from '@/types/accountAssets';
 import type { Chain, UniqueChainId } from '@/types/chain';
 import type { CommonSortKeyType } from '@/types/sortKey';
-import { getFilteredAssetsByChainId, getFilteredChainsByChainId, isStakeableAsset } from '@/utils/asset';
+import { filterAssetsBySearch, getFilteredAssetsByChainId, getFilteredChainsByChainId, getStakeableBalance, isStakeableAsset } from '@/utils/asset';
 import { isTestnetChain } from '@/utils/chain';
-import { minus, times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, getUniqueChainId, isMatchingCoinId, isMatchingUniqueChainId, parseCoinId, parseUniqueChainId } from '@/utils/queryParamGenerator';
+import { minus, toDisplayDenomAmount } from '@/utils/numbers';
+import { getUniqueChainId, isMatchingUniqueChainId, parseCoinId, parseUniqueChainId } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase, shorterAddress, toPercentages } from '@/utils/string';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -52,8 +52,6 @@ export default function CoinSelect({
 }: CoinSelectProps) {
   const { t } = useTranslation();
 
-  const { data: coinGeckoPrice } = useCoinGeckoPrice();
-  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
   const selectedChainFilterId = useExtensionStorageStore((state) => state.selectedChainFilterId);
 
   const isDisableDupeEthermint = variant === 'stake';
@@ -73,6 +71,7 @@ export default function CoinSelect({
   const [search, setSearch] = useState('');
   const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
 
+  const isSearchEmpty = useMemo(() => search.length === 0, [search.length]);
   const isDebouncing = !!search && isPending();
 
   const [isOpenSortBottomSheet, setIsOpenSortBottomSheet] = useState(false);
@@ -125,48 +124,31 @@ export default function CoinSelect({
 
   const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
 
-  const computedAssetValues = useMemo(() => {
-    return (
-      baseCoinList?.map((item) => {
-        const balance = isStakeableAsset(item) ? item.totalBalance || item.balance || '0' : item.balance;
+  const pricedAssets = useAssetPricing(baseCoinList, {
+    getBalance: getStakeableBalance,
+  });
 
-        const displayAmount = toDisplayDenomAmount(balance, item.asset.decimals);
-
-        const chainPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-
-        const value = times(displayAmount, chainPrice);
-
+  const assetsWithApr = useMemo(
+    () =>
+      pricedAssets.map((item) => {
         const apr = (() => {
-          if (variant === 'stake') {
-            if (item.chain.chainType === 'cosmos' && item.chain.apr) {
-              return toPercentages(item.chain.apr, {
-                disableMark: true,
-              });
-            }
+          if (variant !== 'stake') return undefined;
 
-            if (item.chain.chainType === 'sui') {
-              return averageAPY;
-            }
-
-            if (item.chain.chainType === 'iota') {
-              return iotaAverageAPY;
-            }
+          if (item.chain.chainType === 'cosmos' && item.chain.apr) {
+            return toPercentages(item.chain.apr, { disableMark: true });
           }
-
+          if (item.chain.chainType === 'sui') return averageAPY;
+          if (item.chain.chainType === 'iota') return iotaAverageAPY;
           return undefined;
         })();
 
-        return {
-          ...item,
-          value,
-          apr,
-        };
-      }) || []
-    );
-  }, [averageAPY, baseCoinList, coinGeckoPrice, iotaAverageAPY, userCurrencyPreference, variant]);
+        return { ...item, apr };
+      }),
+    [averageAPY, iotaAverageAPY, pricedAssets, variant],
+  );
 
   const sortedAssets = useMemo(() => {
-    const sortedValues = [...computedAssetValues].sort((a, b) => {
+    return [...assetsWithApr].sort((a, b) => {
       const aIsTestnet = isTestnetChain(a.chain.id);
       const bIsTestnet = isTestnetChain(b.chain.id);
 
@@ -190,31 +172,21 @@ export default function CoinSelect({
 
       return 0;
     });
+  }, [assetsWithApr, sortOption, variant]);
 
-    return sortedValues;
-  }, [computedAssetValues, sortOption, variant]);
+  const filteredAssetsByChain = useMemo(() => getFilteredAssetsByChainId(sortedAssets, currentSelectedChainId), [currentSelectedChainId, sortedAssets]);
 
-  const filteredCoinList = useMemo(() => {
-    const filteredAssetsByChain = getFilteredAssetsByChainId(sortedAssets, currentSelectedChainId);
-
-    if (!!search && debouncedSearch.length > 1) {
-      return (
-        filteredAssetsByChain.filter((asset) => {
-          const condition = [asset.asset.symbol, asset.asset.id];
-
-          return condition.some((item) => item.toLowerCase().indexOf(debouncedSearch.toLowerCase()) > -1);
-        }) || []
-      );
-    }
-    return filteredAssetsByChain;
-  }, [currentSelectedChainId, debouncedSearch, search, sortedAssets]);
+  const filteredCoinList = useMemo(
+    () => filterAssetsBySearch(filteredAssetsByChain, debouncedSearch, isSearchEmpty),
+    [debouncedSearch, filteredAssetsByChain, isSearchEmpty],
+  );
 
   const handleOnClickCoin = useCallback(
     (coinId: string) => {
       if (parseCoinId(coinId).chainType !== 'evm') {
         onSelectCoin(coinId);
       } else {
-        const currentCoin = data?.allEVMAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId));
+        const currentCoin = data?.allEVMAccountAssets.find(({ uniqueCoinId }) => uniqueCoinId === coinId);
 
         const cosmosStyleEthermintCoin = (() => {
           const isEthermint = currentCoin?.chain.chainType === 'evm' && currentCoin.chain.isCosmos;
@@ -295,9 +267,9 @@ export default function CoinSelect({
             return (
               <CoinWithChainNameButton
                 key={coin.asset.id.concat(coin.asset.chainId).concat(coin.asset.chainType)}
-                isActive={currentCoinId === getCoinId(coin.asset)}
+                isActive={currentCoinId === coin.uniqueCoinId}
                 displayAmount={displayAmount}
-                apr={coin.apr ? coin.apr : undefined}
+                apr={coin.apr}
                 symbol={resolvedSymbol}
                 chainName={coin.chain.name}
                 assetId={resolvedAssetId}
@@ -308,7 +280,7 @@ export default function CoinSelect({
                   badgeImageURL: coin.chain.image || '',
                 }}
                 onClick={() => {
-                  handleOnClickCoin(getCoinId(coin.asset));
+                  handleOnClickCoin(coin.uniqueCoinId);
                 }}
               />
             );

--- a/src/components/CoinSelect/index.tsx
+++ b/src/components/CoinSelect/index.tsx
@@ -122,7 +122,7 @@ export default function CoinSelect({
   const finalSelectedChainFilterId =
     selectedChainFilterId && variant === 'stake' && currentSelectedChain ? getUniqueChainId(currentSelectedChain) : currentSelectedChainId;
 
-  const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
+  const isShowAssetId = useMemo(() => !!currentSelectedChain || (!!debouncedSearch && !isSearchEmpty), [currentSelectedChain, debouncedSearch, isSearchEmpty]);
 
   const pricedAssets = useAssetPricing(baseCoinList, {
     getBalance: getStakeableBalance,

--- a/src/components/Fee/EVMFee/components/FeeSettingBottomSheet/index.tsx
+++ b/src/components/Fee/EVMFee/components/FeeSettingBottomSheet/index.tsx
@@ -10,7 +10,7 @@ import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
 import type { FeeType } from '@/types/evm/fee';
 import { times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, getUniqueChainIdWithManual, isMatchingUniqueChainId, parseCoinId } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainIdWithManual, parseCoinId } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
 import { toastSuccess } from '@/utils/toast';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
@@ -94,7 +94,7 @@ export default function FeeSettingBottomSheet({
     const chainId = parsedCoinId ? getUniqueChainIdWithManual(parsedCoinId.chainId, parsedCoinId.chainType) : undefined;
 
     return [...(accountAllAssets?.evmAccountAssets || []), ...(accountAllAssets?.evmAccountCustomAssets || [])].find(
-      (item) => isMatchingUniqueChainId(item.chain, chainId) && isEqualsIgnoringCase(item.asset.id, NATIVE_EVM_COIN_ADDRESS),
+      (item) => item.uniqueChainId === chainId && isEqualsIgnoringCase(item.asset.id, NATIVE_EVM_COIN_ADDRESS),
     );
   }, [accountAllAssets?.evmAccountAssets, accountAllAssets?.evmAccountCustomAssets, curretFeeOption?.coinId]);
   const feeCoinId = nativeAccountAsset?.asset ? getCoinId(nativeAccountAsset?.asset) : '';

--- a/src/components/MainBox/Portfolio/components/BalanceValueButton/index.tsx
+++ b/src/components/MainBox/Portfolio/components/BalanceValueButton/index.tsx
@@ -2,9 +2,8 @@ import Typography from '@mui/material/Typography';
 
 import BalanceDisplay from '@/components/BalanceDisplay';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
-import type { PortfolioCoinItem } from '@/pages/-entry';
-import { plus } from '@/utils/numbers';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
+import { usePortfolioValueStore } from '@/zustand/hooks/usePortfolioValueStore';
 
 import { Container, StyledIconButton, ValueButton } from './styled';
 import { StyledIconContainer, TotalBalanceContainer } from '../../styled';
@@ -12,22 +11,18 @@ import { StyledIconContainer, TotalBalanceContainer } from '../../styled';
 import RefreshIcon from '@/assets/images/icons/Refresh18.svg';
 
 interface BalanceValueButtonProps {
-  accountAssets: PortfolioCoinItem[];
   isUpdatingBalance: boolean;
   handleManualBalanceUpdate: () => void;
 }
 
-export default function BalanceValueButton({ accountAssets, isUpdatingBalance, handleManualBalanceUpdate }: BalanceValueButtonProps) {
+export default function BalanceValueButton({ isUpdatingBalance, handleManualBalanceUpdate }: BalanceValueButtonProps) {
   const { isLoading } = useCoinGeckoPrice();
   const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
   const isBalanceVisible = useExtensionStorageStore((state) => state.isBalanceVisible);
   const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
 
-  const aggregateValue = accountAssets.reduce((acc, cur) => {
-    const sum = plus(acc, cur.value);
-
-    return sum;
-  }, '0');
+  const totalValue = usePortfolioValueStore((state) => state.totalValue);
+  const hasAssets = usePortfolioValueStore((state) => state.hasAssets);
 
   return (
     <Container>
@@ -37,11 +32,11 @@ export default function BalanceValueButton({ accountAssets, isUpdatingBalance, h
         }}
       >
         <TotalBalanceContainer>
-          {!accountAssets || accountAssets.length === 0 || isLoading ? (
+          {!hasAssets || isLoading ? (
             <Typography variant="h1n_B">{'--'}</Typography>
           ) : (
             <BalanceDisplay typoOfIntegers="h1n_B" typoOfDecimals="h2n_M" currency={userCurrencyPreference} isDisableLeadingCurreny>
-              {aggregateValue}
+              {totalValue}
             </BalanceDisplay>
           )}
           &nbsp;

--- a/src/components/MainBox/Portfolio/components/BalanceValueWrapper/index.tsx
+++ b/src/components/MainBox/Portfolio/components/BalanceValueWrapper/index.tsx
@@ -7,7 +7,6 @@ import ChipButton from '@/components/common/ChipButton';
 import { useManualBalanceUpdate } from '@/hooks/common/useManualBalanceUpdate';
 import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useUpdateBalance } from '@/hooks/update/useUpdateBalance';
-import type { PortfolioCoinItem } from '@/pages/-entry';
 import { Route as SelectReceiveCoin } from '@/pages/wallet/receive';
 import { Route as ReceiveWithChainId } from '@/pages/wallet/receive/chain/$chainId';
 import { Route as SelectSendCoin } from '@/pages/wallet/send';
@@ -26,13 +25,12 @@ import {
 } from '../../styled';
 import BalanceValueButton from '../BalanceValueButton';
 
-interface BalanceValueButtonProps {
-  accountAssets: PortfolioCoinItem[];
+interface BalanceValueWrapperProps {
   selectedChainId?: UniqueChainId;
   selectedChainMainAsset?: FlatAccountAssets;
 }
 
-export default function BalanceValueWrapper({ accountAssets, selectedChainId, selectedChainMainAsset }: BalanceValueButtonProps) {
+export default function BalanceValueWrapper({ selectedChainId, selectedChainMainAsset }: BalanceValueWrapperProps) {
   const { updateAllBalance, updateChainBalance, isLoadingAllBalance, isLoadingChainBalance } = useManualBalanceUpdate();
   const { isLoading: isUpdateBalanceLoading } = useUpdateBalance();
   const { isLoading: isUpdateChainBalanceLoading } = useAutoBalanceRefresh(selectedChainId && [selectedChainId]);
@@ -65,7 +63,7 @@ export default function BalanceValueWrapper({ accountAssets, selectedChainId, se
   return (
     <BodyContainer>
       <BodyTopContainer>
-        <BalanceValueButton accountAssets={accountAssets} isUpdatingBalance={isUpdatingBalance} handleManualBalanceUpdate={handleManualBalanceUpdate} />
+        <BalanceValueButton isUpdatingBalance={isUpdatingBalance} handleManualBalanceUpdate={handleManualBalanceUpdate} />
       </BodyTopContainer>
       <BodyBottomContainer>
         <BodyBottomChipButtonContainer>

--- a/src/components/MainBox/Portfolio/index.tsx
+++ b/src/components/MainBox/Portfolio/index.tsx
@@ -1,18 +1,19 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
 
 import AddressActionButtons from '@/components/AddressActionButtons';
 import AllNetworkButton from '@/components/AllNetworkButton';
 import StaleBalanceErrorBanner from '@/components/StaleBalanceErrorBanner';
+import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import type { PortfolioCoinItem } from '@/pages/-entry';
 import { Route as DappList } from '@/pages/dapp-list';
 import CurrencyBottomSheet from '@/pages/general-setting/-components/CurrencyBottomSheet';
 import { Route as SelectStakeCoin } from '@/pages/wallet/stake';
 import type { UniqueChainId } from '@/types/chain';
 import { getFilteredChainsByChainId, getMainAssetByChainId } from '@/utils/asset';
 import { getCoinId } from '@/utils/queryParamGenerator';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import BalanceValueWrapper from './components/BalanceValueWrapper';
 import BalanceVisibleControlButton from './components/BalanceVisibleControlButton';
@@ -27,17 +28,16 @@ import SwapIcon from '@/assets/images/icons/Swap22.svg';
 
 import cosmostationLogoImg from '@/assets/images/logos/greyCosmostationLogo.png';
 
-type PortFolioProps = {
-  selectedChainId?: UniqueChainId;
-  accountAllAssetsForValueAggregate: PortfolioCoinItem[];
-  onChangeChaindId: (chainId?: UniqueChainId) => void;
-};
-
-export default function PortFolio({ selectedChainId, accountAllAssetsForValueAggregate, onChangeChaindId }: PortFolioProps) {
+export default function PortFolio() {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  const selectedChainId = useExtensionStorageStore((state) => state.selectedChainFilterId) || undefined;
+  const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
+
   const { data: accountAllAssets } = useAccountAllAssets({ filterByPreferAccountType: true });
+
+  useAutoBalanceRefresh(selectedChainId && [selectedChainId]);
 
   const [isOpenCurrencyBottomSheet, setIsOpenCurrencyBottomSheet] = useState(false);
   const [isOpenMoreOptionBottomSheet, setIsOpenMoreOptionBottomSheet] = useState(false);
@@ -65,6 +65,13 @@ export default function PortFolio({ selectedChainId, accountAllAssetsForValueAgg
     return undefined;
   }, [selectedChainId, selectedChainMainAsset?.chain]);
 
+  const handleChainIdChange = useCallback(
+    (chainId?: UniqueChainId) => {
+      updateExtensionStorageStore('selectedChainFilterId', chainId || null);
+    },
+    [updateExtensionStorageStore],
+  );
+
   return (
     <>
       <StaleBalanceErrorBanner chainId={selectedChainId} fetchStatus={selectedChainMainAsset?.fetchStatus?.balance} />
@@ -87,20 +94,12 @@ export default function PortFolio({ selectedChainId, accountAllAssetsForValueAgg
                 isManageAssets
                 isWithValue
                 sizeVariant="small"
-                selectChainOption={(id) => {
-                  onChangeChaindId(id);
-                }}
+                selectChainOption={handleChainIdChange}
               />
             </TopRightContainer>
           </TopContainer>
         }
-        body={
-          <BalanceValueWrapper
-            accountAssets={accountAllAssetsForValueAggregate}
-            selectedChainId={selectedChainId}
-            selectedChainMainAsset={selectedChainMainAsset}
-          />
-        }
+        body={<BalanceValueWrapper selectedChainId={selectedChainId} selectedChainMainAsset={selectedChainMainAsset} />}
         bottom={
           <BottomButtonContainer>
             <StyledIconTextButton

--- a/src/hooks/cosmos/useAccountTxs.ts
+++ b/src/hooks/cosmos/useAccountTxs.ts
@@ -4,7 +4,6 @@ import { throttle } from 'es-toolkit';
 import { MINTSCAN_FRONT_API_V10_URL } from '@/constants/common';
 import type { AccountTx as AccountTxsPayload } from '@/types/cosmos/txs';
 import { get } from '@/utils/axios';
-import { isMatchingCoinId } from '@/utils/queryParamGenerator';
 
 import type { UseInfiniteFetchConfig } from '../common/useInfiniteFetch';
 import { useInfiniteFetch } from '../common/useInfiniteFetch';
@@ -21,7 +20,7 @@ export function useAccountTxs({ coinId, config }: UseAccountTxsProps) {
   });
 
   const cosmosAccountAsset = useMemo(() => {
-    const evmAsset = accountAssets?.evmAccountAssets?.find((asset) => isMatchingCoinId(asset.asset, coinId));
+    const evmAsset = accountAssets?.evmAccountAssets?.find((asset) => asset.uniqueCoinId === coinId);
     const isEthermint = !!evmAsset && evmAsset.chain.isCosmos;
 
     if (isEthermint) {
@@ -33,7 +32,7 @@ export function useAccountTxs({ coinId, config }: UseAccountTxsProps) {
       );
     }
 
-    return accountAssets?.cosmosAccountAssets?.find((asset) => isMatchingCoinId(asset.asset, coinId));
+    return accountAssets?.cosmosAccountAssets?.find((asset) => asset.uniqueCoinId === coinId);
   }, [accountAssets?.cosmosAccountAssets, accountAssets?.evmAccountAssets, coinId]);
 
   const isSupportHistory = cosmosAccountAsset?.chain.isSupportHistory;

--- a/src/hooks/cosmos/useFees.ts
+++ b/src/hooks/cosmos/useFees.ts
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 
-import type { AccountCosmosAsset, AccountCw20Asset } from '@/types/account';
 import { minus } from '@/utils/numbers';
 import { getUniqueChainId, getUniqueCoinId, parseCoinId } from '@/utils/queryParamGenerator';
 
@@ -72,12 +71,7 @@ export function useFees({ coinId, config }: UseFeesProps) {
     return sortedFeeCoinList.length > 0 ? sortedFeeCoinList : defaultFeeCoin ? [defaultFeeCoin] : [];
   }, [assetGasRate.data.gasRate, baseCoinList, currentUniqueChainId, defaultFeeCoin]);
 
-  const wrappedFeeAssets = useMemo<
-    ((AccountCosmosAsset | AccountCw20Asset) & {
-      balance: string;
-      gasRate: string[];
-    })[]
-  >(
+  const wrappedFeeAssets = useMemo(
     () =>
       feeAssets.map((item) => ({
         ...item,

--- a/src/hooks/cosmos/useFees.ts
+++ b/src/hooks/cosmos/useFees.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 
+import type { AccountCosmosAsset, AccountCw20Asset } from '@/types/account';
 import { minus } from '@/utils/numbers';
-import { getCoinId, isMatchingCoinId, isSameChain, parseCoinId } from '@/utils/queryParamGenerator';
+import { getUniqueChainId, getUniqueCoinId, parseCoinId } from '@/utils/queryParamGenerator';
 
 import { useBalance } from './useBalance';
 import { useGasRate } from './useGasRate';
@@ -20,7 +21,8 @@ export function useFees({ coinId, config }: UseFeesProps) {
 
   const baseCoinList = useMemo(() => [...(accountAssets?.allCosmosAccountAssets || [])], [accountAssets?.allCosmosAccountAssets]);
 
-  const chain = baseCoinList.find((asset) => isMatchingCoinId(asset.asset, coinId))?.chain;
+  const chain = baseCoinList.find((asset) => asset.uniqueCoinId === coinId)?.chain;
+  const currentUniqueChainId = chain && getUniqueChainId(chain);
 
   const assetGasRate = useGasRate({
     coinId,
@@ -32,13 +34,13 @@ export function useFees({ coinId, config }: UseFeesProps) {
   const defaultFeeCoin = useMemo(() => {
     const parsedCoinId = parseCoinId(coinId);
 
-    const mainAssetCoinId = getCoinId({
+    const mainAssetCoinId = getUniqueCoinId({
       id: chain?.mainAssetDenom || '',
       chainId: parsedCoinId.chainId,
       chainType: parsedCoinId.chainType,
     });
 
-    const sourceChainAsset = baseCoinList.find((item) => isMatchingCoinId(item.asset, mainAssetCoinId));
+    const sourceChainAsset = baseCoinList.find((item) => item.uniqueCoinId === mainAssetCoinId);
 
     return (
       sourceChainAsset && {
@@ -52,7 +54,7 @@ export function useFees({ coinId, config }: UseFeesProps) {
     const feeCoinIds = [...Object.keys(assetGasRate.data.gasRate)];
 
     const filteredFeeCoins = baseCoinList
-      .filter((item) => chain && isSameChain(chain, item.chain) && feeCoinIds.includes(item.asset.id))
+      .filter((item) => currentUniqueChainId && currentUniqueChainId === item.uniqueChainId && feeCoinIds.includes(item.asset.id))
       .map((item) => ({
         ...item,
         gasRate: assetGasRate.data.gasRate[item.asset.id],
@@ -68,9 +70,14 @@ export function useFees({ coinId, config }: UseFeesProps) {
     );
 
     return sortedFeeCoinList.length > 0 ? sortedFeeCoinList : defaultFeeCoin ? [defaultFeeCoin] : [];
-  }, [assetGasRate.data.gasRate, baseCoinList, chain, defaultFeeCoin]);
+  }, [assetGasRate.data.gasRate, baseCoinList, currentUniqueChainId, defaultFeeCoin]);
 
-  const wrappedFeeAssets = useMemo(
+  const wrappedFeeAssets = useMemo<
+    ((AccountCosmosAsset | AccountCw20Asset) & {
+      balance: string;
+      gasRate: string[];
+    })[]
+  >(
     () =>
       feeAssets.map((item) => ({
         ...item,

--- a/src/hooks/queries/useAccountAssetIdsMutations.ts
+++ b/src/hooks/queries/useAccountAssetIdsMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { AssetId } from '@/types/asset';
+import type { UniqueCoinId } from '@/types/asset';
+import { isMatchingCoinId, parseCoinId } from '@/utils/queryParamGenerator';
 import { getExtensionLocalStorage, setExtensionLocalStorage } from '@/utils/storage';
 
 export function useAccountAssetIdsMutations(accountId: string) {
@@ -12,18 +13,18 @@ export function useAccountAssetIdsMutations(accountId: string) {
   };
 
   const hideAssetMutation = useMutation({
-    mutationFn: async ({ assetId }: { assetId: AssetId }) => {
+    mutationFn: async ({ assetId }: { assetId: UniqueCoinId }) => {
       const storedHiddenAssetIds = (await getExtensionLocalStorage(`${accountId}-hidden-assetIds`)) || [];
 
-      const isAlreadyHidden = storedHiddenAssetIds.some(
-        (item) => item.chainId === assetId.chainId && item.id === assetId.id && item.chainType === assetId.chainType,
-      );
+      const isAlreadyHidden = storedHiddenAssetIds.some((item) => isMatchingCoinId(item, assetId));
 
       if (isAlreadyHidden) {
         return;
       }
 
-      const updatedHiddenAssetIds = [...storedHiddenAssetIds, assetId];
+      const newHiddenAssetId = parseCoinId(assetId);
+
+      const updatedHiddenAssetIds = [...storedHiddenAssetIds, newHiddenAssetId];
 
       await setExtensionLocalStorage(`${accountId}-hidden-assetIds`, updatedHiddenAssetIds);
     },
@@ -31,12 +32,10 @@ export function useAccountAssetIdsMutations(accountId: string) {
   });
 
   const showAssetMutation = useMutation({
-    mutationFn: async ({ assetId }: { assetId: AssetId }) => {
+    mutationFn: async ({ assetId }: { assetId: UniqueCoinId }) => {
       const storedHiddenAssetIds = (await getExtensionLocalStorage(`${accountId}-hidden-assetIds`)) || [];
 
-      const updatedHiddenAssetIds = storedHiddenAssetIds.filter(
-        (item) => !(item.chainId === assetId.chainId && item.id === assetId.id && item.chainType === assetId.chainType),
-      );
+      const updatedHiddenAssetIds = storedHiddenAssetIds.filter((item) => !isMatchingCoinId(item, assetId));
 
       await setExtensionLocalStorage(`${accountId}-hidden-assetIds`, updatedHiddenAssetIds);
     },
@@ -44,18 +43,18 @@ export function useAccountAssetIdsMutations(accountId: string) {
   });
 
   const addVisibleAssetMutation = useMutation({
-    mutationFn: async ({ assetId }: { assetId: AssetId }) => {
+    mutationFn: async ({ assetId }: { assetId: UniqueCoinId }) => {
       const storedVisibleAssetIds = (await getExtensionLocalStorage(`${accountId}-visible-assetIds`)) || [];
 
-      const isAlreadyVisible = storedVisibleAssetIds.some(
-        (item) => item.chainId === assetId.chainId && item.id === assetId.id && item.chainType === assetId.chainType,
-      );
+      const isAlreadyVisible = storedVisibleAssetIds.some((item) => isMatchingCoinId(item, assetId));
 
       if (isAlreadyVisible) {
         return;
       }
 
-      const updatedVisibleAssetIds = [...storedVisibleAssetIds, assetId];
+      const newVisibleAssetId = parseCoinId(assetId);
+
+      const updatedVisibleAssetIds = [...storedVisibleAssetIds, newVisibleAssetId];
 
       await setExtensionLocalStorage(`${accountId}-visible-assetIds`, updatedVisibleAssetIds);
     },
@@ -63,12 +62,10 @@ export function useAccountAssetIdsMutations(accountId: string) {
   });
 
   const removeVisibleAssetMutation = useMutation({
-    mutationFn: async ({ assetId }: { assetId: AssetId }) => {
+    mutationFn: async ({ assetId }: { assetId: UniqueCoinId }) => {
       const storedVisibleAssetIds = (await getExtensionLocalStorage(`${accountId}-visible-assetIds`)) || [];
 
-      const updatedVisibleAssetIds = storedVisibleAssetIds.filter(
-        (item) => !(item.chainId === assetId.chainId && item.id === assetId.id && item.chainType === assetId.chainType),
-      );
+      const updatedVisibleAssetIds = storedVisibleAssetIds.filter((item) => !isMatchingCoinId(item, assetId));
 
       await setExtensionLocalStorage(`${accountId}-visible-assetIds`, updatedVisibleAssetIds);
     },

--- a/src/hooks/queries/useAccountAssetIdsQuery.ts
+++ b/src/hooks/queries/useAccountAssetIdsQuery.ts
@@ -1,22 +1,23 @@
 import { useQuery } from '@tanstack/react-query';
 
-import type { AssetId } from '@/types/asset';
+import type { UniqueCoinId } from '@/types/asset';
+import { getUniqueCoinId } from '@/utils/queryParamGenerator';
 import { getMultipleFromExtensionStorage } from '@/utils/storage';
 
 export type AccountAssetIdsData = {
-  hiddenAssetIds: AssetId[];
-  visibleAssetIds: AssetId[];
+  hiddenAssetSet: Set<UniqueCoinId>;
+  visibleAssetSet: Set<UniqueCoinId>;
 };
 
-export function useAccountAssetIdsQuery(accountId: string) {
+export function useAccountAssetIdsSet(accountId: string) {
   return useQuery({
     queryKey: ['account-asset-ids', accountId],
     queryFn: async (): Promise<AccountAssetIdsData> => {
       const assetIdsStorage = await getMultipleFromExtensionStorage([`${accountId}-hidden-assetIds`, `${accountId}-visible-assetIds`]);
 
       return {
-        hiddenAssetIds: assetIdsStorage[`${accountId}-hidden-assetIds`] || [],
-        visibleAssetIds: assetIdsStorage[`${accountId}-visible-assetIds`] || [],
+        hiddenAssetSet: new Set((assetIdsStorage[`${accountId}-hidden-assetIds`] || []).map(getUniqueCoinId)),
+        visibleAssetSet: new Set((assetIdsStorage[`${accountId}-visible-assetIds`] || []).map(getUniqueCoinId)),
       };
     },
     staleTime: 1000 * 60,

--- a/src/hooks/useAccountAllAssets.ts
+++ b/src/hooks/useAccountAllAssets.ts
@@ -104,7 +104,7 @@ export function useAccountAllAssets({
 
   const fetcher = async () => {
     try {
-      const opts = { disableFilterHidden: true, disableBalanceFilter: true } as const;
+      const opts = { disableFilterHidden: true, disableBalanceFilter: true };
       const [accountAssets, accountCustomAssets] = await Promise.all([getAccountAssets(param, opts), getAccountCustomAssets(param, opts)]);
       return { ...accountAssets, ...accountCustomAssets };
     } catch {
@@ -186,10 +186,20 @@ export function useAccountAllAssets({
 
     const { cosmosAccountCustomAssets, customCw20AccountAssets, evmAccountCustomAssets, customErc20AccountAssets } = filteredByVisibleList;
 
-    const allCosmosAccountAssets: AllCosmosAccountAssets[] = [...cosmosAccountAssets, ...cosmosAccountCustomAssets, ...cw20AccountAssets, ...customCw20AccountAssets];
+    const allCosmosAccountAssets: AllCosmosAccountAssets[] = [
+      ...cosmosAccountAssets,
+      ...cosmosAccountCustomAssets,
+      ...cw20AccountAssets,
+      ...customCw20AccountAssets,
+    ];
 
     const allCosmosAccountAssetsFiltered: AllCosmosAccountAssets[] = isAccountTypeFilterActive
-      ? [...narrowChainAccountTypes(cosmosAccountAssets, accountType), ...cosmosAccountCustomAssets, ...narrowChainAccountTypes(cw20AccountAssets, accountType), ...customCw20AccountAssets]
+      ? [
+          ...narrowChainAccountTypes(cosmosAccountAssets, accountType),
+          ...cosmosAccountCustomAssets,
+          ...narrowChainAccountTypes(cw20AccountAssets, accountType),
+          ...customCw20AccountAssets,
+        ]
       : allCosmosAccountAssets;
 
     const assets = {

--- a/src/hooks/useAccountAllAssets.ts
+++ b/src/hooks/useAccountAllAssets.ts
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getAccountCustomAssets } from '@/libs/asset/coin/custom/accountAsset';
 import { getAccountAssets } from '@/libs/asset/coin/default/accountAsset';
+import type { ChainToAccountTypeMap } from '@/types/account';
 import type {
   AccountAssets as AccountAllAssets,
   AllCosmosAccountAssets,
@@ -41,6 +42,49 @@ type UseAccountAllAssets =
     }
   | undefined;
 
+function filterByChainAccountType<T extends FlatAccountAssets>(items: T[], accountTypeMap: ChainToAccountTypeMap | undefined): T[] {
+  if (!accountTypeMap) return items;
+
+  return items.filter((item) => {
+    const selected = accountTypeMap[item.chain.id];
+    if (!selected) return true;
+
+    const isSamePubkeyType = selected.pubkeyType && item.address.accountType.pubkeyType ? selected.pubkeyType === item.address.accountType.pubkeyType : true;
+
+    return selected.hdPath === item.address.accountType.hdPath && selected.pubkeyStyle === item.address.accountType.pubkeyStyle && isSamePubkeyType;
+  });
+}
+
+function narrowChainAccountTypes<T extends FlatAccountAssets>(items: T[], accountTypeMap: ChainToAccountTypeMap | undefined): T[] {
+  if (!accountTypeMap) return items;
+
+  return items.map((item) => {
+    const selected = accountTypeMap[item.chain.id];
+    if (!selected) return item;
+
+    return produce(item, (draft) => {
+      draft.chain.accountTypes = draft.chain.accountTypes.filter((origin) => origin.pubkeyStyle === selected.pubkeyStyle && origin.hdPath === selected.hdPath);
+    });
+  });
+}
+
+function filterDuplicatedEthermintAssets<T extends FlatAccountAssets>(cosmosItems: T[], evmItems: FlatAccountAssets[] | undefined): T[] {
+  if (!evmItems?.length) return cosmosItems;
+
+  return cosmosItems.filter((item) => {
+    if (item.chain.chainType !== 'cosmos' || !item.chain.isEvm || item.chain.mainAssetDenom !== item.asset.id) return true;
+
+    return !evmItems.some((evmAsset) => {
+      if (evmAsset.chain.id !== item.chain.id) return false;
+
+      const { hdPath, pubkeyStyle, pubkeyType } = evmAsset.address.accountType;
+      const { hdPath: compareHdPath, pubkeyStyle: comparePubkeyStyle, pubkeyType: comparePubkeyType } = item.address.accountType;
+
+      return hdPath === compareHdPath && pubkeyStyle === comparePubkeyStyle && pubkeyType === comparePubkeyType;
+    });
+  });
+}
+
 export function useAccountAllAssets({
   accountId,
   filterByPreferAccountType = false,
@@ -60,12 +104,9 @@ export function useAccountAllAssets({
 
   const fetcher = async () => {
     try {
-      const accountAssets = await getAccountAssets(param, { disableFilterHidden: true, disableBalanceFilter: true });
-      const accountCustomAssets = await getAccountCustomAssets(param, { disableFilterHidden: true, disableBalanceFilter: true });
-      return {
-        ...accountAssets,
-        ...accountCustomAssets,
-      };
+      const opts = { disableFilterHidden: true, disableBalanceFilter: true } as const;
+      const [accountAssets, accountCustomAssets] = await Promise.all([getAccountAssets(param, opts), getAccountCustomAssets(param, opts)]);
+      return { ...accountAssets, ...accountCustomAssets };
     } catch {
       return null;
     }
@@ -85,261 +126,91 @@ export function useAccountAllAssets({
     const { hiddenAssetSet: hidden, visibleAssetSet: visible } = assetIds || {};
 
     const shouldShowAsset = (uniqueCoinId: UniqueCoinId, balance: string) => {
-      const isVisible = visible?.has(uniqueCoinId);
+      if (visible?.has(uniqueCoinId)) return true;
 
-      if (isVisible) return true;
+      if (!disableHiddenFilter && (hidden?.has(uniqueCoinId) || hiddenCustom.has(uniqueCoinId))) return false;
 
-      const isHidden = disableHiddenFilter ? false : hidden?.has(uniqueCoinId) || hiddenCustom.has(uniqueCoinId);
-
-      if (isHidden) return false;
-
-      const isBalanceGreaterThanZero = gt(balance, '0');
-
-      return disableBalanceFilter ? true : isBalanceGreaterThanZero;
+      return disableBalanceFilter || gt(balance, '0');
     };
 
-    const filterAssetList = <T extends { uniqueCoinId: UniqueCoinId; balance: string }>(list: T[]): T[] =>
+    const filterVisible = <T extends { uniqueCoinId: UniqueCoinId; balance: string }>(list: T[]): T[] =>
       list.filter(({ uniqueCoinId, balance }) => shouldShowAsset(uniqueCoinId, balance));
 
     return {
-      cosmosAccountAssets: filterAssetList(data.cosmosAccountAssets),
-      cosmosAccountCustomAssets: filterAssetList(data.cosmosAccountCustomAssets),
-      evmAccountAssets: filterAssetList(data.evmAccountAssets),
-      evmAccountCustomAssets: filterAssetList(data.evmAccountCustomAssets),
-      aptosAccountAssets: filterAssetList(data.aptosAccountAssets),
-      suiAccountAssets: filterAssetList(data.suiAccountAssets),
-      cw20AccountAssets: filterAssetList(data.cw20AccountAssets),
-      erc20AccountAssets: filterAssetList(data.erc20AccountAssets),
+      cosmosAccountAssets: filterVisible(data.cosmosAccountAssets),
+      cosmosAccountCustomAssets: filterVisible(data.cosmosAccountCustomAssets),
+      evmAccountAssets: filterVisible(data.evmAccountAssets),
+      evmAccountCustomAssets: filterVisible(data.evmAccountCustomAssets),
+      aptosAccountAssets: filterVisible(data.aptosAccountAssets),
+      suiAccountAssets: filterVisible(data.suiAccountAssets),
+      cw20AccountAssets: filterVisible(data.cw20AccountAssets),
+      erc20AccountAssets: filterVisible(data.erc20AccountAssets),
       customErc20AccountAssets: data.customErc20AccountAssets,
       customCw20AccountAssets: data.customCw20AccountAssets,
-      bitcoinAccountAssets: filterAssetList(data.bitcoinAccountAssets),
-      iotaAccountAssets: filterAssetList(data.iotaAccountAssets),
-      solanaAccountAssets: filterAssetList(data.solanaAccountAssets),
-      spltokenAccountAssets: filterAssetList(data.spltokenAccountAssets),
-      gnoAccountAssets: filterAssetList(data.gnoAccountAssets),
-      grc20AccountAssets: filterAssetList(data.grc20AccountAssets),
+      bitcoinAccountAssets: filterVisible(data.bitcoinAccountAssets),
+      iotaAccountAssets: filterVisible(data.iotaAccountAssets),
+      solanaAccountAssets: filterVisible(data.solanaAccountAssets),
+      spltokenAccountAssets: filterVisible(data.spltokenAccountAssets),
+      gnoAccountAssets: filterVisible(data.gnoAccountAssets),
+      grc20AccountAssets: filterVisible(data.grc20AccountAssets),
     };
   }, [assetIds, data, disableBalanceFilter, disableHiddenFilter, hiddenCustom]);
 
   const returnData = useMemo(() => {
     if (!filteredByVisibleList) return null;
 
-    if (filterByPreferAccountType) {
-      const filteredCosmos = filteredByVisibleList.cosmosAccountAssets
-        .filter((item) => {
-          const selectedChainAccountType = accountType?.[item.chain.id];
+    const isAccountTypeFilterActive = filterByPreferAccountType && !!accountType;
 
-          if (selectedChainAccountType) {
-            const isSamePubkeyType = (() => {
-              if (selectedChainAccountType.pubkeyType && item.address.accountType.pubkeyType) {
-                return selectedChainAccountType.pubkeyType === item.address.accountType.pubkeyType;
-              }
-              return true;
-            })();
-            return (
-              selectedChainAccountType.hdPath === item.address.accountType.hdPath &&
-              selectedChainAccountType.pubkeyStyle === item.address.accountType.pubkeyStyle &&
-              isSamePubkeyType
-            );
-          }
-          return true;
-        })
-        .filter((item) => {
-          if (disableDupeEthermint) {
-            return true;
-          }
+    const cosmosAccountAssets = isAccountTypeFilterActive
+      ? filterDuplicatedEthermintAssets(
+          filterByChainAccountType(filteredByVisibleList.cosmosAccountAssets, accountType),
+          disableDupeEthermint ? undefined : data?.evmAccountAssets,
+        )
+      : filteredByVisibleList.cosmosAccountAssets;
 
-          const isDuplicatedEVMAsset =
-            item.chain.chainType === 'cosmos' &&
-            item.chain.isEvm &&
-            item.chain.mainAssetDenom === item.asset.id &&
-            data?.evmAccountAssets.some((evmAsset) => {
-              const isSameAssetChain = evmAsset.chain.id === item.chain.id;
+    const cw20AccountAssets = isAccountTypeFilterActive
+      ? filterByChainAccountType(filteredByVisibleList.cw20AccountAssets, accountType)
+      : filteredByVisibleList.cw20AccountAssets;
 
-              const { hdPath, pubkeyStyle, pubkeyType } = evmAsset.address.accountType;
-              const { hdPath: compareHdPath, pubkeyStyle: comparePubkeyStyle, pubkeyType: comparePubkeyType } = item.address.accountType;
-              const isSameAccountType = hdPath === compareHdPath && pubkeyStyle === comparePubkeyStyle && pubkeyType === comparePubkeyType;
+    const evmAccountAssets = isAccountTypeFilterActive
+      ? filterByChainAccountType(filteredByVisibleList.evmAccountAssets, accountType)
+      : filteredByVisibleList.evmAccountAssets;
 
-              return isSameAssetChain && isSameAccountType;
-            });
-          if (isDuplicatedEVMAsset) {
-            return false;
-          }
+    const erc20AccountAssets = isAccountTypeFilterActive
+      ? filterByChainAccountType(filteredByVisibleList.erc20AccountAssets, accountType)
+      : filteredByVisibleList.erc20AccountAssets;
 
-          return true;
-        });
+    const bitcoinAccountAssets = isAccountTypeFilterActive
+      ? filterByChainAccountType(filteredByVisibleList.bitcoinAccountAssets, accountType)
+      : filteredByVisibleList.bitcoinAccountAssets;
 
-      const cosmosAssetsWithPreferredAccountType = filteredCosmos.map((item) => {
-        const selectedChainAccountType = accountType?.[item.chain.id];
+    const { cosmosAccountCustomAssets, customCw20AccountAssets, evmAccountCustomAssets, customErc20AccountAssets } = filteredByVisibleList;
 
-        if (selectedChainAccountType) {
-          return produce(item, (draft) => {
-            draft.chain.accountTypes = draft.chain.accountTypes.filter(
-              (accountType) => accountType.pubkeyStyle === selectedChainAccountType.pubkeyStyle && accountType.hdPath === selectedChainAccountType.hdPath,
-            );
-          });
-        }
+    const allCosmosAccountAssets: AllCosmosAccountAssets[] = [...cosmosAccountAssets, ...cosmosAccountCustomAssets, ...cw20AccountAssets, ...customCw20AccountAssets];
 
-        return item;
-      });
+    const allCosmosAccountAssetsFiltered: AllCosmosAccountAssets[] = isAccountTypeFilterActive
+      ? [...narrowChainAccountTypes(cosmosAccountAssets, accountType), ...cosmosAccountCustomAssets, ...narrowChainAccountTypes(cw20AccountAssets, accountType), ...customCw20AccountAssets]
+      : allCosmosAccountAssets;
 
-      const filteredCW20 = filteredByVisibleList.cw20AccountAssets.filter((item) => {
-        const selectedChainAccountType = accountType?.[item.chain.id];
+    const assets = {
+      ...filteredByVisibleList,
+      cosmosAccountAssets,
+      cw20AccountAssets,
+      evmAccountAssets,
+      erc20AccountAssets,
+      bitcoinAccountAssets,
+    };
 
-        if (selectedChainAccountType) {
-          const isSamePubkeyType = (() => {
-            if (selectedChainAccountType.pubkeyType && item.address.accountType.pubkeyType) {
-              return selectedChainAccountType.pubkeyType === item.address.accountType.pubkeyType;
-            }
-            return true;
-          })();
-
-          return (
-            selectedChainAccountType.hdPath === item.address.accountType.hdPath &&
-            selectedChainAccountType.pubkeyStyle === item.address.accountType.pubkeyStyle &&
-            isSamePubkeyType
-          );
-        }
-        return true;
-      });
-
-      const cw20AssetsWithPreferredAccountType = filteredCW20.map((item) => {
-        const selectedChainAccountType = accountType?.[item.chain.id];
-
-        if (selectedChainAccountType) {
-          return produce(item, (draft) => {
-            draft.chain.accountTypes = draft.chain.accountTypes.filter(
-              (accountType) => accountType.pubkeyStyle === selectedChainAccountType.pubkeyStyle && accountType.hdPath === selectedChainAccountType.hdPath,
-            );
-          });
-        }
-
-        return item;
-      });
-
-      const filteredEVM = filteredByVisibleList.evmAccountAssets.filter((item) => {
-        const selectedChainAccountType = accountType?.[item.chain.id];
-
-        if (selectedChainAccountType) {
-          const isSamePubkeyType = (() => {
-            if (selectedChainAccountType.pubkeyType && item.address.accountType.pubkeyType) {
-              return selectedChainAccountType.pubkeyType === item.address.accountType.pubkeyType;
-            }
-            return true;
-          })();
-
-          return (
-            selectedChainAccountType.hdPath === item.address.accountType.hdPath &&
-            selectedChainAccountType.pubkeyStyle === item.address.accountType.pubkeyStyle &&
-            isSamePubkeyType
-          );
-        }
-        return true;
-      });
-
-      const filteredERC20Assets = filteredByVisibleList.erc20AccountAssets.filter((item) => {
-        const selectedChainAccountType = accountType?.[item.chain.id];
-
-        if (selectedChainAccountType) {
-          const isSamePubkeyType = (() => {
-            if (selectedChainAccountType.pubkeyType && item.address.accountType.pubkeyType) {
-              return selectedChainAccountType.pubkeyType === item.address.accountType.pubkeyType;
-            }
-            return true;
-          })();
-          return (
-            selectedChainAccountType.hdPath === item.address.accountType.hdPath &&
-            selectedChainAccountType.pubkeyStyle === item.address.accountType.pubkeyStyle &&
-            isSamePubkeyType
-          );
-        }
-        return true;
-      });
-
-      const filteredBitcoin = filteredByVisibleList.bitcoinAccountAssets.filter((item) => {
-        const selectedChainAccountType = accountType?.[item.chain.id];
-
-        if (selectedChainAccountType) {
-          const isSamePubkeyType = (() => {
-            if (selectedChainAccountType.pubkeyType && item.address.accountType.pubkeyType) {
-              return selectedChainAccountType.pubkeyType === item.address.accountType.pubkeyType;
-            }
-            return true;
-          })();
-
-          return (
-            selectedChainAccountType.hdPath === item.address.accountType.hdPath &&
-            selectedChainAccountType.pubkeyStyle === item.address.accountType.pubkeyStyle &&
-            isSamePubkeyType
-          );
-        }
-        return true;
-      });
-
-      const filteredAccountAssets = produce(filteredByVisibleList, (draft) => {
-        draft.cosmosAccountAssets = filteredCosmos;
-        draft.cw20AccountAssets = filteredCW20;
-        draft.evmAccountAssets = filteredEVM;
-        draft.erc20AccountAssets = filteredERC20Assets;
-        draft.bitcoinAccountAssets = filteredBitcoin;
-      });
-
-      const flatAccountAssets = Object.values(filteredAccountAssets).flat() as FlatAccountAssets[];
-
-      const returnData: UseAccountAssetsResponse = {
-        ...filteredAccountAssets,
-        flatAccountAssets: flatAccountAssets,
-        allCosmosAccountAssets: [
-          ...filteredAccountAssets.cosmosAccountAssets,
-          ...filteredAccountAssets.cosmosAccountCustomAssets,
-          ...filteredAccountAssets.cw20AccountAssets,
-          ...filteredAccountAssets.customCw20AccountAssets,
-        ],
-        allCosmosAccountAssetsFiltered: [
-          ...cosmosAssetsWithPreferredAccountType,
-          ...filteredAccountAssets.cosmosAccountCustomAssets,
-          ...cw20AssetsWithPreferredAccountType,
-          ...filteredAccountAssets.customCw20AccountAssets,
-        ],
-        allEVMAccountAssets: [
-          ...filteredAccountAssets.evmAccountAssets,
-          ...filteredAccountAssets.evmAccountCustomAssets,
-          ...filteredAccountAssets.erc20AccountAssets,
-          ...filteredAccountAssets.customErc20AccountAssets,
-        ],
-        allSolanaAccountAssets: [...filteredAccountAssets.solanaAccountAssets, ...filteredAccountAssets.spltokenAccountAssets],
-        allGnoAccountAssets: [...filteredAccountAssets.gnoAccountAssets, ...filteredAccountAssets.grc20AccountAssets],
-      };
-
-      return returnData;
-    } else {
-      const flatAccountAssets = Object.values(filteredByVisibleList).flat();
-
-      const cosmosAccountAssets = [
-        ...filteredByVisibleList.cosmosAccountAssets,
-        ...filteredByVisibleList.cosmosAccountCustomAssets,
-        ...filteredByVisibleList.cw20AccountAssets,
-        ...filteredByVisibleList.customCw20AccountAssets,
-      ];
-
-      const returnData: UseAccountAssetsResponse = {
-        ...filteredByVisibleList,
-        flatAccountAssets: flatAccountAssets,
-        allCosmosAccountAssets: cosmosAccountAssets,
-        allCosmosAccountAssetsFiltered: cosmosAccountAssets,
-        allEVMAccountAssets: [
-          ...filteredByVisibleList.evmAccountAssets,
-          ...filteredByVisibleList.evmAccountCustomAssets,
-          ...filteredByVisibleList.erc20AccountAssets,
-          ...filteredByVisibleList.customErc20AccountAssets,
-        ],
-        allSolanaAccountAssets: [...filteredByVisibleList.solanaAccountAssets, ...filteredByVisibleList.spltokenAccountAssets],
-        allGnoAccountAssets: [...filteredByVisibleList.gnoAccountAssets, ...filteredByVisibleList.grc20AccountAssets],
-      };
-
-      return returnData;
-    }
-  }, [accountType, data?.evmAccountAssets, disableDupeEthermint, filterByPreferAccountType, filteredByVisibleList]);
+    return {
+      ...assets,
+      flatAccountAssets: Object.values(assets).flat() as FlatAccountAssets[],
+      allCosmosAccountAssets,
+      allCosmosAccountAssetsFiltered,
+      allEVMAccountAssets: [...evmAccountAssets, ...evmAccountCustomAssets, ...erc20AccountAssets, ...customErc20AccountAssets],
+      allSolanaAccountAssets: [...filteredByVisibleList.solanaAccountAssets, ...filteredByVisibleList.spltokenAccountAssets],
+      allGnoAccountAssets: [...filteredByVisibleList.gnoAccountAssets, ...filteredByVisibleList.grc20AccountAssets],
+    } satisfies UseAccountAssetsResponse;
+  }, [accountType, data, disableDupeEthermint, filterByPreferAccountType, filteredByVisibleList]);
 
   return { data: returnData, isLoading, isFetching, error, refetch };
 }

--- a/src/hooks/useAccountAllAssets.ts
+++ b/src/hooks/useAccountAllAssets.ts
@@ -13,13 +13,13 @@ import type {
   AllSolanaAccountAssets,
   FlatAccountAssets,
 } from '@/types/accountAssets';
-import type { AssetId } from '@/types/asset';
+import type { UniqueCoinId } from '@/types/asset';
 import { gt } from '@/utils/numbers';
-import { getCoinId } from '@/utils/queryParamGenerator';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
-import { useAccountAssetIdsQuery } from './queries/useAccountAssetIdsQuery';
+import { useAccountAssetIdsSet } from './queries/useAccountAssetIdsQuery';
 import { useCurrentAccount } from './useCurrentAccount';
+import { useCustomAssets } from './useCustomAssets';
 
 export type UseAccountAssetsResponse = AccountAllAssets & {
   flatAccountAssets: FlatAccountAssets[];
@@ -50,17 +50,13 @@ export function useAccountAllAssets({
   config,
 }: UseAccountAllAssets = {}) {
   const { currentAccount } = useCurrentAccount();
+  const { currentCustomHiddenAssetIdsSet: hiddenCustom } = useCustomAssets();
   const param = useMemo(() => accountId || currentAccount.id, [accountId, currentAccount.id]);
 
   const preferAccountType = useExtensionStorageStore((state) => state.preferAccountType);
   const accountType = useMemo(() => preferAccountType[param], [param, preferAccountType]);
 
-  const { data: assetIds } = useAccountAssetIdsQuery(param);
-  const storedHiddenCustomAssetIds = useExtensionStorageStore((state) => state.customHiddenAssetIds);
-
-  const hiddenAssetIds = useMemo(() => assetIds?.hiddenAssetIds || [], [assetIds?.hiddenAssetIds]);
-  const hiddenCustomAssetIds = useMemo(() => storedHiddenCustomAssetIds || [], [storedHiddenCustomAssetIds]);
-  const visibleAssetIds = useMemo(() => assetIds?.visibleAssetIds || [], [assetIds?.visibleAssetIds]);
+  const { data: assetIds } = useAccountAssetIdsSet(param);
 
   const fetcher = async () => {
     try {
@@ -83,28 +79,17 @@ export function useAccountAllAssets({
     ...config,
   });
 
-  const assetIdSets = useMemo(
-    () => ({
-      visible: new Set(visibleAssetIds.map(getCoinId)),
-      hidden: new Set(hiddenAssetIds.map(getCoinId)),
-      hiddenCustom: new Set(hiddenCustomAssetIds.map(getCoinId)),
-    }),
-    [visibleAssetIds, hiddenAssetIds, hiddenCustomAssetIds],
-  );
-
   const filteredByVisibleList = useMemo(() => {
     if (!data) return null;
 
-    const { visible, hidden, hiddenCustom } = assetIdSets;
+    const { hiddenAssetSet: hidden, visibleAssetSet: visible } = assetIds || {};
 
-    const shouldShowAsset = (asset: AssetId, balance: string) => {
-      const assetCoinId = getCoinId(asset);
-
-      const isVisible = visible.has(assetCoinId);
+    const shouldShowAsset = (uniqueCoinId: UniqueCoinId, balance: string) => {
+      const isVisible = visible?.has(uniqueCoinId);
 
       if (isVisible) return true;
 
-      const isHidden = disableHiddenFilter ? false : hidden.has(assetCoinId) || hiddenCustom.has(assetCoinId);
+      const isHidden = disableHiddenFilter ? false : hidden?.has(uniqueCoinId) || hiddenCustom.has(uniqueCoinId);
 
       if (isHidden) return false;
 
@@ -113,8 +98,8 @@ export function useAccountAllAssets({
       return disableBalanceFilter ? true : isBalanceGreaterThanZero;
     };
 
-    const filterAssetList = <T extends { asset: AssetId; balance: string }>(list: T[]): T[] =>
-      list.filter(({ asset, balance }) => shouldShowAsset(asset, balance));
+    const filterAssetList = <T extends { uniqueCoinId: UniqueCoinId; balance: string }>(list: T[]): T[] =>
+      list.filter(({ uniqueCoinId, balance }) => shouldShowAsset(uniqueCoinId, balance));
 
     return {
       cosmosAccountAssets: filterAssetList(data.cosmosAccountAssets),
@@ -134,7 +119,7 @@ export function useAccountAllAssets({
       gnoAccountAssets: filterAssetList(data.gnoAccountAssets),
       grc20AccountAssets: filterAssetList(data.grc20AccountAssets),
     };
-  }, [assetIdSets, data, disableBalanceFilter, disableHiddenFilter]);
+  }, [assetIds, data, disableBalanceFilter, disableHiddenFilter, hiddenCustom]);
 
   const returnData = useMemo(() => {
     if (!filteredByVisibleList) return null;

--- a/src/hooks/useAssetPricing.ts
+++ b/src/hooks/useAssetPricing.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+import type { FlatAccountAssets } from '@/types/accountAssets';
+import { times, toDisplayDenomAmount } from '@/utils/numbers';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
+
+import { useCoinGeckoPrice } from './useCoinGeckoPrice';
+
+export type AssetWithValue<T = FlatAccountAssets> = T & {
+  value: string;
+  displayAmount: string;
+};
+
+type UseAssetPricingOptions<T> = {
+  getBalance?: (item: T) => string;
+};
+
+export function useAssetPricing<T extends FlatAccountAssets>(assets: T[] | undefined, options?: UseAssetPricingOptions<T>): AssetWithValue<T>[] {
+  const { data: coinGeckoPrice } = useCoinGeckoPrice();
+  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
+
+  return useMemo(() => {
+    if (!assets) return [];
+
+    return assets.map((item) => {
+      const balance = options?.getBalance?.(item) ?? item.balance;
+      const displayAmount = toDisplayDenomAmount(balance, item.asset.decimals);
+      const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
+      const value = times(displayAmount, coinPrice);
+
+      return { ...item, value, displayAmount };
+    });
+  }, [assets, options, coinGeckoPrice, userCurrencyPreference]);
+}

--- a/src/hooks/useAssetPricing.ts
+++ b/src/hooks/useAssetPricing.ts
@@ -30,5 +30,6 @@ export function useAssetPricing<T extends FlatAccountAssets>(assets: T[] | undef
 
       return { ...item, value, displayAmount };
     });
-  }, [assets, options, coinGeckoPrice, userCurrencyPreference]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assets, coinGeckoPrice, options?.getBalance, userCurrencyPreference]);
 }

--- a/src/hooks/useAssetVisibilityToggle.ts
+++ b/src/hooks/useAssetVisibilityToggle.ts
@@ -12,10 +12,10 @@ import { useCustomAssets } from './useCustomAssets';
 import type { ProcessedAsset } from './useProcessedAssets';
 
 type UseAssetVisibilityToggleParams = {
-  visibleCount: number;
+  isLastVisible: boolean;
 };
 
-export function useAssetVisibilityToggle({ visibleCount }: UseAssetVisibilityToggleParams) {
+export function useAssetVisibilityToggle({ isLastVisible }: UseAssetVisibilityToggleParams) {
   const { t } = useTranslation();
 
   const { hideAsset, showAsset } = useCurrentHiddenAssetIds();
@@ -25,8 +25,6 @@ export function useAssetVisibilityToggle({ visibleCount }: UseAssetVisibilityTog
   const { removeCustomCW20Token } = useCurrentCustomCW20Tokens();
   const [tokenToDelete, setTokenToDelete] = useState<ProcessedAsset | undefined>();
 
-  const isLastStanding = visibleCount === 1;
-
   const handleAssetVisibility = useCallback(
     async (asset: ProcessedAsset) => {
       if (asset.isHiddenState) {
@@ -35,16 +33,16 @@ export function useAssetVisibilityToggle({ visibleCount }: UseAssetVisibilityTog
         return;
       }
 
-      if (isLastStanding) return toastError(t('pages.manage-assets.visibility.assets.entry.lastStandingError'));
-      if (!asset.isHiddenState) await removeVisibleAsset(asset.uniqueCoinId);
+      if (isLastVisible) return toastError(t('pages.manage-assets.visibility.assets.entry.lastStandingError'));
+      await removeVisibleAsset(asset.uniqueCoinId);
       if (!asset.isBalanceZero) await (asset.innerTokenType === 'custom-asset' ? hideCustomAsset : hideAsset)(asset.uniqueCoinId);
     },
-    [addVisibleAsset, hideAsset, hideCustomAsset, isLastStanding, removeVisibleAsset, showAsset, showCustomAsset, t],
+    [addVisibleAsset, hideAsset, hideCustomAsset, isLastVisible, removeVisibleAsset, showAsset, showCustomAsset, t],
   );
 
   const handleToggleVisibility = useCallback(
     async (coin: ProcessedAsset) => {
-      if (coin.isCustomToken) {
+      if (coin.innerTokenType === 'custom-cw20' || coin.innerTokenType === 'custom-erc20') {
         setTokenToDelete(coin);
       } else {
         await handleAssetVisibility(coin);
@@ -53,13 +51,15 @@ export function useAssetVisibilityToggle({ visibleCount }: UseAssetVisibilityTog
     [handleAssetVisibility],
   );
 
-  const confirmDeleteAndHide = useCallback(() => {
-    if (tokenToDelete?.asset) {
-      const uniqueCoinId = tokenToDelete?.uniqueCoinId || getUniqueCoinId(tokenToDelete.asset);
+  const confirmDeleteAndHide = useCallback(async () => {
+    try {
+      if (tokenToDelete?.asset) {
+        const uniqueCoinId = tokenToDelete.uniqueCoinId || getUniqueCoinId(tokenToDelete.asset);
 
-      if (tokenToDelete.asset.type === 'cw20') return removeCustomCW20Token(uniqueCoinId);
-      if (tokenToDelete.asset.type === 'erc20') return removeCustomERC20Token(uniqueCoinId);
-
+        if (tokenToDelete.asset.type === 'cw20') await removeCustomCW20Token(uniqueCoinId);
+        else if (tokenToDelete.asset.type === 'erc20') await removeCustomERC20Token(uniqueCoinId);
+      }
+    } finally {
       setTokenToDelete(undefined);
     }
   }, [removeCustomCW20Token, removeCustomERC20Token, tokenToDelete?.asset, tokenToDelete?.uniqueCoinId]);

--- a/src/hooks/useAssetVisibilityToggle.ts
+++ b/src/hooks/useAssetVisibilityToggle.ts
@@ -1,0 +1,81 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { getUniqueCoinId } from '@/utils/queryParamGenerator';
+import { toastError } from '@/utils/toast';
+
+import { useCurrentCustomCW20Tokens } from './useCurrentCustomCW20Tokens';
+import { useCurrentCustomERC20Tokens } from './useCurrentCustomERC20Tokens';
+import { useCurrentHiddenAssetIds } from './useCurrentHiddenAssetIds';
+import { useCurrentVisibleAssetIds } from './useCurrentVisibleAssetIds';
+import { useCustomAssets } from './useCustomAssets';
+import type { ProcessedAsset } from './useProcessedAssets';
+
+type UseAssetVisibilityToggleParams = {
+  visibleCount: number;
+};
+
+export function useAssetVisibilityToggle({ visibleCount }: UseAssetVisibilityToggleParams) {
+  const { t } = useTranslation();
+
+  const { hideAsset, showAsset } = useCurrentHiddenAssetIds();
+  const { removeVisibleAsset, addVisibleAsset } = useCurrentVisibleAssetIds();
+  const { hideCustomAsset, showCustomAsset } = useCustomAssets();
+  const { removeCustomERC20Token } = useCurrentCustomERC20Tokens();
+  const { removeCustomCW20Token } = useCurrentCustomCW20Tokens();
+  const [tokenToDelete, setTokenToDelete] = useState<ProcessedAsset | undefined>();
+
+  const isLastStanding = visibleCount === 1;
+
+  const handleAssetVisibility = useCallback(
+    async (asset: ProcessedAsset) => {
+      if (asset.isHiddenState) {
+        await (asset.innerTokenType === 'custom-asset' ? showCustomAsset : showAsset)(asset.uniqueCoinId);
+        if (asset.isBalanceZero) await addVisibleAsset(asset.uniqueCoinId);
+        return;
+      }
+
+      if (isLastStanding) return toastError(t('pages.manage-assets.visibility.assets.entry.lastStandingError'));
+      if (!asset.isHiddenState) await removeVisibleAsset(asset.uniqueCoinId);
+      if (!asset.isBalanceZero) await (asset.innerTokenType === 'custom-asset' ? hideCustomAsset : hideAsset)(asset.uniqueCoinId);
+    },
+    [addVisibleAsset, hideAsset, hideCustomAsset, isLastStanding, removeVisibleAsset, showAsset, showCustomAsset, t],
+  );
+
+  const handleToggleVisibility = useCallback(
+    async (coin: ProcessedAsset) => {
+      if (coin.isCustomToken) {
+        setTokenToDelete(coin);
+      } else {
+        await handleAssetVisibility(coin);
+      }
+    },
+    [handleAssetVisibility],
+  );
+
+  const confirmDeleteAndHide = useCallback(() => {
+    if (tokenToDelete?.asset) {
+      const uniqueCoinId = tokenToDelete?.uniqueCoinId || getUniqueCoinId(tokenToDelete.asset);
+
+      if (tokenToDelete.asset.type === 'cw20') return removeCustomCW20Token(uniqueCoinId);
+      if (tokenToDelete.asset.type === 'erc20') return removeCustomERC20Token(uniqueCoinId);
+
+      setTokenToDelete(undefined);
+    }
+  }, [removeCustomCW20Token, removeCustomERC20Token, tokenToDelete?.asset, tokenToDelete?.uniqueCoinId]);
+
+  const deleteConfirmState = useMemo(
+    () => ({
+      token: tokenToDelete,
+      isOpen: !!tokenToDelete?.asset,
+      onClose: () => setTokenToDelete(undefined),
+      onConfirm: confirmDeleteAndHide,
+    }),
+    [tokenToDelete, confirmDeleteAndHide],
+  );
+
+  return {
+    handleToggleVisibility,
+    deleteConfirmState,
+  };
+}

--- a/src/hooks/useCurrentCustomCW20Tokens.ts
+++ b/src/hooks/useCurrentCustomCW20Tokens.ts
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
+
 import type { CosmosCw20Asset } from '@/types/asset';
-import { getCoinId } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueCoinId } from '@/utils/queryParamGenerator';
 import { getExtensionLocalStorage } from '@/utils/storage';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -12,6 +14,7 @@ export function useCurrentCustomCW20Tokens() {
   const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
 
   const currentCustomCW20Tokens = customCw20Assets;
+  const currentCustomCW20TokenIdsSet = useMemo(() => new Set(customCw20Assets.map(getUniqueCoinId)), [customCw20Assets]);
 
   const addCustomCW20Token = async (asset: CosmosCw20Asset) => {
     const storedCW20Assets = await getExtensionLocalStorage('cw20Assets');
@@ -64,5 +67,5 @@ export function useCurrentCustomCW20Tokens() {
     await refreshAssets();
   };
 
-  return { currentCustomCW20Tokens, addCustomCW20Token, addCustomCW20Tokens, removeCustomCW20Token };
+  return { currentCustomCW20Tokens, currentCustomCW20TokenIdsSet, addCustomCW20Token, addCustomCW20Tokens, removeCustomCW20Token };
 }

--- a/src/hooks/useCurrentCustomERC20Tokens.ts
+++ b/src/hooks/useCurrentCustomERC20Tokens.ts
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
+
 import type { EvmErc20Asset } from '@/types/asset';
-import { getCoinId } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueCoinId } from '@/utils/queryParamGenerator';
 import { getExtensionLocalStorage } from '@/utils/storage';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -11,6 +13,7 @@ export function useCurrentCustomERC20Tokens() {
   const { refreshAssets } = useRefreshAccountAllAssets();
 
   const currentCustomERC20Tokens = customErc20Assets;
+  const currentCustomERC20TokenIdsSet = useMemo(() => new Set(customErc20Assets.map(getUniqueCoinId)), [customErc20Assets]);
 
   const addCustomERC20Token = async (asset: EvmErc20Asset) => {
     const storedERC20Assets = await getExtensionLocalStorage('erc20Assets');
@@ -63,5 +66,5 @@ export function useCurrentCustomERC20Tokens() {
     await refreshAssets();
   };
 
-  return { currentCustomERC20Tokens, addCustomERC20Token, addCustomERC20Tokens, removeCustomERC20Token };
+  return { currentCustomERC20Tokens, currentCustomERC20TokenIdsSet, addCustomERC20Token, addCustomERC20Tokens, removeCustomERC20Token };
 }

--- a/src/hooks/useCurrentHiddenAssetIds.ts
+++ b/src/hooks/useCurrentHiddenAssetIds.ts
@@ -1,24 +1,22 @@
-import { useMemo } from 'react';
-
-import type { AssetId } from '@/types/asset';
+import type { UniqueCoinId } from '@/types/asset';
 
 import { useAccountAssetIdsMutations } from './queries/useAccountAssetIdsMutations';
-import { useAccountAssetIdsQuery } from './queries/useAccountAssetIdsQuery';
+import { useAccountAssetIdsSet } from './queries/useAccountAssetIdsQuery';
 import { useCurrentAccount } from './useCurrentAccount';
 
 export function useCurrentHiddenAssetIds() {
   const { currentAccount } = useCurrentAccount();
 
-  const { data: assetIds } = useAccountAssetIdsQuery(currentAccount.id);
+  const { data: assetIds } = useAccountAssetIdsSet(currentAccount.id);
   const mutations = useAccountAssetIdsMutations(currentAccount.id);
 
-  const currentHiddenAssetIds = useMemo(() => assetIds?.hiddenAssetIds || [], [assetIds?.hiddenAssetIds]);
+  const currentHiddenAssetIds = assetIds?.hiddenAssetSet ?? new Set<UniqueCoinId>();
 
-  const hideAsset = async (assetId: AssetId) => {
+  const hideAsset = async (assetId: UniqueCoinId) => {
     await mutations.hideAsset({ assetId });
   };
 
-  const showAsset = async (assetId: AssetId) => {
+  const showAsset = async (assetId: UniqueCoinId) => {
     await mutations.showAsset({ assetId });
   };
 

--- a/src/hooks/useCurrentHiddenAssetIds.ts
+++ b/src/hooks/useCurrentHiddenAssetIds.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import type { UniqueCoinId } from '@/types/asset';
 
 import { useAccountAssetIdsMutations } from './queries/useAccountAssetIdsMutations';
@@ -10,7 +12,7 @@ export function useCurrentHiddenAssetIds() {
   const { data: assetIds } = useAccountAssetIdsSet(currentAccount.id);
   const mutations = useAccountAssetIdsMutations(currentAccount.id);
 
-  const currentHiddenAssetIds = assetIds?.hiddenAssetSet ?? new Set<UniqueCoinId>();
+  const currentHiddenAssetIdsSet = useMemo(() => assetIds?.hiddenAssetSet ?? new Set<UniqueCoinId>(), [assetIds?.hiddenAssetSet]);
 
   const hideAsset = async (assetId: UniqueCoinId) => {
     await mutations.hideAsset({ assetId });
@@ -20,5 +22,5 @@ export function useCurrentHiddenAssetIds() {
     await mutations.showAsset({ assetId });
   };
 
-  return { currentHiddenAssetIds, hideAsset, showAsset };
+  return { currentHiddenAssetIdsSet, hideAsset, showAsset };
 }

--- a/src/hooks/useCurrentVisibleAssetIds.ts
+++ b/src/hooks/useCurrentVisibleAssetIds.ts
@@ -1,24 +1,22 @@
-import { useMemo } from 'react';
-
-import type { AssetId } from '@/types/asset';
+import type { UniqueCoinId } from '@/types/asset';
 
 import { useAccountAssetIdsMutations } from './queries/useAccountAssetIdsMutations';
-import { useAccountAssetIdsQuery } from './queries/useAccountAssetIdsQuery';
+import { useAccountAssetIdsSet } from './queries/useAccountAssetIdsQuery';
 import { useCurrentAccount } from './useCurrentAccount';
 
 export function useCurrentVisibleAssetIds() {
   const { currentAccount } = useCurrentAccount();
 
-  const { data: assetIds } = useAccountAssetIdsQuery(currentAccount.id);
+  const { data: assetIds } = useAccountAssetIdsSet(currentAccount.id);
   const mutations = useAccountAssetIdsMutations(currentAccount.id);
 
-  const currentVisibleAssetIds = useMemo(() => assetIds?.visibleAssetIds || [], [assetIds?.visibleAssetIds]);
+  const currentVisibleAssetIds = assetIds?.visibleAssetSet ?? new Set<UniqueCoinId>();
 
-  const addVisibleAsset = async (assetId: AssetId) => {
+  const addVisibleAsset = async (assetId: UniqueCoinId) => {
     await mutations.addVisibleAsset({ assetId });
   };
 
-  const removeVisibleAsset = async (assetId: AssetId) => {
+  const removeVisibleAsset = async (assetId: UniqueCoinId) => {
     await mutations.removeVisibleAsset({ assetId });
   };
 

--- a/src/hooks/useCurrentVisibleAssetIds.ts
+++ b/src/hooks/useCurrentVisibleAssetIds.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import type { UniqueCoinId } from '@/types/asset';
 
 import { useAccountAssetIdsMutations } from './queries/useAccountAssetIdsMutations';
@@ -10,7 +12,7 @@ export function useCurrentVisibleAssetIds() {
   const { data: assetIds } = useAccountAssetIdsSet(currentAccount.id);
   const mutations = useAccountAssetIdsMutations(currentAccount.id);
 
-  const currentVisibleAssetIds = assetIds?.visibleAssetSet ?? new Set<UniqueCoinId>();
+  const currentVisibleAssetIdsSet = useMemo(() => assetIds?.visibleAssetSet ?? new Set<UniqueCoinId>(), [assetIds?.visibleAssetSet]);
 
   const addVisibleAsset = async (assetId: UniqueCoinId) => {
     await mutations.addVisibleAsset({ assetId });
@@ -20,5 +22,5 @@ export function useCurrentVisibleAssetIds() {
     await mutations.removeVisibleAsset({ assetId });
   };
 
-  return { currentVisibleAssetIds, addVisibleAsset, removeVisibleAsset };
+  return { currentVisibleAssetIdsSet, addVisibleAsset, removeVisibleAsset };
 }

--- a/src/hooks/useCustomAssets.ts
+++ b/src/hooks/useCustomAssets.ts
@@ -1,5 +1,7 @@
-import type { AssetId, CustomAsset } from '@/types/asset';
-import { isMatchingCoinId, isSameCoin } from '@/utils/queryParamGenerator';
+import { useMemo } from 'react';
+
+import type { CustomAsset, UniqueCoinId } from '@/types/asset';
+import { getUniqueCoinId, isMatchingCoinId, isSameCoin, parseCoinId } from '@/utils/queryParamGenerator';
 import { getExtensionLocalStorage } from '@/utils/storage';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
@@ -11,6 +13,8 @@ export function useCustomAssets() {
   const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
 
   const { refreshAssets } = useRefreshAccountAllAssets();
+
+  const currentCustomHiddenAssetIdsSet = useMemo(() => new Set(customHiddenAssetIds.map(getUniqueCoinId)), [customHiddenAssetIds]);
 
   const addCustomAsset = async (newAsset: CustomAsset) => {
     const storedCustomAssets = await getExtensionLocalStorage('customAssets');
@@ -50,26 +54,28 @@ export function useCustomAssets() {
     await refreshAssets();
   };
 
-  const hideCustomAsset = async (targetAsset: AssetId) => {
+  const hideCustomAsset = async (assetId: UniqueCoinId) => {
     const storedCustomHiddenAssetIds = await getExtensionLocalStorage('customHiddenAssetIds');
 
-    const isAlreadyAdded = storedCustomHiddenAssetIds.some((item) => isSameCoin(item, targetAsset));
+    const isAlreadyAdded = storedCustomHiddenAssetIds.some((item) => isMatchingCoinId(item, assetId));
 
     if (isAlreadyAdded) {
       return;
     }
 
-    const updatedCustomHiddenAssetIds = [...storedCustomHiddenAssetIds, targetAsset];
+    const newHiddenAssetId = parseCoinId(assetId);
+
+    const updatedCustomHiddenAssetIds = [...storedCustomHiddenAssetIds, newHiddenAssetId];
 
     await updateExtensionStorageStore('customHiddenAssetIds', updatedCustomHiddenAssetIds);
 
     await refreshAssets();
   };
 
-  const showCustomAsset = async (assetId: AssetId) => {
+  const showCustomAsset = async (assetId: UniqueCoinId) => {
     const storedCustomHiddenAssetIds = await getExtensionLocalStorage('customHiddenAssetIds');
 
-    const updatedCustomHiddenAssetIds = storedCustomHiddenAssetIds.filter((item) => !isSameCoin(item, assetId));
+    const updatedCustomHiddenAssetIds = storedCustomHiddenAssetIds.filter((item) => !isMatchingCoinId(item, assetId));
 
     await updateExtensionStorageStore('customHiddenAssetIds', updatedCustomHiddenAssetIds);
 
@@ -79,6 +85,7 @@ export function useCustomAssets() {
   return {
     customAssets,
     customHiddenAssetIds,
+    currentCustomHiddenAssetIdsSet,
     addCustomAsset,
     removeCustomAsset,
     editCustomAsset,

--- a/src/hooks/useCustomAssets.ts
+++ b/src/hooks/useCustomAssets.ts
@@ -15,6 +15,7 @@ export function useCustomAssets() {
   const { refreshAssets } = useRefreshAccountAllAssets();
 
   const currentCustomHiddenAssetIdsSet = useMemo(() => new Set(customHiddenAssetIds.map(getUniqueCoinId)), [customHiddenAssetIds]);
+  const currentCustomAssetIdsSet = useMemo(() => new Set(customAssets.map(getUniqueCoinId)), [customAssets]);
 
   const addCustomAsset = async (newAsset: CustomAsset) => {
     const storedCustomAssets = await getExtensionLocalStorage('customAssets');
@@ -84,6 +85,7 @@ export function useCustomAssets() {
 
   return {
     customAssets,
+    currentCustomAssetIdsSet,
     customHiddenAssetIds,
     currentCustomHiddenAssetIdsSet,
     addCustomAsset,

--- a/src/hooks/useGetAccountAsset.ts
+++ b/src/hooks/useGetAccountAsset.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { getMatchinCoinFromCoinId, parseCoinId } from '@/utils/queryParamGenerator';
+import { getMatchingCoinFromCoinId, parseCoinId } from '@/utils/queryParamGenerator';
 
 import { useAccountAllAssets } from './useAccountAllAssets';
 
@@ -23,15 +23,15 @@ export function useGetAccountAsset({ coinId, options }: UseGetAccountAsset) {
 
   const assetFinders = useMemo(() => {
     return {
-      cosmos: () => getMatchinCoinFromCoinId(accountAllAssets?.allCosmosAccountAssets, coinId),
-      filteredCosmosAssetByAccountType: () => getMatchinCoinFromCoinId(accountAllAssets?.allCosmosAccountAssetsFiltered, coinId),
-      evm: () => getMatchinCoinFromCoinId(accountAllAssets?.allEVMAccountAssets, coinId),
-      aptos: () => getMatchinCoinFromCoinId(accountAllAssets?.aptosAccountAssets, coinId),
-      sui: () => getMatchinCoinFromCoinId(accountAllAssets?.suiAccountAssets, coinId),
-      bitcoin: () => getMatchinCoinFromCoinId(accountAllAssets?.bitcoinAccountAssets, coinId),
-      iota: () => getMatchinCoinFromCoinId(accountAllAssets?.iotaAccountAssets, coinId),
-      solana: () => getMatchinCoinFromCoinId(accountAllAssets?.allSolanaAccountAssets, coinId),
-      gno: () => getMatchinCoinFromCoinId(accountAllAssets?.allGnoAccountAssets, coinId),
+      cosmos: () => getMatchingCoinFromCoinId(accountAllAssets?.allCosmosAccountAssets, coinId),
+      filteredCosmosAssetByAccountType: () => getMatchingCoinFromCoinId(accountAllAssets?.allCosmosAccountAssetsFiltered, coinId),
+      evm: () => getMatchingCoinFromCoinId(accountAllAssets?.allEVMAccountAssets, coinId),
+      aptos: () => getMatchingCoinFromCoinId(accountAllAssets?.aptosAccountAssets, coinId),
+      sui: () => getMatchingCoinFromCoinId(accountAllAssets?.suiAccountAssets, coinId),
+      bitcoin: () => getMatchingCoinFromCoinId(accountAllAssets?.bitcoinAccountAssets, coinId),
+      iota: () => getMatchingCoinFromCoinId(accountAllAssets?.iotaAccountAssets, coinId),
+      solana: () => getMatchingCoinFromCoinId(accountAllAssets?.allSolanaAccountAssets, coinId),
+      gno: () => getMatchingCoinFromCoinId(accountAllAssets?.allGnoAccountAssets, coinId),
     };
   }, [
     accountAllAssets?.allCosmosAccountAssets,

--- a/src/hooks/useGetAccountAsset.ts
+++ b/src/hooks/useGetAccountAsset.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { isMatchingCoinId, parseCoinId } from '@/utils/queryParamGenerator';
+import { getMatchinCoinFromCoinId, parseCoinId } from '@/utils/queryParamGenerator';
 
 import { useAccountAllAssets } from './useAccountAllAssets';
 
@@ -23,15 +23,15 @@ export function useGetAccountAsset({ coinId, options }: UseGetAccountAsset) {
 
   const assetFinders = useMemo(() => {
     return {
-      cosmos: () => accountAllAssets?.allCosmosAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      filteredCosmosAssetByAccountType: () => accountAllAssets?.allCosmosAccountAssetsFiltered.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      evm: () => accountAllAssets?.allEVMAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      aptos: () => accountAllAssets?.aptosAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      sui: () => accountAllAssets?.suiAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      bitcoin: () => accountAllAssets?.bitcoinAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      iota: () => accountAllAssets?.iotaAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      solana: () => accountAllAssets?.allSolanaAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
-      gno: () => accountAllAssets?.allGnoAccountAssets.find(({ asset }) => isMatchingCoinId(asset, coinId)),
+      cosmos: () => getMatchinCoinFromCoinId(accountAllAssets?.allCosmosAccountAssets, coinId),
+      filteredCosmosAssetByAccountType: () => getMatchinCoinFromCoinId(accountAllAssets?.allCosmosAccountAssetsFiltered, coinId),
+      evm: () => getMatchinCoinFromCoinId(accountAllAssets?.allEVMAccountAssets, coinId),
+      aptos: () => getMatchinCoinFromCoinId(accountAllAssets?.aptosAccountAssets, coinId),
+      sui: () => getMatchinCoinFromCoinId(accountAllAssets?.suiAccountAssets, coinId),
+      bitcoin: () => getMatchinCoinFromCoinId(accountAllAssets?.bitcoinAccountAssets, coinId),
+      iota: () => getMatchinCoinFromCoinId(accountAllAssets?.iotaAccountAssets, coinId),
+      solana: () => getMatchinCoinFromCoinId(accountAllAssets?.allSolanaAccountAssets, coinId),
+      gno: () => getMatchinCoinFromCoinId(accountAllAssets?.allGnoAccountAssets, coinId),
     };
   }, [
     accountAllAssets?.allCosmosAccountAssets,

--- a/src/hooks/useGroupAccountAssets.ts
+++ b/src/hooks/useGroupAccountAssets.ts
@@ -2,9 +2,7 @@ import { useMemo } from 'react';
 
 import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
 import type { FlatAccountAssets, SingleOrGroupAccountAssets } from '@/types/accountAssets';
-import { isStakeableAsset } from '@/utils/asset';
 import { lt, plus, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId } from '@/utils/queryParamGenerator';
 
 import { useAccountAllAssets } from './useAccountAllAssets';
 import { useCurrentAccount } from './useCurrentAccount';
@@ -26,9 +24,13 @@ type UseGroupAccountAssetsProps =
     }
   | undefined;
 
+function getAssetDisplayAmount(asset: FlatAccountAssets): string {
+  const totalBalance = 'totalBalance' in asset ? asset.totalBalance || asset.balance || '0' : asset.balance;
+  return toDisplayDenomAmount(totalBalance, asset.asset.decimals);
+}
+
 export function useGroupAccountAssets({ accountId }: UseGroupAccountAssetsProps = {}) {
   const { currentAccount } = useCurrentAccount();
-
   const param = accountId || currentAccount.id;
 
   const {
@@ -43,101 +45,103 @@ export function useGroupAccountAssets({ accountId }: UseGroupAccountAssetsProps 
   });
 
   const groupAccountAssets = useMemo(() => {
-    const assetToSingleOrGroup = currentAccountAssets?.flatAccountAssets.reduce<SingleAndGroupedAssets>(
-      (acc, asset) => {
-        if (!asset.asset.coinGeckoId) {
-          acc.singles.push(asset);
-          return acc;
+    const flatAssets = currentAccountAssets?.flatAccountAssets;
+    if (!flatAssets?.length) return null;
+
+    const singles: SingleOrGroupAccountAssets[] = [];
+    const groupMap: Record<string, FlatAccountAssets[]> = {};
+
+    const groupInfo: Record<
+      string,
+      {
+        representative: FlatAccountAssets;
+        totalAmount: string;
+        count: number;
+        oldestUpdateTime?: number;
+      }
+    > = {};
+
+    for (const asset of flatAssets) {
+      const displayAmount = getAssetDisplayAmount(asset);
+      const coinGeckoId = asset.asset.coinGeckoId;
+
+      if (!coinGeckoId) {
+        singles.push({
+          ...asset,
+          totalDisplayAmount: displayAmount,
+          counts: '1',
+        });
+        continue;
+      }
+
+      if (!groupInfo[coinGeckoId]) {
+        groupInfo[coinGeckoId] = {
+          representative: asset,
+          totalAmount: displayAmount,
+          count: 1,
+          oldestUpdateTime: asset.lastUpdatedAtMs || undefined,
+        };
+        groupMap[coinGeckoId] = [asset];
+      } else {
+        const info = groupInfo[coinGeckoId];
+
+        info.totalAmount = plus(info.totalAmount, displayAmount);
+        info.count += 1;
+        groupMap[coinGeckoId].push(asset);
+
+        if (asset.lastUpdatedAtMs && (!info.oldestUpdateTime || lt(asset.lastUpdatedAtMs, info.oldestUpdateTime))) {
+          info.oldestUpdateTime = asset.lastUpdatedAtMs;
         }
 
-        if (!acc.groups[asset.asset.coinGeckoId]) {
-          acc.groups[asset.asset.coinGeckoId] = [asset];
-        } else {
-          acc.groups[asset.asset.coinGeckoId].push(asset);
+        if (shouldReplaceRepresentative(info.representative, asset)) {
+          info.representative = asset;
         }
-        return acc;
-      },
-      { singles: [], groups: {} },
-    );
+      }
+    }
 
-    if (!assetToSingleOrGroup) return null;
+    const groupedAssets: SingleOrGroupAccountAssets[] = [];
+    const finalGroupMap: Record<string, FlatAccountAssets[]> = {};
 
-    const singles = assetToSingleOrGroup.singles;
-    const groups = assetToSingleOrGroup.groups;
-
-    const validGroups = Object.fromEntries(
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      Object.entries(groups).filter(([_, value]) => {
-        return value.length > 1;
-      }),
-    );
-
-    const invalidGroups = Object.values(
-      Object.fromEntries(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        Object.entries(groups).filter(([_, value]) => {
-          return value.length === 1;
-        }),
-      ),
-    );
-
-    const singleAccountAssets = [...singles, ...invalidGroups.flat()].map((item) => {
-      const totalBalance = isStakeableAsset(item) ? item.totalBalance || item.balance || '0' : item.balance;
-
-      return {
-        ...item,
-        totalDisplayAmount: toDisplayDenomAmount(totalBalance, item.asset.decimals),
-        counts: '1',
-      };
-    });
-
-    const coinGeckoIdToTotalDisplayAmount = Object.entries(validGroups).reduce((acc: Record<string, string>, [coinGeckoId, value]) => {
-      const filteredAccountAssets =
-        currentAccountAssets?.flatAccountAssets.filter((item) => value.some((v) => getCoinId(v.asset) === getCoinId(item.asset))) || [];
-
-      const totalAmount = filteredAccountAssets.reduce((totalAmount, cur) => {
-        const totalBalance = isStakeableAsset(cur) ? cur.totalBalance || cur.balance || '0' : cur.balance;
-
-        const displayAmount = toDisplayDenomAmount(totalBalance, cur.asset.decimals);
-
-        return plus(totalAmount, displayAmount);
-      }, '0');
-
-      return { ...acc, [coinGeckoId]: totalAmount };
-    }, {});
-
-    const groupAccountAssets = Object.values(validGroups).map((item) => {
-      const sortList = item.sort((a) => {
-        if (a.asset.type === 'native') {
-          return -1;
-        }
-        return 1;
-      });
-
-      const firstItem = sortList[0].asset.id === NATIVE_EVM_COIN_ADDRESS ? sortList.find((v) => v.chain.id === 'ethereum') || sortList[0] : sortList[0];
-
-      const oldestItem = sortList.reduce<FlatAccountAssets | null>((min, curr) => {
-        if (!curr.lastUpdatedAtMs) return min;
-
-        if (!min?.lastUpdatedAtMs || lt(curr.lastUpdatedAtMs, min.lastUpdatedAtMs)) return curr;
-
-        return min;
-      }, null);
-
-      return {
-        ...firstItem,
-        totalDisplayAmount: coinGeckoIdToTotalDisplayAmount[firstItem.asset.coinGeckoId || ''] || '0',
-        counts: item.length.toString(),
-        lastUpdatedAtMs: oldestItem?.lastUpdatedAtMs,
-      };
-    });
+    for (const [coinGeckoId, info] of Object.entries(groupInfo)) {
+      if (info.count === 1) {
+        singles.push({
+          ...info.representative,
+          totalDisplayAmount: info.totalAmount,
+          counts: '1',
+        });
+      } else {
+        finalGroupMap[coinGeckoId] = groupMap[coinGeckoId];
+        groupedAssets.push({
+          ...info.representative,
+          totalDisplayAmount: info.totalAmount,
+          counts: info.count.toString(),
+          lastUpdatedAtMs: info.oldestUpdateTime,
+        });
+      }
+    }
 
     return {
-      singleAccountAssets,
-      groupAccountAssets,
-      groupMap: validGroups,
+      singleAccountAssets: singles,
+      groupAccountAssets: groupedAssets,
+      groupMap: finalGroupMap,
     };
   }, [currentAccountAssets?.flatAccountAssets]);
 
   return { groupAccountAssets, isLoading, isFetching };
+}
+
+function shouldReplaceRepresentative(existingBest: FlatAccountAssets, newAsset: FlatAccountAssets): boolean {
+  const isNewNative = newAsset.asset.type === 'native';
+  const isExistingNative = existingBest.asset.type === 'native';
+
+  if (!isExistingNative && isNewNative) {
+    return true;
+  }
+
+  if (isExistingNative && isNewNative) {
+    const isEthereumMainnet = newAsset.asset.id === NATIVE_EVM_COIN_ADDRESS && newAsset.chain.id === 'ethereum';
+    return isEthereumMainnet;
+  }
+
+  return false;
 }

--- a/src/hooks/useProcessedAssets.ts
+++ b/src/hooks/useProcessedAssets.ts
@@ -22,7 +22,6 @@ export type ProcessedAsset = FlatAccountAssets & {
   displayAmount: string;
   resolvedAssetId: string;
   isBalanceZero: boolean;
-  isCustomToken: boolean;
   innerTokenType: 'custom-cw20' | 'custom-erc20' | 'supported-asset' | 'custom-asset';
 };
 
@@ -31,7 +30,7 @@ type UseProcessedAssetsParams = {
   sortOption: CommonSortKeyType;
   currentSelectedChainId: UniqueChainId | undefined;
   search: string;
-  debouncedSearch: string;
+  isSearchEmpty: boolean;
 };
 
 function getHiddenState(
@@ -51,22 +50,47 @@ function getHiddenState(
   return false;
 }
 
+function resolveAssetId(coin: FlatAccountAssets): string {
+  const { asset, chain } = coin;
+  if (chain.mainAssetDenom === asset.id || asset.id === NATIVE_EVM_COIN_ADDRESS) return asset.description || '-';
+  if (asset.id.length > 15) return shorterAddress(asset.id, 16) || '-';
+  return asset.id || '-';
+}
+
+function resolveTokenType(
+  coinId: UniqueCoinId,
+  erc20Set: Set<UniqueCoinId>,
+  cw20Set: Set<UniqueCoinId>,
+  customAssetSet: Set<UniqueCoinId>,
+): ProcessedAsset['innerTokenType'] {
+  if (erc20Set.has(coinId)) return 'custom-erc20';
+  if (cw20Set.has(coinId)) return 'custom-cw20';
+  if (customAssetSet.has(coinId)) return 'custom-asset';
+  return 'supported-asset';
+}
+
 function useSortedAndFilteredList(
   baseCoinList: FlatAccountAssets[],
   sortOption: CommonSortKeyType,
   currentSelectedChainId: UniqueChainId | undefined,
   search: string,
-  debouncedSearch: string,
+  isSearchEmpty: boolean,
 ): AssetWithValue<FlatAccountAssets>[] {
   const pricedAssets = useAssetPricing(baseCoinList);
 
-  const sorted = useMemo(() => sortAssetsByKey(pricedAssets, sortOption), [pricedAssets, sortOption]);
+  const sortedAssets = useMemo(() => sortAssetsByKey(pricedAssets, sortOption), [pricedAssets, sortOption]);
 
   return useMemo(() => {
-    const filteredByChain = getFilteredAssetsByChainId(sorted, currentSelectedChainId);
-    return filterAssetsBySearch(filteredByChain, search, debouncedSearch);
-  }, [sorted, currentSelectedChainId, search, debouncedSearch]);
+    const chainFilteredAssets = getFilteredAssetsByChainId(sortedAssets, currentSelectedChainId);
+    return filterAssetsBySearch(chainFilteredAssets, search, isSearchEmpty);
+  }, [currentSelectedChainId, isSearchEmpty, search, sortedAssets]);
 }
+
+type HiddenStateSnapshot = {
+  hiddenAssetIds: Set<UniqueCoinId>;
+  visibleAssetIds: Set<UniqueCoinId>;
+  hiddenCustomAssetIds: Set<UniqueCoinId>;
+};
 
 function useFinalProcessedList(
   filteredCoinList: AssetWithValue<FlatAccountAssets>[],
@@ -78,107 +102,70 @@ function useFinalProcessedList(
   const { currentCustomERC20TokenIdsSet } = useCurrentCustomERC20Tokens();
   const { currentCustomCW20TokenIdsSet } = useCurrentCustomCW20Tokens();
 
-  const initialStateSnapshotRef = useRef<{
-    hiddenAssetIds: Set<UniqueCoinId>;
-    visibleAssetIds: Set<UniqueCoinId>;
-    hiddenCustomAssetIds: Set<UniqueCoinId>;
-  } | null>(null);
+  const snapshotRef = useRef<HiddenStateSnapshot | null>(null);
 
-  if (initialStateSnapshotRef.current === null && (currentHiddenAssetIdsSet?.size || currentVisibleAssetIdsSet?.size || customHiddenAssetSet?.size)) {
-    initialStateSnapshotRef.current = {
-      hiddenAssetIds: new Set(currentHiddenAssetIdsSet ?? []),
-      visibleAssetIds: new Set(currentVisibleAssetIdsSet ?? []),
-      hiddenCustomAssetIds: new Set(customHiddenAssetSet ?? []),
-    };
+  if (snapshotRef.current === null) {
+    const hasData = !!(currentHiddenAssetIdsSet?.size || currentVisibleAssetIdsSet?.size || customHiddenAssetSet?.size);
+    if (hasData) {
+      snapshotRef.current = {
+        hiddenAssetIds: new Set(currentHiddenAssetIdsSet ?? []),
+        visibleAssetIds: new Set(currentVisibleAssetIdsSet ?? []),
+        hiddenCustomAssetIds: new Set(customHiddenAssetSet ?? []),
+      };
+    }
   }
 
   return useMemo(() => {
-    const initialSnapshot = initialStateSnapshotRef.current;
-    const sortingHiddenAssetIds = initialSnapshot?.hiddenAssetIds ?? currentHiddenAssetIdsSet;
-    const sortingVisibleAssetIds = initialSnapshot?.visibleAssetIds ?? currentVisibleAssetIdsSet;
-    const sortingHiddenCustomAssetIds = initialSnapshot?.hiddenCustomAssetIds ?? customHiddenAssetSet;
+    const snapshot = snapshotRef.current;
+    const snapshotHiddenAssetIds = snapshot?.hiddenAssetIds ?? currentHiddenAssetIdsSet;
+    const snapshotVisibleAssetIds = snapshot?.visibleAssetIds ?? currentVisibleAssetIdsSet;
+    const snapshotCustomHiddenAssetIds = snapshot?.hiddenCustomAssetIds ?? customHiddenAssetSet;
 
-    const { visible, hidden, visibleCount } = filteredCoinList.reduce<{ visible: ProcessedAsset[]; hidden: ProcessedAsset[]; visibleCount: number }>(
-      (acc, coin) => {
-        const currentCoinId = coin.uniqueCoinId;
+    const visible: ProcessedAsset[] = [];
+    const hidden: ProcessedAsset[] = [];
+    let visibleCount = 0;
 
-        const isCustomERC20 = currentCustomERC20TokenIdsSet.has(currentCoinId);
-        const isCustomCW20 = currentCustomCW20TokenIdsSet.has(currentCoinId);
-        const isCustomToken = isCustomERC20 || isCustomCW20;
+    for (const coin of filteredCoinList) {
+      const coinId = coin.uniqueCoinId;
+      const isBalanceZero = coin.balance === '0';
+      const innerTokenType = resolveTokenType(coinId, currentCustomERC20TokenIdsSet, currentCustomCW20TokenIdsSet, customAssetSet);
+      const isCustomToken = innerTokenType === 'custom-erc20' || innerTokenType === 'custom-cw20';
 
-        const isCustomAsset = customAssetSet.has(currentCoinId);
+      const isHiddenState = getHiddenState(coinId, isCustomToken, isBalanceZero, currentHiddenAssetIdsSet, customHiddenAssetSet, currentVisibleAssetIdsSet);
+      const isSortingHidden = getHiddenState(
+        coinId,
+        isCustomToken,
+        isBalanceZero,
+        snapshotHiddenAssetIds,
+        snapshotCustomHiddenAssetIds,
+        snapshotVisibleAssetIds,
+      );
 
-        const isBalanceZero = coin.balance === '0';
+      const processedItem: ProcessedAsset = {
+        ...coin,
+        isHiddenState,
+        resolvedAssetId: resolveAssetId(coin),
+        isBalanceZero,
+        innerTokenType,
+      };
 
-        const isHiddenState = getHiddenState(
-          currentCoinId,
-          isCustomToken,
-          isBalanceZero,
-          currentHiddenAssetIdsSet,
-          customHiddenAssetSet,
-          currentVisibleAssetIdsSet,
-        );
+      if (isSortingHidden) {
+        hidden.push(processedItem);
+      } else {
+        visible.push(processedItem);
+      }
 
-        const resolvedAssetId =
-          coin.chain.mainAssetDenom === coin.asset.id || coin.asset.id === NATIVE_EVM_COIN_ADDRESS
-            ? coin.asset.description
-            : coin.asset.id.length > 15
-              ? shorterAddress(coin.asset.id, 16)
-              : coin.asset.id;
-
-        const innerTokenType = (() => {
-          if (isCustomERC20) {
-            return 'custom-erc20';
-          } else if (isCustomCW20) {
-            return 'custom-cw20';
-          } else if (isCustomAsset) {
-            return 'custom-asset';
-          } else {
-            return 'supported-asset';
-          }
-        })();
-
-        // NOTE 초기 정렬용 스냅샷뜬 히든스테이트
-        const isSortingHidden = getHiddenState(
-          currentCoinId,
-          isCustomToken,
-          isBalanceZero,
-          sortingHiddenAssetIds,
-          sortingHiddenCustomAssetIds,
-          sortingVisibleAssetIds,
-        );
-
-        const processedItem: ProcessedAsset = {
-          ...coin,
-          isHiddenState,
-          resolvedAssetId: resolvedAssetId || '-',
-          isBalanceZero,
-          isCustomToken,
-          innerTokenType,
-        };
-
-        if (isSortingHidden) {
-          acc.hidden.push(processedItem);
-        } else {
-          acc.visible.push(processedItem);
-        }
-
-        if (!isHiddenState) acc.visibleCount++;
-
-        return acc;
-      },
-      { visible: [] as ProcessedAsset[], hidden: [] as ProcessedAsset[], visibleCount: 0 },
-    );
-
-    let result = [...visible, ...hidden];
-
-    if (currentSelectedChainId && result.length > 0) {
-      const denoms = result[0]?.chain.chainDefaultCoinDenoms ?? [];
-
-      result = sortByReference(result, denoms, (item, denom) => isEqualsIgnoringCase(item.asset.id, denom));
+      if (!isHiddenState) visibleCount++;
     }
 
-    return { list: result, visibleCount };
+    const mergedAssets = [...visible, ...hidden];
+
+    const sortedByDefaultDenom =
+      currentSelectedChainId && mergedAssets.length > 0
+        ? sortByReference(mergedAssets, mergedAssets[0]?.chain.chainDefaultCoinDenoms ?? [], (item, denom) => isEqualsIgnoringCase(item.asset.id, denom))
+        : mergedAssets;
+
+    return { list: sortedByDefaultDenom, visibleCount };
   }, [
     currentCustomCW20TokenIdsSet,
     currentCustomERC20TokenIdsSet,
@@ -191,8 +178,8 @@ function useFinalProcessedList(
   ]);
 }
 
-export function useProcessedAssets({ baseCoinList, sortOption, currentSelectedChainId, search, debouncedSearch }: UseProcessedAssetsParams) {
-  const filteredCoinList = useSortedAndFilteredList(baseCoinList, sortOption, currentSelectedChainId, search, debouncedSearch);
+export function useProcessedAssets({ baseCoinList, sortOption, currentSelectedChainId, search, isSearchEmpty }: UseProcessedAssetsParams) {
+  const filteredCoinList = useSortedAndFilteredList(baseCoinList, sortOption, currentSelectedChainId, search, isSearchEmpty);
 
   return useFinalProcessedList(filteredCoinList, currentSelectedChainId);
 }

--- a/src/hooks/useProcessedAssets.ts
+++ b/src/hooks/useProcessedAssets.ts
@@ -1,0 +1,198 @@
+import { useMemo, useRef } from 'react';
+
+import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
+import type { FlatAccountAssets } from '@/types/accountAssets';
+import type { UniqueCoinId } from '@/types/asset';
+import type { UniqueChainId } from '@/types/chain';
+import type { CommonSortKeyType } from '@/types/sortKey';
+import { sortByReference } from '@/utils/array';
+import { filterAssetsBySearch, getFilteredAssetsByChainId, sortAssetsByKey } from '@/utils/asset';
+import { isEqualsIgnoringCase, shorterAddress } from '@/utils/string';
+
+import { type AssetWithValue, useAssetPricing } from './useAssetPricing';
+import { useCurrentCustomCW20Tokens } from './useCurrentCustomCW20Tokens';
+import { useCurrentCustomERC20Tokens } from './useCurrentCustomERC20Tokens';
+import { useCurrentHiddenAssetIds } from './useCurrentHiddenAssetIds';
+import { useCurrentVisibleAssetIds } from './useCurrentVisibleAssetIds';
+import { useCustomAssets } from './useCustomAssets';
+
+export type ProcessedAsset = FlatAccountAssets & {
+  value: string;
+  isHiddenState: boolean;
+  displayAmount: string;
+  resolvedAssetId: string;
+  isBalanceZero: boolean;
+  isCustomToken: boolean;
+  innerTokenType: 'custom-cw20' | 'custom-erc20' | 'supported-asset' | 'custom-asset';
+};
+
+type UseProcessedAssetsParams = {
+  baseCoinList: FlatAccountAssets[];
+  sortOption: CommonSortKeyType;
+  currentSelectedChainId: UniqueChainId | undefined;
+  search: string;
+  debouncedSearch: string;
+};
+
+function getHiddenState(
+  coinId: UniqueCoinId,
+  isCustomToken: boolean,
+  isBalanceZero: boolean,
+  hiddenAssetSet: Set<UniqueCoinId> | undefined,
+  customHiddenAssetSet: Set<UniqueCoinId> | undefined,
+  visibleAssetSet: Set<UniqueCoinId> | undefined,
+): boolean {
+  const isVisibleAsset = visibleAssetSet?.has(coinId);
+  if (isCustomToken || isVisibleAsset) return false;
+
+  const isHiddenAsset = customHiddenAssetSet?.has(coinId) || hiddenAssetSet?.has(coinId);
+  if (isHiddenAsset || isBalanceZero) return true;
+
+  return false;
+}
+
+function useSortedAndFilteredList(
+  baseCoinList: FlatAccountAssets[],
+  sortOption: CommonSortKeyType,
+  currentSelectedChainId: UniqueChainId | undefined,
+  search: string,
+  debouncedSearch: string,
+): AssetWithValue<FlatAccountAssets>[] {
+  const pricedAssets = useAssetPricing(baseCoinList);
+
+  const sorted = useMemo(() => sortAssetsByKey(pricedAssets, sortOption), [pricedAssets, sortOption]);
+
+  return useMemo(() => {
+    const filteredByChain = getFilteredAssetsByChainId(sorted, currentSelectedChainId);
+    return filterAssetsBySearch(filteredByChain, search, debouncedSearch);
+  }, [sorted, currentSelectedChainId, search, debouncedSearch]);
+}
+
+function useFinalProcessedList(
+  filteredCoinList: AssetWithValue<FlatAccountAssets>[],
+  currentSelectedChainId: UniqueChainId | undefined,
+): { list: ProcessedAsset[]; visibleCount: number } {
+  const { currentCustomHiddenAssetIdsSet: customHiddenAssetSet, currentCustomAssetIdsSet: customAssetSet } = useCustomAssets();
+  const { currentHiddenAssetIdsSet } = useCurrentHiddenAssetIds();
+  const { currentVisibleAssetIdsSet } = useCurrentVisibleAssetIds();
+  const { currentCustomERC20TokenIdsSet } = useCurrentCustomERC20Tokens();
+  const { currentCustomCW20TokenIdsSet } = useCurrentCustomCW20Tokens();
+
+  const initialStateSnapshotRef = useRef<{
+    hiddenAssetIds: Set<UniqueCoinId>;
+    visibleAssetIds: Set<UniqueCoinId>;
+    hiddenCustomAssetIds: Set<UniqueCoinId>;
+  } | null>(null);
+
+  if (initialStateSnapshotRef.current === null && (currentHiddenAssetIdsSet?.size || currentVisibleAssetIdsSet?.size || customHiddenAssetSet?.size)) {
+    initialStateSnapshotRef.current = {
+      hiddenAssetIds: new Set(currentHiddenAssetIdsSet ?? []),
+      visibleAssetIds: new Set(currentVisibleAssetIdsSet ?? []),
+      hiddenCustomAssetIds: new Set(customHiddenAssetSet ?? []),
+    };
+  }
+
+  return useMemo(() => {
+    const initialSnapshot = initialStateSnapshotRef.current;
+    const sortingHiddenAssetIds = initialSnapshot?.hiddenAssetIds ?? currentHiddenAssetIdsSet;
+    const sortingVisibleAssetIds = initialSnapshot?.visibleAssetIds ?? currentVisibleAssetIdsSet;
+    const sortingHiddenCustomAssetIds = initialSnapshot?.hiddenCustomAssetIds ?? customHiddenAssetSet;
+
+    const { visible, hidden, visibleCount } = filteredCoinList.reduce<{ visible: ProcessedAsset[]; hidden: ProcessedAsset[]; visibleCount: number }>(
+      (acc, coin) => {
+        const currentCoinId = coin.uniqueCoinId;
+
+        const isCustomERC20 = currentCustomERC20TokenIdsSet.has(currentCoinId);
+        const isCustomCW20 = currentCustomCW20TokenIdsSet.has(currentCoinId);
+        const isCustomToken = isCustomERC20 || isCustomCW20;
+
+        const isCustomAsset = customAssetSet.has(currentCoinId);
+
+        const isBalanceZero = coin.balance === '0';
+
+        const isHiddenState = getHiddenState(
+          currentCoinId,
+          isCustomToken,
+          isBalanceZero,
+          currentHiddenAssetIdsSet,
+          customHiddenAssetSet,
+          currentVisibleAssetIdsSet,
+        );
+
+        const resolvedAssetId =
+          coin.chain.mainAssetDenom === coin.asset.id || coin.asset.id === NATIVE_EVM_COIN_ADDRESS
+            ? coin.asset.description
+            : coin.asset.id.length > 15
+              ? shorterAddress(coin.asset.id, 16)
+              : coin.asset.id;
+
+        const innerTokenType = (() => {
+          if (isCustomERC20) {
+            return 'custom-erc20';
+          } else if (isCustomCW20) {
+            return 'custom-cw20';
+          } else if (isCustomAsset) {
+            return 'custom-asset';
+          } else {
+            return 'supported-asset';
+          }
+        })();
+
+        // NOTE 초기 정렬용 스냅샷뜬 히든스테이트
+        const isSortingHidden = getHiddenState(
+          currentCoinId,
+          isCustomToken,
+          isBalanceZero,
+          sortingHiddenAssetIds,
+          sortingHiddenCustomAssetIds,
+          sortingVisibleAssetIds,
+        );
+
+        const processedItem: ProcessedAsset = {
+          ...coin,
+          isHiddenState,
+          resolvedAssetId: resolvedAssetId || '-',
+          isBalanceZero,
+          isCustomToken,
+          innerTokenType,
+        };
+
+        if (isSortingHidden) {
+          acc.hidden.push(processedItem);
+        } else {
+          acc.visible.push(processedItem);
+        }
+
+        if (!isHiddenState) acc.visibleCount++;
+
+        return acc;
+      },
+      { visible: [] as ProcessedAsset[], hidden: [] as ProcessedAsset[], visibleCount: 0 },
+    );
+
+    let result = [...visible, ...hidden];
+
+    if (currentSelectedChainId && result.length > 0) {
+      const denoms = result[0]?.chain.chainDefaultCoinDenoms ?? [];
+
+      result = sortByReference(result, denoms, (item, denom) => isEqualsIgnoringCase(item.asset.id, denom));
+    }
+
+    return { list: result, visibleCount };
+  }, [
+    currentCustomCW20TokenIdsSet,
+    currentCustomERC20TokenIdsSet,
+    currentSelectedChainId,
+    customAssetSet,
+    customHiddenAssetSet,
+    filteredCoinList,
+    currentHiddenAssetIdsSet,
+    currentVisibleAssetIdsSet,
+  ]);
+}
+
+export function useProcessedAssets({ baseCoinList, sortOption, currentSelectedChainId, search, debouncedSearch }: UseProcessedAssetsParams) {
+  const filteredCoinList = useSortedAndFilteredList(baseCoinList, sortOption, currentSelectedChainId, search, debouncedSearch);
+
+  return useFinalProcessedList(filteredCoinList, currentSelectedChainId);
+}

--- a/src/libs/asset.ts
+++ b/src/libs/asset.ts
@@ -38,9 +38,9 @@ export async function getHiddenAssetsSet(id: string): Promise<Set<string>> {
 export async function updateHiddenAssets(id: string, hiddenAssetIds: AssetId[]) {
   const storedHiddenAssetIds = await getHiddenAssets(id);
 
-  const filteredStoredHiddenAssetIds = storedHiddenAssetIds.filter(
-    (storedHiddenAssetId) => !hiddenAssetIds.find((hiddenAssetId) => getCoinIdWithManual(storedHiddenAssetId) === getCoinIdWithManual(hiddenAssetId)),
-  );
+  const newHiddenCoinIds = new Set(hiddenAssetIds.map((assetId) => getCoinIdWithManual(assetId)));
+
+  const filteredStoredHiddenAssetIds = storedHiddenAssetIds.filter((storedHiddenAssetId) => !newHiddenCoinIds.has(getCoinIdWithManual(storedHiddenAssetId)));
 
   const updatedHiddenAssetIds = [...filteredStoredHiddenAssetIds, ...hiddenAssetIds];
 

--- a/src/libs/asset/coin/custom/accountAsset.ts
+++ b/src/libs/asset/coin/custom/accountAsset.ts
@@ -5,7 +5,7 @@ import type { ExtensionStorage } from '@/types/extension';
 import { createAllChainMap } from '@/utils/cache/chainMap';
 import { devLogger } from '@/utils/devLogger';
 import { gt } from '@/utils/numbers';
-import { getCoinId, getUniqueChainIdWithManual } from '@/utils/queryParamGenerator';
+import { getCoinId, getUniqueChainId, getUniqueChainIdWithManual, getUniqueCoinId } from '@/utils/queryParamGenerator';
 
 type GetAccountCustomAssetsOption = {
   disableFilterHidden?: boolean;
@@ -56,6 +56,8 @@ export async function getAccountCustomAssets(id: string, option?: GetAccountCust
       const balance = balanceInfo?.balances?.find((balance) => balance.denom === type)?.amount || '0';
 
       const result: AccountCustomCosmosAsset = {
+        uniqueCoinId: getUniqueCoinId(asset),
+        uniqueChainId: getUniqueChainId(chain),
         chain,
         asset,
         address,
@@ -82,6 +84,8 @@ export async function getAccountCustomAssets(id: string, option?: GetAccountCust
       const balance = balanceInfo?.balance ? BigInt(balanceInfo?.balance).toString() : '0';
 
       const result: AccountCustomEvmAsset = {
+        uniqueCoinId: getUniqueCoinId(asset),
+        uniqueChainId: getUniqueChainId(chain),
         chain,
         asset,
         address,

--- a/src/libs/asset/coin/default/accountAsset.ts
+++ b/src/libs/asset/coin/default/accountAsset.ts
@@ -195,14 +195,14 @@ async function getCosmosAccountAssets(id: string, assets: { asset: CosmosAsset; 
   );
 
   return assets.flatMap(({ asset, chain, addresses }) => {
+    const isVestingChain = vestingChainIds.has(chain.id);
+
     return addresses.map((address) => {
       const type = asset.id;
       const assetKey = getAssetKey(address.chainId, address.chainType, address.address);
       const assetKeyWithId = getAssetKeyWithId(type, address.chainId, address.chainType, address.address);
 
-      const isVestingChainMainAsset = vestingChainIds.has(chain.id) && chain.mainAssetDenom === asset.id;
-
-      const accountInfo = isVestingChainMainAsset ? formattingAccount(cosmosAccountInfoMap.get(assetKey)?.accountInfo) : undefined;
+      const isVestingChainMainAsset = isVestingChain && chain.mainAssetDenom === asset.id;
 
       const balanceInfo = cosmosBalancesMap.get(assetKey);
 
@@ -249,24 +249,28 @@ async function getCosmosAccountAssets(id: string, assets: { asset: CosmosAsset; 
       const locked = lockedInfo?.lockedBalances?.find((balance) => balance.denom === type)?.amount || '0';
 
       const resolvedBalance = (() => {
-        if (isVestingChainMainAsset && accountInfo) {
-          const vestingRemained = getVestingRemained(accountInfo, type);
-          const delegatedVestingTotal = chain.id === KAVA_CHAINLIST_ID ? getDelegatedVestingTotal(accountInfo, type) : delegation;
+        if (isVestingChainMainAsset) {
+          const accountInfo = formattingAccount(cosmosAccountInfoMap.get(assetKey)?.accountInfo);
 
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const [vestingRelatedAvailable, _] = (() => {
-            if (gt(vestingRemained, '0')) {
-              if (chain.id === PERSISTENCE_CHAINLIST_ID) {
-                return getPersistenceVestingRelatedBalances(balance, vestingRemained);
+          if (accountInfo) {
+            const vestingRemained = getVestingRemained(accountInfo, type);
+            const delegatedVestingTotal = chain.id === KAVA_CHAINLIST_ID ? getDelegatedVestingTotal(accountInfo, type) : delegation;
+
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const [vestingRelatedAvailable, _] = (() => {
+              if (gt(vestingRemained, '0')) {
+                if (chain.id === PERSISTENCE_CHAINLIST_ID) {
+                  return getPersistenceVestingRelatedBalances(balance, vestingRemained);
+                }
+
+                return getVestingRelatedBalances(balance, vestingRemained, delegatedVestingTotal, undelegation);
               }
 
-              return getVestingRelatedBalances(balance, vestingRemained, delegatedVestingTotal, undelegation);
-            }
+              return [balance, '0'];
+            })();
 
-            return [balance, '0'];
-          })();
-
-          return vestingRelatedAvailable;
+            return vestingRelatedAvailable;
+          }
         }
         return balance;
       })();
@@ -350,19 +354,26 @@ async function getEVMAccountAssets(
     `${id}-commission-cosmos`,
   ]);
 
-  const evmBalances = storage[`${id}-balance-evm`] || [];
+  const evmBalancesMap = new Map((storage[`${id}-balance-evm`] || []).map((item) => [getAssetKey(String(item.chainId), item.chainType, item.address), item]));
 
-  const cosmosDelegations = storage[`${id}-delegation-cosmos`] || [];
-  const cosmosUndelegations = storage[`${id}-undelegation-cosmos`] || [];
-  const cosmosRewards = storage[`${id}-reward-cosmos`] || [];
-  const cosmosCommissions = storage[`${id}-commission-cosmos`] || [];
+  const cosmosDelegationsMap = new Map(
+    (storage[`${id}-delegation-cosmos`] || []).map((item) => [getAssetKeyWithId(item.assetId, String(item.chainId), item.chainType, item.address), item]),
+  );
+  const cosmosUndelegationsMap = new Map(
+    (storage[`${id}-undelegation-cosmos`] || []).map((item) => [getAssetKeyWithId(item.assetId, String(item.chainId), item.chainType, item.address), item]),
+  );
+  const cosmosRewardsMap = new Map(
+    (storage[`${id}-reward-cosmos`] || []).map((item) => [getAssetKeyWithId(item.assetId, String(item.chainId), item.chainType, item.address), item]),
+  );
+  const cosmosCommissionsMap = new Map(
+    (storage[`${id}-commission-cosmos`] || []).map((item) => [getAssetKeyWithId(item.assetId, String(item.chainId), item.chainType, item.address), item]),
+  );
 
   return assets
     .map(({ asset, chain, addresses }) => {
       return addresses.map((address) => {
-        const balanceInfo = evmBalances?.find(
-          (balance) => balance.chainId === address.chainId && balance.chainType === address.chainType && balance.address === address.address,
-        );
+        const assetKey = getAssetKey(address.chainId, address.chainType, address.address);
+        const balanceInfo = evmBalancesMap.get(assetKey);
 
         const balance = balanceInfo?.balance ? BigInt(balanceInfo?.balance).toString() : '0';
         const lastUpdatedAtMs = balanceInfo?.lastUpdatedAtMs;
@@ -377,13 +388,13 @@ async function getEVMAccountAssets(
             (cosmosCoin) => cosmosCoin.asset.id === mainAssetDenom && cosmosCoin.asset.chainId === chain.id && cosmosCoin.asset.chainType === 'cosmos',
           );
 
-          const { asset: cosmosStyleCoin, addresses } = cosmosStyleCoinAsset || {};
+          const { asset: cosmosStyleCoin, addresses, chain: cosmosStyleChain } = cosmosStyleCoinAsset || {};
 
           const cosmosStyleAddress = addresses?.find((accountAddressItem) => accountAddressItem.accountType.hdPath === address.accountType.hdPath);
 
-          const delegationInfo = cosmosDelegations?.find(
-            (balance) => balance.assetId === mainAssetDenom && balance.chainId === address.chainId && balance.address === cosmosStyleAddress?.address,
-          );
+          const cosmosAssetKey = getAssetKeyWithId(mainAssetDenom || '', address.chainId, cosmosStyleChain?.chainType || '', cosmosStyleAddress?.address || '');
+
+          const delegationInfo = cosmosDelegationsMap.get(cosmosAssetKey);
 
           const delegation =
             delegationInfo?.delegations
@@ -394,9 +405,7 @@ async function getEVMAccountAssets(
           const decimalsAdjustment = cosmosStyleCoin?.decimals ? asset.decimals - cosmosStyleCoin.decimals : 0;
           const resolvedDelegation = gt(decimalsAdjustment, '0') ? toBaseDenomAmount(delegation, decimalsAdjustment) : delegation;
 
-          const undelegationInfo = cosmosUndelegations?.find(
-            (balance) => balance.assetId === mainAssetDenom && balance.chainId === address.chainId && balance.address === cosmosStyleAddress?.address,
-          );
+          const undelegationInfo = cosmosUndelegationsMap.get(cosmosAssetKey);
 
           const undelegation =
             undelegationInfo?.unbondings
@@ -408,9 +417,7 @@ async function getEVMAccountAssets(
 
           const resolvedUndelegation = gt(decimalsAdjustment, '0') ? toBaseDenomAmount(undelegation, decimalsAdjustment) : undelegation;
 
-          const rewardInfo = cosmosRewards?.find(
-            (balance) => balance.assetId === mainAssetDenom && balance.chainId === address.chainId && balance.address === cosmosStyleAddress?.address,
-          );
+          const rewardInfo = cosmosRewardsMap.get(cosmosAssetKey);
 
           const reward =
             rewardInfo?.rewards.total
@@ -420,9 +427,7 @@ async function getEVMAccountAssets(
 
           const resolvedReward = gt(decimalsAdjustment, '0') ? toBaseDenomAmount(reward, decimalsAdjustment) : reward;
 
-          const commissioInfo = cosmosCommissions?.find(
-            (balance) => balance.assetId === mainAssetDenom && balance.chainId === address.chainId && balance.address === cosmosStyleAddress?.address,
-          );
+          const commissioInfo = cosmosCommissionsMap.get(cosmosAssetKey);
 
           const commission =
             commissioInfo?.commissions?.commission.commission
@@ -433,10 +438,6 @@ async function getEVMAccountAssets(
           const resolvedCommission = gt(decimalsAdjustment, '0') ? toBaseDenomAmount(commission, decimalsAdjustment) : commission;
 
           const totalBalance = sum([balance, resolvedDelegation, resolvedUndelegation, resolvedReward, resolvedCommission]);
-
-          const fetchStatus: AccountEVMAssetFetchStatus = {
-            balance: balanceInfo?.status,
-          };
 
           const result: AccountEvmAsset = {
             uniqueCoinId: getUniqueCoinId(asset),

--- a/src/libs/asset/coin/default/accountAsset.ts
+++ b/src/libs/asset/coin/default/accountAsset.ts
@@ -36,6 +36,7 @@ import type {
   SolanaAsset,
   SolanaSpltokenAsset,
   SuiAsset,
+  UniqueCoinId,
 } from '@/types/asset';
 import type { AptosChain, BitcoinChain, CosmosChain, EvmChain, GnoChain, IotaChain, SolanaChain, SuiChain } from '@/types/chain';
 import type { ExtensionStorage } from '@/types/extension';
@@ -43,7 +44,7 @@ import { formattingAccount } from '@/utils/cosmos/account';
 import { getDelegatedVestingTotal, getPersistenceVestingRelatedBalances, getVestingRelatedBalances, getVestingRemained } from '@/utils/cosmos/vesting';
 import { devLogger } from '@/utils/devLogger';
 import { gt, minus, plus, sum, toBaseDenomAmount } from '@/utils/numbers';
-import { getCoinId } from '@/utils/queryParamGenerator';
+import { getUniqueChainId, getUniqueCoinId } from '@/utils/queryParamGenerator';
 
 import { getAssetsWithChainAndAddress } from './getAssets';
 
@@ -118,9 +119,13 @@ export async function getAccountAssets(id: string, option?: GetAccountAssetsOpti
 
   const hiddenAssetIdSet = isFilterHidden ? await getHiddenAssetsSet(id) : null;
 
-  const filterAssets = <T extends { asset: Asset; balance?: string; totalBalance?: string }>(assets: T[]): T[] => {
+  const filterAssets = <T extends { uniqueCoinId: UniqueCoinId; asset: Asset; balance?: string; totalBalance?: string }>(assets: T[]): T[] => {
+    if (!isFilterHidden && !isFilterByBalance) {
+      return assets;
+    }
+
     return assets.filter((asset) => {
-      if (hiddenAssetIdSet && hiddenAssetIdSet.has(getCoinId(asset.asset))) {
+      if (hiddenAssetIdSet && hiddenAssetIdSet.has(asset.uniqueCoinId)) {
         return false;
       }
 
@@ -273,6 +278,8 @@ async function getCosmosAccountAssets(id: string, assets: { asset: CosmosAsset; 
       };
 
       const result: AccountCosmosAsset = {
+        uniqueCoinId: getUniqueCoinId(asset),
+        uniqueChainId: getUniqueChainId(chain),
         chain,
         asset,
         address,
@@ -314,6 +321,8 @@ async function getCW20AccountAssets(id: string, assets: { asset: CosmosCw20Asset
         };
 
         const result: AccountCw20Asset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -430,6 +439,8 @@ async function getEVMAccountAssets(
           };
 
           const result: AccountEvmAsset = {
+            uniqueCoinId: getUniqueCoinId(asset),
+            uniqueChainId: getUniqueChainId(chain),
             chain,
             asset,
             address,
@@ -447,6 +458,8 @@ async function getEVMAccountAssets(
         }
 
         const result: AccountEvmAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -486,6 +499,8 @@ async function getERC20AccountAssets(id: string, assets: { asset: EvmErc20Asset;
         };
 
         const result: AccountErc20Asset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -525,6 +540,8 @@ async function getCustomERC20AccountAssets(id: string, assets: { asset: EvmErc20
         };
 
         const result: AccountErc20Asset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -563,6 +580,8 @@ async function getCustomCW20AccountAssets(id: string, assets: { asset: CosmosCw2
           balance: targetCW20BalanceInfo?.status,
         };
         const result: AccountCw20Asset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -597,6 +616,8 @@ async function getAptosAccountAssets(id: string, assets: { asset: AptosAsset; ch
         };
 
         const result: AccountAptosAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -659,6 +680,8 @@ async function getSuiAccountAssets(id: string, assets: { asset: SuiAsset; chain:
           const totalBalance = sum([balance, delegation, reward]);
 
           const result: AccountSuiAsset = {
+            uniqueCoinId: getUniqueCoinId(asset),
+            uniqueChainId: getUniqueChainId(chain),
             chain,
             asset,
             address,
@@ -674,6 +697,8 @@ async function getSuiAccountAssets(id: string, assets: { asset: SuiAsset; chain:
         }
 
         const result: AccountSuiAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -718,6 +743,8 @@ async function getBitcoinAccountAssets(id: string, assets: { asset: BitcoinAsset
             : '0';
 
         const result: AccountBitcoinAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain: specificAccountTypeChain,
           asset,
           address,
@@ -780,6 +807,8 @@ async function getIotaAccountAssets(id: string, assets: { asset: IotaAsset; chai
           const totalBalance = sum([balance, delegation, reward]);
 
           const result: AccountIotaAsset = {
+            uniqueCoinId: getUniqueCoinId(asset),
+            uniqueChainId: getUniqueChainId(chain),
             chain,
             asset,
             address,
@@ -795,6 +824,8 @@ async function getIotaAccountAssets(id: string, assets: { asset: IotaAsset; chai
         }
 
         const result: AccountIotaAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -830,6 +861,8 @@ async function getGnoAccountAssets(id: string, assets: { asset: GnoAsset; chain:
         };
 
         const result: AccountGnoAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -869,6 +902,8 @@ async function getGrc20AccountAssets(id: string, assets: { asset: GnoGrc20Asset;
         };
 
         const result: AccountGrc20Asset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -904,6 +939,8 @@ async function getSolanaAccountAssets(id: string, assets: { asset: SolanaAsset; 
         };
 
         const result: AccountSolanaAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,
@@ -943,6 +980,8 @@ async function getSplTokenAccountAssets(id: string, assets: { asset: SolanaSplto
         };
 
         const result: AccountSpltokenAsset = {
+          uniqueCoinId: getUniqueCoinId(asset),
+          uniqueChainId: getUniqueChainId(chain),
           chain,
           asset,
           address,

--- a/src/pages/-components/CryptoFilterSection/index.tsx
+++ b/src/pages/-components/CryptoFilterSection/index.tsx
@@ -1,0 +1,50 @@
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import AdBannerCarousel from '@/components/AdBannerCarousel';
+import Search from '@/components/Search';
+
+import { AdCarouselContainer, FilterContainer, StickyTabPanelContentsContainer } from './styled';
+import ManageCryptoSection from '../ManageCryptoSection';
+
+type CryptoFilterSectionProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  onClearSearch: () => void;
+  isDebouncing: boolean;
+  onClickFilter: () => void;
+};
+
+function CryptoFilterSection({ search, onSearchChange, onClearSearch, isDebouncing, onClickFilter }: CryptoFilterSectionProps) {
+  const { t } = useTranslation();
+
+  const handleSearchChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onSearchChange(event.currentTarget.value);
+    },
+    [onSearchChange],
+  );
+
+  return (
+    <StickyTabPanelContentsContainer>
+      <FilterContainer>
+        <Search
+          value={search}
+          onChange={handleSearchChange}
+          placeholder={t('pages.index.searchPlaceholder')}
+          isPending={isDebouncing}
+          onClickFilter={onClickFilter}
+          onClear={onClearSearch}
+        />
+      </FilterContainer>
+
+      <AdCarouselContainer>
+        <AdBannerCarousel />
+      </AdCarouselContainer>
+
+      <ManageCryptoSection />
+    </StickyTabPanelContentsContainer>
+  );
+}
+
+export default memo(CryptoFilterSection);

--- a/src/pages/-components/CryptoFilterSection/index.tsx
+++ b/src/pages/-components/CryptoFilterSection/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AdBannerCarousel from '@/components/AdBannerCarousel';
@@ -18,19 +18,14 @@ type CryptoFilterSectionProps = {
 function CryptoFilterSection({ search, onSearchChange, onClearSearch, isDebouncing, onClickFilter }: CryptoFilterSectionProps) {
   const { t } = useTranslation();
 
-  const handleSearchChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      onSearchChange(event.currentTarget.value);
-    },
-    [onSearchChange],
-  );
-
   return (
     <StickyTabPanelContentsContainer>
       <FilterContainer>
         <Search
           value={search}
-          onChange={handleSearchChange}
+          onChange={(event) => {
+            onSearchChange(event.currentTarget.value);
+          }}
           placeholder={t('pages.index.searchPlaceholder')}
           isPending={isDebouncing}
           onClickFilter={onClickFilter}

--- a/src/pages/-components/CryptoFilterSection/styled.tsx
+++ b/src/pages/-components/CryptoFilterSection/styled.tsx
@@ -1,0 +1,25 @@
+import { styled } from '@mui/material/styles';
+
+export const StickyTabPanelContentsContainer = styled('div')(({ theme }) => ({
+  width: '100%',
+  height: 'fit-content',
+  position: 'sticky',
+  top: '7.8rem',
+
+  padding: '0.8rem 1.2rem',
+
+  boxSizing: 'border-box',
+
+  zIndex: 1,
+  backgroundColor: theme.palette.color.base50,
+}));
+
+export const FilterContainer = styled('div')({
+  width: '100%',
+});
+
+export const AdCarouselContainer = styled('div')({
+  margin: '0.8rem 0 1.1rem',
+
+  overflow: 'hidden',
+});

--- a/src/pages/-components/CryptoListSection/index.tsx
+++ b/src/pages/-components/CryptoListSection/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -26,6 +26,16 @@ function CryptoListSection({ assets, isLoading }: CryptoListSectionProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
+  const processedAssets = useMemo(
+    () =>
+      assets.map((coin) => ({
+        ...coin,
+        isGroupToken: gt(coin.counts || '0', '1'),
+        resolvedSymbol: coin.asset.symbol + (isTestnetChain(coin.chain.id) ? ' (Testnet)' : ''),
+      })),
+    [assets],
+  );
+
   const handleCoinClick = useCallback(
     (coin: PortfolioCoinItem) => {
       const isGroupToken = gt(coin.counts || '0', '1');
@@ -39,32 +49,6 @@ function CryptoListSection({ assets, isLoading }: CryptoListSectionProps) {
       });
     },
     [navigate],
-  );
-
-  const renderCoinItem = useCallback(
-    (coin: PortfolioCoinItem | undefined, virtualItem: { index: number }) => {
-      if (!coin) return null;
-
-      const isGroupToken = gt(coin.counts || '0', '1');
-      const resolvedSymbol = coin.asset.symbol + `${isTestnetChain(coin.chain.id) ? ' (Testnet)' : ''}`;
-
-      return (
-        <CoinWithMarketTrendButton
-          key={getCoinId(coin.asset) + virtualItem.index}
-          onClick={() => handleCoinClick(coin)}
-          fetchStatus={coin.fetchStatus?.balance}
-          displayAmount={coin.totalDisplayAmount || '0'}
-          symbol={resolvedSymbol}
-          coinGeckoId={coin.asset.coinGeckoId}
-          coinImageProps={{
-            imageURL: coin.asset.image,
-            isAggregatedCoin: gt(coin.counts || '0', '1'),
-            badgeImageURL: isGroupToken ? undefined : coin.chain.image || undefined,
-          }}
-        />
-      );
-    },
-    [handleCoinClick],
   );
 
   if (isLoading) {
@@ -87,7 +71,26 @@ function CryptoListSection({ assets, isLoading }: CryptoListSectionProps) {
 
   return (
     <CoinButtonWrapper>
-      <VirtualizedList items={assets} estimateSize={() => 60} renderItem={renderCoinItem} overscan={5} />
+      <VirtualizedList
+        items={processedAssets}
+        estimateSize={() => 60}
+        renderItem={(coin, virtualItem) => (
+          <CoinWithMarketTrendButton
+            key={coin.uniqueCoinId + virtualItem.index}
+            onClick={() => handleCoinClick(coin)}
+            fetchStatus={coin.fetchStatus?.balance}
+            displayAmount={coin.totalDisplayAmount || '0'}
+            symbol={coin.resolvedSymbol}
+            coinGeckoId={coin.asset.coinGeckoId}
+            coinImageProps={{
+              imageURL: coin.asset.image,
+              isAggregatedCoin: coin.isGroupToken,
+              badgeImageURL: coin.isGroupToken ? undefined : coin.chain.image || undefined,
+            }}
+          />
+        )}
+        overscan={5}
+      />
     </CoinButtonWrapper>
   );
 }

--- a/src/pages/-components/CryptoListSection/index.tsx
+++ b/src/pages/-components/CryptoListSection/index.tsx
@@ -1,0 +1,95 @@
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from '@tanstack/react-router';
+
+import CoinWithMarketTrendButton from '@/components/CoinWithMarketTrendButton';
+import { VirtualizedList } from '@/components/common/VirtualizedList';
+import EmptyAsset from '@/components/EmptyAsset';
+import type { PortfolioCoinItem } from '@/pages/-entry';
+import { Route as CoinDetail } from '@/pages/coin-detail/$coinId';
+import { Route as CoinOverview } from '@/pages/coin-overview/$coinId';
+import { isTestnetChain } from '@/utils/chain';
+import { gt } from '@/utils/numbers';
+import { getCoinId } from '@/utils/queryParamGenerator';
+
+import { CoinButtonWrapper, EmptyAssetContainer } from './styled';
+import SkeletonCoinList from '../SkeletonCoinList';
+
+import NoListIcon from '@/assets/images/icons/NoList70.svg';
+
+type CryptoListSectionProps = {
+  assets: PortfolioCoinItem[];
+  isLoading: boolean;
+};
+
+function CryptoListSection({ assets, isLoading }: CryptoListSectionProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const handleCoinClick = useCallback(
+    (coin: PortfolioCoinItem) => {
+      const isGroupToken = gt(coin.counts || '0', '1');
+      const destinationRoute = isGroupToken ? CoinOverview.to : CoinDetail.to;
+
+      navigate({
+        to: destinationRoute,
+        params: {
+          coinId: getCoinId(coin.asset),
+        },
+      });
+    },
+    [navigate],
+  );
+
+  const renderCoinItem = useCallback(
+    (coin: PortfolioCoinItem | undefined, virtualItem: { index: number }) => {
+      if (!coin) return null;
+
+      const isGroupToken = gt(coin.counts || '0', '1');
+      const resolvedSymbol = coin.asset.symbol + `${isTestnetChain(coin.chain.id) ? ' (Testnet)' : ''}`;
+
+      return (
+        <CoinWithMarketTrendButton
+          key={getCoinId(coin.asset) + virtualItem.index}
+          onClick={() => handleCoinClick(coin)}
+          fetchStatus={coin.fetchStatus?.balance}
+          displayAmount={coin.totalDisplayAmount || '0'}
+          symbol={resolvedSymbol}
+          coinGeckoId={coin.asset.coinGeckoId}
+          coinImageProps={{
+            imageURL: coin.asset.image,
+            isAggregatedCoin: gt(coin.counts || '0', '1'),
+            badgeImageURL: isGroupToken ? undefined : coin.chain.image || undefined,
+          }}
+        />
+      );
+    },
+    [handleCoinClick],
+  );
+
+  if (isLoading) {
+    return (
+      <CoinButtonWrapper>
+        <SkeletonCoinList />
+      </CoinButtonWrapper>
+    );
+  }
+
+  if (assets.length === 0) {
+    return (
+      <CoinButtonWrapper>
+        <EmptyAssetContainer>
+          <EmptyAsset icon={<NoListIcon />} title={t('pages.index.noTokens')} subTitle={t('pages.index.noTokensDescription')} />
+        </EmptyAssetContainer>
+      </CoinButtonWrapper>
+    );
+  }
+
+  return (
+    <CoinButtonWrapper>
+      <VirtualizedList items={assets} estimateSize={() => 60} renderItem={renderCoinItem} overscan={5} />
+    </CoinButtonWrapper>
+  );
+}
+
+export default memo(CryptoListSection);

--- a/src/pages/-components/CryptoListSection/styled.tsx
+++ b/src/pages/-components/CryptoListSection/styled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+
+export const CoinButtonWrapper = styled('div')({
+  flex: '1',
+  width: '100%',
+});
+
+export const EmptyAssetContainer = styled('div')({
+  flex: 1,
+
+  display: 'flex',
+  height: '100%',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '2rem 0',
+});

--- a/src/pages/-components/CryptoTab/index.tsx
+++ b/src/pages/-components/CryptoTab/index.tsx
@@ -1,0 +1,94 @@
+import { memo, useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDebounce } from 'use-debounce';
+import { Typography } from '@mui/material';
+
+import SortBottomSheet from '@/components/SortBottomSheet';
+import { useScroll } from '@/components/Wrapper/components/ScrollProvider';
+import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
+import { useCryptoAssets } from '@/pages/-hooks/useCryptoAssets';
+import type { DashboardCoinSortKeyType } from '@/types/sortKey';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
+
+import CryptoFilterSection from '../CryptoFilterSection';
+import CryptoListSection from '../CryptoListSection';
+
+function CryptoTab() {
+  const { t } = useTranslation();
+  const { scrollToTop } = useScroll();
+
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
+  const [isOpenSortBottomSheet, setIsOpenSortBottomSheet] = useState(false);
+
+  const isDebouncing = !!search && isPending();
+
+  const dashboardCoinSortKey = useExtensionStorageStore((state) => state.dashboardCoinSortKey);
+  const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
+
+  const { filteredAssetsBySearch, isLoading } = useCryptoAssets({
+    search,
+    debouncedSearch,
+  });
+
+  useEffect(() => {
+    if (search.length > 1 || search.length === 0) {
+      scrollToTop();
+    }
+  }, [scrollToTop, search.length]);
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value);
+  }, []);
+
+  const handleClearSearch = useCallback(() => {
+    setSearch('');
+    cancel();
+  }, [cancel]);
+
+  const handleOpenSortBottomSheet = useCallback(() => {
+    setIsOpenSortBottomSheet(true);
+  }, []);
+
+  const handleCloseSortBottomSheet = useCallback(() => {
+    setIsOpenSortBottomSheet(false);
+  }, []);
+
+  const handleSelectSortOption = useCallback(
+    (val: string) => {
+      updateExtensionStorageStore('dashboardCoinSortKey', val as DashboardCoinSortKeyType);
+    },
+    [updateExtensionStorageStore],
+  );
+
+  return (
+    <>
+      <CryptoFilterSection
+        search={search}
+        onSearchChange={handleSearchChange}
+        onClearSearch={handleClearSearch}
+        isDebouncing={isDebouncing}
+        onClickFilter={handleOpenSortBottomSheet}
+      />
+      <CryptoListSection assets={filteredAssetsBySearch} isLoading={isLoading} />
+      <SortBottomSheet
+        optionButtonProps={[
+          {
+            sortKey: DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER,
+            children: <Typography variant="b2_M">{t('pages.index.valueHighOrder')}</Typography>,
+          },
+          {
+            sortKey: DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC,
+            children: <Typography variant="b2_M">{t('pages.index.alphabeticalAsc')}</Typography>,
+          },
+        ]}
+        currentSortOption={dashboardCoinSortKey}
+        open={isOpenSortBottomSheet}
+        onClose={handleCloseSortBottomSheet}
+        onSelectSortOption={handleSelectSortOption}
+      />
+    </>
+  );
+}
+
+export default memo(CryptoTab);

--- a/src/pages/-components/CryptoTab/index.tsx
+++ b/src/pages/-components/CryptoTab/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'use-debounce';
 import { Typography } from '@mui/material';
@@ -21,14 +21,15 @@ function CryptoTab() {
   const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
   const [isOpenSortBottomSheet, setIsOpenSortBottomSheet] = useState(false);
 
+  const isSearchEmpty = useMemo(() => search.length === 0, [search.length]);
   const isDebouncing = !!search && isPending();
 
   const dashboardCoinSortKey = useExtensionStorageStore((state) => state.dashboardCoinSortKey);
   const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
 
   const { filteredAssetsBySearch, isLoading } = useCryptoAssets({
-    search,
-    debouncedSearch,
+    search: debouncedSearch,
+    isSearchEmpty,
   });
 
   useEffect(() => {

--- a/src/pages/-components/CryptoTab/index.tsx
+++ b/src/pages/-components/CryptoTab/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'use-debounce';
 import { Typography } from '@mui/material';
@@ -37,38 +37,21 @@ function CryptoTab() {
     }
   }, [scrollToTop, search.length]);
 
-  const handleSearchChange = useCallback((value: string) => {
-    setSearch(value);
-  }, []);
-
-  const handleClearSearch = useCallback(() => {
-    setSearch('');
-    cancel();
-  }, [cancel]);
-
-  const handleOpenSortBottomSheet = useCallback(() => {
-    setIsOpenSortBottomSheet(true);
-  }, []);
-
-  const handleCloseSortBottomSheet = useCallback(() => {
-    setIsOpenSortBottomSheet(false);
-  }, []);
-
-  const handleSelectSortOption = useCallback(
-    (val: string) => {
-      updateExtensionStorageStore('dashboardCoinSortKey', val as DashboardCoinSortKeyType);
-    },
-    [updateExtensionStorageStore],
-  );
-
   return (
     <>
       <CryptoFilterSection
         search={search}
-        onSearchChange={handleSearchChange}
-        onClearSearch={handleClearSearch}
+        onSearchChange={(value) => {
+          setSearch(value);
+        }}
+        onClearSearch={() => {
+          setSearch('');
+          cancel();
+        }}
         isDebouncing={isDebouncing}
-        onClickFilter={handleOpenSortBottomSheet}
+        onClickFilter={() => {
+          setIsOpenSortBottomSheet(true);
+        }}
       />
       <CryptoListSection assets={filteredAssetsBySearch} isLoading={isLoading} />
       <SortBottomSheet
@@ -84,8 +67,12 @@ function CryptoTab() {
         ]}
         currentSortOption={dashboardCoinSortKey}
         open={isOpenSortBottomSheet}
-        onClose={handleCloseSortBottomSheet}
-        onSelectSortOption={handleSelectSortOption}
+        onClose={() => {
+          setIsOpenSortBottomSheet(false);
+        }}
+        onSelectSortOption={(val) => {
+          updateExtensionStorageStore('dashboardCoinSortKey', val as DashboardCoinSortKeyType);
+        }}
       />
     </>
   );

--- a/src/pages/-components/ManageCryptoSection/index.tsx
+++ b/src/pages/-components/ManageCryptoSection/index.tsx
@@ -1,0 +1,44 @@
+import { memo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Typography } from '@mui/material';
+import { useNavigate } from '@tanstack/react-router';
+
+import CheckBoxTextButton from '@/components/common/CheckBoxTextButton';
+import IconTextButton from '@/components/common/IconTextButton';
+import { Route as ManageAssets } from '@/pages/manage-assets/visibility/assets';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
+
+import { Container, MarginLeftTypography } from './styled';
+
+import PlusIcon from '@/assets/images/icons/Plus12.svg';
+
+function ManageCryptoSection() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const isHideSmalValue = useExtensionStorageStore((state) => state.isHideSmalValue);
+  const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
+
+  const handleToggleHideSmallValue = useCallback(() => {
+    updateExtensionStorageStore('isHideSmalValue', !isHideSmalValue);
+  }, [isHideSmalValue, updateExtensionStorageStore]);
+
+  const handleNavigateToManageAssets = useCallback(() => {
+    navigate({
+      to: ManageAssets.to,
+    });
+  }, [navigate]);
+
+  return (
+    <Container>
+      <CheckBoxTextButton isChecked={isHideSmalValue} onClick={handleToggleHideSmallValue}>
+        <Typography variant="b3_R">{t('pages.index.hideSmallBalance')}</Typography>
+      </CheckBoxTextButton>
+      <IconTextButton onClick={handleNavigateToManageAssets} leadingIcon={<PlusIcon />}>
+        <MarginLeftTypography variant="b3_M">{t('pages.index.manageCrypto')}</MarginLeftTypography>
+      </IconTextButton>
+    </Container>
+  );
+}
+
+export default memo(ManageCryptoSection);

--- a/src/pages/-components/ManageCryptoSection/styled.tsx
+++ b/src/pages/-components/ManageCryptoSection/styled.tsx
@@ -1,0 +1,16 @@
+import { Typography as BaseTypography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const Container = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+
+  marginTop: '1.2rem',
+});
+
+export const MarginLeftTypography = styled(BaseTypography)(({ theme }) => ({
+  marginLeft: '0.4rem',
+
+  color: theme.palette.color.base1300,
+}));

--- a/src/pages/-components/NFTList/index.tsx
+++ b/src/pages/-components/NFTList/index.tsx
@@ -11,8 +11,8 @@ import { useScroll } from '@/components/Wrapper/components/ScrollProvider';
 import { useCurrentAccountAddedNFTsWithMetaData } from '@/hooks/useCurrentAccountAddedNFTsWithMetaData';
 import { Route as ManageNFTs } from '@/pages/manage-assets/visibility/nfts';
 import { Route as NFTDetail } from '@/pages/nft-detail/$id';
-import type { UniqueChainId } from '@/types/chain';
 import { getUniqueChainIdWithManual } from '@/utils/queryParamGenerator';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import NFTItem, { NFTSkeletonItem } from './components/NFTItem';
 import {
@@ -29,11 +29,9 @@ import {
 import NoListIcon from '@/assets/images/icons/NoList70.svg';
 import PlusIcon from '@/assets/images/icons/Plus12.svg';
 
-export type NFTListProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> & {
-  selectedChainId?: UniqueChainId;
-};
+export type NFTListProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>;
 
-export default function NFTList({ selectedChainId, ...reamainder }: NFTListProps) {
+export default function NFTList({ ...remainder }: NFTListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
@@ -43,6 +41,7 @@ export default function NFTList({ selectedChainId, ...reamainder }: NFTListProps
 
   const { scrollToTop } = useScroll();
   const { currentAccountAddNFTsWithMeta, isLoading } = useCurrentAccountAddedNFTsWithMetaData();
+  const selectedChainId = useExtensionStorageStore((state) => state.selectedChainFilterId) || undefined;
 
   const isNFTSearchingDebouncing = !!search && isPending();
 
@@ -75,7 +74,7 @@ export default function NFTList({ selectedChainId, ...reamainder }: NFTListProps
   }, [scrollToTop, search.length]);
 
   return (
-    <Contaienr {...reamainder}>
+    <Contaienr {...remainder}>
       <StickyTabPanelContentsContainer>
         <FilterContaienr>
           <Search

--- a/src/pages/-entry.tsx
+++ b/src/pages/-entry.tsx
@@ -1,61 +1,16 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useDebounce } from 'use-debounce';
-import { Typography } from '@mui/material';
-import { useNavigate } from '@tanstack/react-router';
+import { useCallback, useState } from 'react';
 
-import AdBannerCarousel from '@/components/AdBannerCarousel';
 import BaseBody from '@/components/BaseLayout/components/BaseBody';
 import EdgeAligner from '@/components/BaseLayout/components/EdgeAligner';
 import CheckLegacyAddressBalanceBottomSheet from '@/components/CheckLegacyAddressBalanceBottomSheet';
-import CoinWithMarketTrendButton from '@/components/CoinWithMarketTrendButton';
-import CheckBoxTextButton from '@/components/common/CheckBoxTextButton';
-import IconTextButton from '@/components/common/IconTextButton';
 import { Tab, Tabs } from '@/components/common/Tab';
-import { VirtualizedList } from '@/components/common/VirtualizedList';
-import EmptyAsset from '@/components/EmptyAsset';
 import PortFolio from '@/components/MainBox/Portfolio';
-import Search from '@/components/Search';
-import SortBottomSheet from '@/components/SortBottomSheet';
-import { useScroll } from '@/components/Wrapper/components/ScrollProvider';
-import { CURRENCY_TYPE } from '@/constants/currency';
-import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
-import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
-import { useUpdateBalance } from '@/hooks/update/useUpdateBalance';
-import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
 import { useCurrentAccountAddedNFTsWithMetaData } from '@/hooks/useCurrentAccountAddedNFTsWithMetaData';
-import { useGroupAccountAssets } from '@/hooks/useGroupAccountAssets';
-import { Route as CoinDetail } from '@/pages/coin-detail/$coinId';
-import { Route as CoinOverview } from '@/pages/coin-overview/$coinId';
-import { Route as ManageAssets } from '@/pages/manage-assets/visibility/assets';
 import type { FlatAccountAssets } from '@/types/accountAssets';
-import type { DashboardCoinSortKeyType } from '@/types/sortKey';
-import { removeDuplicates } from '@/utils/array';
-import { getDefaultAssets, getFilteredAssetsByChainId, isStakeableAsset } from '@/utils/asset';
-import { isTestnetChain } from '@/utils/chain';
-import { gt, gte, minus, times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId } from '@/utils/queryParamGenerator';
-import { isEqualsIgnoringCase } from '@/utils/string';
-import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
+import CryptoTab from './-components/CryptoTab';
 import NFTList from './-components/NFTList';
-import SkeletonCoinList from './-components/SkeletonCoinList';
-import {
-  AdCarouselContainer,
-  CoinButtonWrapper,
-  Container,
-  EmptyAssetContainer,
-  FilterContaienr,
-  ManageCryptoContainer,
-  MarginLeftTypography,
-  StickyTabContainer,
-  StickyTabPanelContentsContainer,
-  StyledTabPanel,
-} from './-styled';
-
-import NoListIcon from '@/assets/images/icons/NoList70.svg';
-import PlusIcon from '@/assets/images/icons/Plus12.svg';
+import { Container, StickyTabContainer, StyledTabPanel } from './-styled';
 
 export type PortfolioCoinItem = FlatAccountAssets & {
   value: string;
@@ -64,185 +19,16 @@ export type PortfolioCoinItem = FlatAccountAssets & {
   counts: string;
 };
 
+const TAB_LABELS = ['Crypto', 'NFTs'] as const;
+
 export default function Entry() {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-
-  const { scrollToTop } = useScroll();
-  const { isLoading: isUpdateBalanceLoading } = useUpdateBalance();
-
-  const { data: accountAllAssets } = useAccountAllAssets({ filterByPreferAccountType: true });
-  const { data: coinGeckoPrice, isLoading: isCoinGeckoPriceLoading } = useCoinGeckoPrice();
-  const { data: usdCoinGeckoPrice, isLoading: isCoinGeckoPriceUSDLoading } = useCoinGeckoPrice('usd');
-
-  const dashboardCoinSortKey = useExtensionStorageStore((state) => state.dashboardCoinSortKey);
-  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
-  const isHideSmalValue = useExtensionStorageStore((state) => state.isHideSmalValue);
-  const selectedChainFilterId = useExtensionStorageStore((state) => state.selectedChainFilterId);
-  const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
-
-  useAutoBalanceRefresh(selectedChainFilterId && [selectedChainFilterId]);
-  useCurrentAccountAddedNFTsWithMetaData();
-  const [search, setSearch] = useState('');
-  const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
-
-  const isDebouncing = !!search && isPending();
-
-  const [isOpenSortBottomSheet, setIsOpenSortBottomSheet] = useState(false);
   const [tabValue, setTabValue] = useState(0);
 
-  const tabLabels = ['Crypto', 'NFTs'];
+  useCurrentAccountAddedNFTsWithMetaData();
 
-  const { groupAccountAssets, isLoading: isGroupAssetsLoading } = useGroupAccountAssets();
-
-  const isFirstBalanceLoading = !groupAccountAssets?.singleAccountAssets.length && !groupAccountAssets?.groupAccountAssets.length && isUpdateBalanceLoading;
-  const isLoading = isFirstBalanceLoading || isGroupAssetsLoading || isCoinGeckoPriceLoading || isCoinGeckoPriceUSDLoading;
-
-  const chainDefaultCoins = useMemo<PortfolioCoinItem[] | undefined>(() => {
-    const chainFilteredAllCoins = getFilteredAssetsByChainId(accountAllAssets?.flatAccountAssets, selectedChainFilterId || undefined);
-
-    const chainDefaultCoins = getDefaultAssets(chainFilteredAllCoins)
-      ?.slice()
-      .sort((a, b) => {
-        const denoms = a.chain.chainDefaultCoinDenoms ?? [];
-        const idxA = denoms.findIndex((d) => isEqualsIgnoringCase(d, a.asset.id));
-        const idxB = denoms.findIndex((d) => isEqualsIgnoringCase(d, b.asset.id));
-
-        return (idxA < 0 ? Number.MAX_SAFE_INTEGER : idxA) - (idxB < 0 ? Number.MAX_SAFE_INTEGER : idxB);
-      });
-
-    if (!chainDefaultCoins || chainDefaultCoins?.length === 0) return undefined;
-
-    return chainDefaultCoins.map((item) => {
-      const balance = isStakeableAsset(item) ? item.totalBalance || '0' : item.balance;
-      const totalDisplayAmount = toDisplayDenomAmount(balance, item.asset.decimals) || '0';
-
-      const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-      const coinPriceInDolalr = (item.asset.coinGeckoId && usdCoinGeckoPrice?.[item.asset.coinGeckoId]?.[CURRENCY_TYPE.USD]) || 0;
-
-      const value = times(totalDisplayAmount, coinPrice);
-      const valueInDollar = times(totalDisplayAmount, coinPriceInDolalr);
-      return {
-        ...item,
-        counts: '1',
-        totalDisplayAmount,
-        value,
-        dollarValue: valueInDollar,
-      };
-    });
-  }, [accountAllAssets?.flatAccountAssets, coinGeckoPrice, selectedChainFilterId, usdCoinGeckoPrice, userCurrencyPreference]);
-
-  const computedAssetValues = useMemo<PortfolioCoinItem[]>(() => {
-    const baseCoinList = [...(groupAccountAssets?.groupAccountAssets || []), ...(groupAccountAssets?.singleAccountAssets || [])];
-
-    const unGroupedAccountAssets = Object.values(groupAccountAssets?.groupMap || []).flat();
-    const mappedUngroupAccountAssets = unGroupedAccountAssets.map((item) => {
-      const balance = isStakeableAsset(item) ? item.totalBalance || '0' : item.balance;
-      const totalDisplayAmount = toDisplayDenomAmount(balance, item.asset.decimals);
-
-      return {
-        ...item,
-        counts: '1',
-        totalDisplayAmount,
-      };
-    });
-
-    const displayedAssets =
-      (!!search && debouncedSearch.length > 1) || selectedChainFilterId
-        ? [...mappedUngroupAccountAssets, ...(groupAccountAssets?.singleAccountAssets || [])]
-        : baseCoinList;
-
-    return displayedAssets.map((item) => {
-      const displayAmount = item.totalDisplayAmount || '0';
-
-      const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-      const coinPriceInDolalr = (item.asset.coinGeckoId && usdCoinGeckoPrice?.[item.asset.coinGeckoId]?.[CURRENCY_TYPE.USD]) || 0;
-
-      const value = times(displayAmount, coinPrice);
-      const valueInDollar = times(displayAmount, coinPriceInDolalr);
-
-      return {
-        ...item,
-        value,
-        dollarValue: valueInDollar,
-      };
-    });
-  }, [
-    coinGeckoPrice,
-    debouncedSearch.length,
-    groupAccountAssets?.groupAccountAssets,
-    groupAccountAssets?.groupMap,
-    groupAccountAssets?.singleAccountAssets,
-    search,
-    selectedChainFilterId,
-    usdCoinGeckoPrice,
-    userCurrencyPreference,
-  ]);
-
-  const hideSmallValueAssets = useMemo(() => {
-    if (isHideSmalValue) {
-      return computedAssetValues.filter((coin) => {
-        return gte(coin.dollarValue, '1');
-      });
-    }
-
-    return computedAssetValues;
-  }, [computedAssetValues, isHideSmalValue]);
-
-  const sortedAssets = useMemo(
-    () =>
-      hideSmallValueAssets.toSorted((a, b) => {
-        if (dashboardCoinSortKey === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {
-          return Number(minus(b.value, a.value));
-        }
-
-        if (dashboardCoinSortKey === DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC) {
-          return a.asset.symbol.localeCompare(b.asset.symbol);
-        }
-
-        return 0;
-      }),
-    [dashboardCoinSortKey, hideSmallValueAssets],
-  );
-
-  const filteredAssetsBySearch = useMemo(() => {
-    const filteredByChain = getFilteredAssetsByChainId(sortedAssets, selectedChainFilterId || undefined);
-
-    const mergeWithChainDefaultCoins = (assets: PortfolioCoinItem[]): PortfolioCoinItem[] => {
-      if (!selectedChainFilterId) return assets;
-
-      return removeDuplicates([...(chainDefaultCoins || []), ...assets], (a, b) => a.asset.id === b.asset.id);
-    };
-
-    const filterBySearchTerm = (assets: PortfolioCoinItem[]): PortfolioCoinItem[] => {
-      return assets.filter((asset) => {
-        const searchTargets = [asset.asset.symbol, asset.asset.id];
-        const lowerSearch = debouncedSearch.toLowerCase();
-
-        return searchTargets.some((target) => target.toLowerCase().includes(lowerSearch));
-      });
-    };
-
-    const hasValidSearch = !!search && debouncedSearch.length > 1;
-
-    if (hasValidSearch) {
-      const baseAssets = mergeWithChainDefaultCoins(filteredByChain);
-
-      return filterBySearchTerm(baseAssets);
-    }
-
-    return mergeWithChainDefaultCoins(filteredByChain);
-  }, [chainDefaultCoins, debouncedSearch, search, selectedChainFilterId, sortedAssets]);
-
-  const handleChange = (_: React.SyntheticEvent, newTabValue: number) => {
+  const handleTabChange = useCallback((_: React.SyntheticEvent, newTabValue: number) => {
     setTabValue(newTabValue);
-  };
-
-  useEffect(() => {
-    if (search.length > 1 || search.length === 0) {
-      scrollToTop();
-    }
-  }, [scrollToTop, search.length]);
+  }, []);
 
   return (
     <>
@@ -253,132 +39,23 @@ export default function Entry() {
           }}
         >
           <Container>
-            <PortFolio
-              selectedChainId={selectedChainFilterId || undefined}
-              accountAllAssetsForValueAggregate={filteredAssetsBySearch}
-              onChangeChaindId={(chainId) => {
-                updateExtensionStorageStore('selectedChainFilterId', chainId || null);
-              }}
-            />
+            <PortFolio />
 
             <StickyTabContainer>
-              <Tabs value={tabValue} onChange={handleChange} variant="fullWidth">
-                {tabLabels.map((item) => (
+              <Tabs value={tabValue} onChange={handleTabChange} variant="fullWidth">
+                {TAB_LABELS.map((item) => (
                   <Tab key={item} label={item} />
                 ))}
               </Tabs>
             </StickyTabContainer>
+
             <StyledTabPanel value={tabValue} index={0} data-is-active={tabValue === 0}>
-              <StickyTabPanelContentsContainer>
-                <FilterContaienr>
-                  <Search
-                    value={search}
-                    onChange={(event) => {
-                      setSearch(event.currentTarget.value);
-                    }}
-                    placeholder={t('pages.index.searchPlaceholder')}
-                    isPending={isDebouncing}
-                    onClickFilter={() => {
-                      setIsOpenSortBottomSheet(true);
-                    }}
-                    onClear={() => {
-                      setSearch('');
-                      cancel();
-                    }}
-                  />
-                </FilterContaienr>
-
-                <AdCarouselContainer>
-                  <AdBannerCarousel />
-                </AdCarouselContainer>
-                <ManageCryptoContainer>
-                  <CheckBoxTextButton
-                    isChecked={isHideSmalValue}
-                    onClick={() => {
-                      updateExtensionStorageStore('isHideSmalValue', !isHideSmalValue);
-                    }}
-                  >
-                    <Typography variant="b3_R">{t('pages.index.hideSmallBalance')}</Typography>
-                  </CheckBoxTextButton>
-                  <IconTextButton
-                    onClick={() => {
-                      navigate({
-                        to: ManageAssets.to,
-                      });
-                    }}
-                    leadingIcon={<PlusIcon />}
-                  >
-                    <MarginLeftTypography variant="b3_M">{t('pages.index.manageCrypto')}</MarginLeftTypography>
-                  </IconTextButton>
-                </ManageCryptoContainer>
-              </StickyTabPanelContentsContainer>
-              <CoinButtonWrapper>
-                {isLoading ? (
-                  <SkeletonCoinList />
-                ) : filteredAssetsBySearch.length > 0 ? (
-                  <VirtualizedList
-                    items={filteredAssetsBySearch}
-                    estimateSize={() => 60}
-                    renderItem={(coin, virtualItem) => {
-                      if (!coin) return null;
-
-                      const isGroupToken = gt(coin.counts || '0', '1');
-                      const destinationRoute = isGroupToken ? CoinOverview.to : CoinDetail.to;
-
-                      const resolvedSymbol = coin.asset.symbol + `${isTestnetChain(coin.chain.id) ? ' (Testnet)' : ''}`;
-                      return (
-                        <CoinWithMarketTrendButton
-                          key={getCoinId(coin.asset) + virtualItem.index}
-                          onClick={() => {
-                            navigate({
-                              to: destinationRoute,
-                              params: {
-                                coinId: getCoinId(coin.asset),
-                              },
-                            });
-                          }}
-                          fetchStatus={coin.fetchStatus?.balance}
-                          displayAmount={coin.totalDisplayAmount || '0'}
-                          symbol={resolvedSymbol}
-                          coinGeckoId={coin.asset.coinGeckoId}
-                          coinImageProps={{
-                            imageURL: coin.asset.image,
-                            isAggregatedCoin: gt(coin.counts || '0', '1'),
-                            badgeImageURL: isGroupToken ? undefined : coin.chain.image || undefined,
-                          }}
-                        />
-                      );
-                    }}
-                    overscan={5}
-                  />
-                ) : (
-                  <EmptyAssetContainer>
-                    <EmptyAsset icon={<NoListIcon />} title={t('pages.index.noTokens')} subTitle={t('pages.index.noTokensDescription')} />
-                  </EmptyAssetContainer>
-                )}
-              </CoinButtonWrapper>
+              <CryptoTab />
             </StyledTabPanel>
+
             <StyledTabPanel value={tabValue} index={1} data-is-active={tabValue === 1}>
-              <NFTList selectedChainId={selectedChainFilterId || undefined} />
+              <NFTList />
             </StyledTabPanel>
-            <SortBottomSheet
-              optionButtonProps={[
-                {
-                  sortKey: DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER,
-                  children: <Typography variant="b2_M">{t('pages.index.valueHighOrder')}</Typography>,
-                },
-                {
-                  sortKey: DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC,
-                  children: <Typography variant="b2_M">{t('pages.index.alphabeticalAsc')}</Typography>,
-                },
-              ]}
-              currentSortOption={dashboardCoinSortKey}
-              open={isOpenSortBottomSheet}
-              onClose={() => setIsOpenSortBottomSheet(false)}
-              onSelectSortOption={(val) => {
-                updateExtensionStorageStore('dashboardCoinSortKey', val as DashboardCoinSortKeyType);
-              }}
-            />
           </Container>
         </EdgeAligner>
       </BaseBody>

--- a/src/pages/-hooks/useCryptoAssets.ts
+++ b/src/pages/-hooks/useCryptoAssets.ts
@@ -1,21 +1,20 @@
 import { useEffect, useMemo } from 'react';
 
 import { CURRENCY_TYPE } from '@/constants/currency';
-import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
 import { useGroupAccountAssets } from '@/hooks/useGroupAccountAssets';
 import type { PortfolioCoinItem } from '@/pages/-entry';
 import type { DashboardCoinSortKeyType } from '@/types/sortKey';
-import { removeDuplicates } from '@/utils/array';
-import { getDefaultAssetsByChainId, getFilteredAssetsByChainId } from '@/utils/asset';
-import { gte, minus, plus, times, toDisplayDenomAmount } from '@/utils/numbers';
+import { removeDuplicates, sortByReference } from '@/utils/array';
+import { filterAssetsBySearch, getDefaultAssetsByChainId, getFilteredAssetsByChainId, sortAssetsByKey } from '@/utils/asset';
+import { gte, plus, times, toDisplayDenomAmount } from '@/utils/numbers';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 import { usePortfolioValueStore } from '@/zustand/hooks/usePortfolioValueStore';
 
 type UseCryptoAssetsParams = {
   search: string;
-  debouncedSearch: string;
+  isSearchEmpty: boolean;
 };
 
 type PriceData = Record<string, Record<string, number>>;
@@ -38,29 +37,12 @@ function applyPriceToAsset(
   };
 }
 
-function sortAssets(assets: PortfolioCoinItem[], sortKey: DashboardCoinSortKeyType): PortfolioCoinItem[] {
-  return assets.toSorted((a, b) => {
-    if (sortKey === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {
-      return Number(minus(b.value, a.value));
-    }
-    if (sortKey === DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC) {
-      return a.asset.symbol.localeCompare(b.asset.symbol);
-    }
-    return 0;
-  });
+function extractDisplayAmount(item: { totalBalance?: string; balance: string; asset: { decimals: number } }) {
+  const balance = item.totalBalance || item.balance;
+  return toDisplayDenomAmount(balance, item.asset.decimals) || '0';
 }
 
-function filterBySearch(assets: PortfolioCoinItem[], searchTerm: string): PortfolioCoinItem[] {
-  if (!searchTerm || searchTerm.length <= 1) return assets;
-
-  const lowerSearch = searchTerm.toLowerCase();
-  return assets.filter((asset) => {
-    const searchTargets = [asset.asset.symbol, asset.asset.id];
-    return searchTargets.some((target) => target.toLowerCase().includes(lowerSearch));
-  });
-}
-
-export function useCryptoAssets({ search, debouncedSearch }: UseCryptoAssetsParams) {
+export function useCryptoAssets({ search, isSearchEmpty }: UseCryptoAssetsParams) {
   const { data: accountAllAssets } = useAccountAllAssets({ filterByPreferAccountType: true });
   const { data: coinGeckoPrice, isLoading: isCoinGeckoPriceLoading } = useCoinGeckoPrice();
   const { data: usdCoinGeckoPrice, isLoading: isCoinGeckoPriceUSDLoading } = useCoinGeckoPrice('usd');
@@ -75,6 +57,8 @@ export function useCryptoAssets({ search, debouncedSearch }: UseCryptoAssetsPara
   const isFirstBalanceLoading = !groupAccountAssets?.singleAccountAssets.length && !groupAccountAssets?.groupAccountAssets.length;
   const isLoading = isFirstBalanceLoading || isGroupAssetsLoading || isCoinGeckoPriceLoading || isCoinGeckoPriceUSDLoading;
 
+  const isSearchActive = useMemo(() => search.length > 1, [search.length]);
+
   const chainDefaultCoinsBase = useMemo(
     () => getDefaultAssetsByChainId(accountAllAssets?.flatAccountAssets, selectedChainFilterId),
     [accountAllAssets?.flatAccountAssets, selectedChainFilterId],
@@ -84,61 +68,59 @@ export function useCryptoAssets({ search, debouncedSearch }: UseCryptoAssetsPara
     if (!groupAccountAssets) return [];
 
     const { groupAccountAssets: grouped, singleAccountAssets: singles, groupMap } = groupAccountAssets;
-    const isSearchOrFilterMode = (!!search && debouncedSearch.length > 1) || !!selectedChainFilterId;
+    const isSearchOrFilterMode = (!isSearchEmpty && isSearchActive) || !!selectedChainFilterId;
 
     if (isSearchOrFilterMode) {
       const ungroupedAssets = Object.values(groupMap)
         .flat()
-        .map((item) => {
-          const balance = 'totalBalance' in item ? item.totalBalance || '0' : item.balance;
-          return {
-            ...item,
-            counts: '1',
-            totalDisplayAmount: toDisplayDenomAmount(balance, item.asset.decimals),
-          };
-        });
+        .map((item) => ({
+          ...item,
+          counts: '1',
+          totalDisplayAmount: extractDisplayAmount(item),
+        }));
       return [...ungroupedAssets, ...singles];
     }
 
     return [...grouped, ...singles];
-  }, [groupAccountAssets, search, debouncedSearch.length, selectedChainFilterId]);
+  }, [groupAccountAssets, isSearchEmpty, isSearchActive, selectedChainFilterId]);
 
-  const assetsWithPrice = useMemo<PortfolioCoinItem[]>(() => {
-    return baseAssets.map((item) => {
-      const priceInfo = applyPriceToAsset(item, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
-      return { ...item, ...priceInfo } as PortfolioCoinItem;
-    });
-  }, [baseAssets, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference]);
+  const assetsWithPrice = useMemo<PortfolioCoinItem[]>(
+    () =>
+      baseAssets.map((item) => {
+        const priceInfo = applyPriceToAsset(item, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
+        return { ...item, ...priceInfo } as PortfolioCoinItem;
+      }),
+    [baseAssets, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference],
+  );
 
-  const filteredByValue = useMemo(() => {
-    if (!isHideSmalValue) return assetsWithPrice;
-    return assetsWithPrice.filter((coin) => gte(coin.dollarValue, '1'));
-  }, [assetsWithPrice, isHideSmalValue]);
-
-  const filteredAssets = useMemo(() => {
-    const chainFiltered = getFilteredAssetsByChainId(filteredByValue, selectedChainFilterId || undefined);
-
-    let merged = chainFiltered;
-    if (selectedChainFilterId && chainDefaultCoinsBase) {
-      const chainDefaultCoinsWithPrice = chainDefaultCoinsBase.map((item) => {
-        const balance = 'totalBalance' in item ? item.totalBalance || '0' : item.balance;
-        const totalDisplayAmount = toDisplayDenomAmount(balance, item.asset.decimals) || '0';
+  const chainDefaultCoinsWithPrice = useMemo(
+    () =>
+      chainDefaultCoinsBase?.map((item) => {
+        const totalDisplayAmount = extractDisplayAmount(item);
         const priceInfo = applyPriceToAsset({ ...item, totalDisplayAmount }, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
-        return {
-          ...item,
-          counts: '1',
-          totalDisplayAmount,
-          ...priceInfo,
-        } as PortfolioCoinItem;
-      });
+        return { ...item, counts: '1', totalDisplayAmount, ...priceInfo } as PortfolioCoinItem;
+      }),
+    [chainDefaultCoinsBase, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference],
+  );
 
-      merged = removeDuplicates([...chainDefaultCoinsWithPrice, ...chainFiltered], (a, b) => a.asset.id === b.asset.id);
-    }
+  const sortedAssets = useMemo(() => {
+    const assetsAboveMinValue = isHideSmalValue ? assetsWithPrice.filter((coin) => gte(coin.dollarValue, '1')) : assetsWithPrice;
 
-    return filterBySearch(merged, debouncedSearch);
-  }, [filteredByValue, selectedChainFilterId, chainDefaultCoinsBase, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference, debouncedSearch]);
+    const assetsByChain = getFilteredAssetsByChainId(assetsAboveMinValue, selectedChainFilterId || undefined);
 
-  const sortedAssets = useMemo(() => sortAssets(filteredAssets, dashboardCoinSortKey), [filteredAssets, dashboardCoinSortKey]);
+    const assetsWithDefaults =
+      selectedChainFilterId && chainDefaultCoinsWithPrice
+        ? removeDuplicates([...chainDefaultCoinsWithPrice, ...assetsByChain], (a, b) => a.uniqueCoinId === b.uniqueCoinId)
+        : assetsByChain;
+
+    const assetsMatchingSearch = filterAssetsBySearch(assetsWithDefaults, search, isSearchEmpty);
+
+    const assetsSortedByKey = sortAssetsByKey(assetsMatchingSearch, dashboardCoinSortKey as DashboardCoinSortKeyType);
+
+    return chainDefaultCoinsWithPrice && chainDefaultCoinsWithPrice?.length > 0
+      ? sortByReference(assetsSortedByKey, chainDefaultCoinsWithPrice, (a, b) => a.uniqueCoinId === b.uniqueCoinId)
+      : assetsSortedByKey;
+  }, [assetsWithPrice, isHideSmalValue, selectedChainFilterId, chainDefaultCoinsWithPrice, search, isSearchEmpty, dashboardCoinSortKey]);
 
   const totalValue = useMemo(() => sortedAssets.reduce((acc, cur) => plus(acc, cur.value), '0'), [sortedAssets]);
 

--- a/src/pages/-hooks/useCryptoAssets.ts
+++ b/src/pages/-hooks/useCryptoAssets.ts
@@ -5,7 +5,8 @@ import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
 import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
 import { useGroupAccountAssets } from '@/hooks/useGroupAccountAssets';
 import type { PortfolioCoinItem } from '@/pages/-entry';
-import type { DashboardCoinSortKeyType } from '@/types/sortKey';
+import type { SimplePrice } from '@/types/coinGecko';
+import type { CurrencyType } from '@/types/currency';
 import { removeDuplicates, sortByReference } from '@/utils/array';
 import { filterAssetsBySearch, getDefaultAssetsByChainId, getFilteredAssetsByChainId, sortAssetsByKey } from '@/utils/asset';
 import { gte, plus, times, toDisplayDenomAmount } from '@/utils/numbers';
@@ -17,13 +18,11 @@ type UseCryptoAssetsParams = {
   isSearchEmpty: boolean;
 };
 
-type PriceData = Record<string, Record<string, number>>;
-
 function applyPriceToAsset(
   asset: { totalDisplayAmount?: string; asset: { coinGeckoId?: string }; counts?: string },
-  coinGeckoPrice: PriceData | undefined,
-  usdCoinGeckoPrice: PriceData | undefined,
-  userCurrencyPreference: string,
+  userCurrencyPreference: CurrencyType,
+  coinGeckoPrice?: SimplePrice,
+  usdCoinGeckoPrice?: SimplePrice,
 ): { value: string; dollarValue: string } {
   const displayAmount = asset.totalDisplayAmount || '0';
   const coinGeckoId = asset.asset.coinGeckoId;
@@ -87,8 +86,8 @@ export function useCryptoAssets({ search, isSearchEmpty }: UseCryptoAssetsParams
   const assetsWithPrice = useMemo<PortfolioCoinItem[]>(
     () =>
       baseAssets.map((item) => {
-        const priceInfo = applyPriceToAsset(item, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
-        return { ...item, ...priceInfo } as PortfolioCoinItem;
+        const priceInfo = applyPriceToAsset(item, userCurrencyPreference, coinGeckoPrice, usdCoinGeckoPrice);
+        return { ...item, ...priceInfo };
       }),
     [baseAssets, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference],
   );
@@ -97,8 +96,8 @@ export function useCryptoAssets({ search, isSearchEmpty }: UseCryptoAssetsParams
     () =>
       chainDefaultCoinsBase?.map((item) => {
         const totalDisplayAmount = extractDisplayAmount(item);
-        const priceInfo = applyPriceToAsset({ ...item, totalDisplayAmount }, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
-        return { ...item, counts: '1', totalDisplayAmount, ...priceInfo } as PortfolioCoinItem;
+        const priceInfo = applyPriceToAsset({ ...item, totalDisplayAmount }, userCurrencyPreference, coinGeckoPrice, usdCoinGeckoPrice);
+        return { ...item, counts: '1', totalDisplayAmount, ...priceInfo };
       }),
     [chainDefaultCoinsBase, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference],
   );
@@ -115,7 +114,7 @@ export function useCryptoAssets({ search, isSearchEmpty }: UseCryptoAssetsParams
 
     const assetsMatchingSearch = filterAssetsBySearch(assetsWithDefaults, search, isSearchEmpty);
 
-    const assetsSortedByKey = sortAssetsByKey(assetsMatchingSearch, dashboardCoinSortKey as DashboardCoinSortKeyType);
+    const assetsSortedByKey = sortAssetsByKey(assetsMatchingSearch, dashboardCoinSortKey);
 
     return chainDefaultCoinsWithPrice && chainDefaultCoinsWithPrice?.length > 0
       ? sortByReference(assetsSortedByKey, chainDefaultCoinsWithPrice, (a, b) => a.uniqueCoinId === b.uniqueCoinId)

--- a/src/pages/-hooks/useCryptoAssets.ts
+++ b/src/pages/-hooks/useCryptoAssets.ts
@@ -1,0 +1,160 @@
+import { useEffect, useMemo } from 'react';
+
+import { CURRENCY_TYPE } from '@/constants/currency';
+import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
+import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
+import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
+import { useGroupAccountAssets } from '@/hooks/useGroupAccountAssets';
+import type { PortfolioCoinItem } from '@/pages/-entry';
+import type { DashboardCoinSortKeyType } from '@/types/sortKey';
+import { removeDuplicates } from '@/utils/array';
+import { getDefaultAssetsByChainId, getFilteredAssetsByChainId } from '@/utils/asset';
+import { gte, minus, plus, times, toDisplayDenomAmount } from '@/utils/numbers';
+import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
+import { usePortfolioValueStore } from '@/zustand/hooks/usePortfolioValueStore';
+
+type UseCryptoAssetsParams = {
+  search: string;
+  debouncedSearch: string;
+};
+
+type PriceData = Record<string, Record<string, number>>;
+
+function applyPriceToAsset(
+  asset: { totalDisplayAmount?: string; asset: { coinGeckoId?: string }; counts?: string },
+  coinGeckoPrice: PriceData | undefined,
+  usdCoinGeckoPrice: PriceData | undefined,
+  userCurrencyPreference: string,
+): { value: string; dollarValue: string } {
+  const displayAmount = asset.totalDisplayAmount || '0';
+  const coinGeckoId = asset.asset.coinGeckoId;
+
+  const coinPrice = (coinGeckoId && coinGeckoPrice?.[coinGeckoId]?.[userCurrencyPreference]) || 0;
+  const coinPriceInDollar = (coinGeckoId && usdCoinGeckoPrice?.[coinGeckoId]?.[CURRENCY_TYPE.USD]) || 0;
+
+  return {
+    value: times(displayAmount, coinPrice),
+    dollarValue: times(displayAmount, coinPriceInDollar),
+  };
+}
+
+function sortAssets(assets: PortfolioCoinItem[], sortKey: DashboardCoinSortKeyType): PortfolioCoinItem[] {
+  return assets.toSorted((a, b) => {
+    if (sortKey === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {
+      return Number(minus(b.value, a.value));
+    }
+    if (sortKey === DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC) {
+      return a.asset.symbol.localeCompare(b.asset.symbol);
+    }
+    return 0;
+  });
+}
+
+function filterBySearch(assets: PortfolioCoinItem[], searchTerm: string): PortfolioCoinItem[] {
+  if (!searchTerm || searchTerm.length <= 1) return assets;
+
+  const lowerSearch = searchTerm.toLowerCase();
+  return assets.filter((asset) => {
+    const searchTargets = [asset.asset.symbol, asset.asset.id];
+    return searchTargets.some((target) => target.toLowerCase().includes(lowerSearch));
+  });
+}
+
+export function useCryptoAssets({ search, debouncedSearch }: UseCryptoAssetsParams) {
+  const { data: accountAllAssets } = useAccountAllAssets({ filterByPreferAccountType: true });
+  const { data: coinGeckoPrice, isLoading: isCoinGeckoPriceLoading } = useCoinGeckoPrice();
+  const { data: usdCoinGeckoPrice, isLoading: isCoinGeckoPriceUSDLoading } = useCoinGeckoPrice('usd');
+
+  const dashboardCoinSortKey = useExtensionStorageStore((state) => state.dashboardCoinSortKey);
+  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
+  const isHideSmalValue = useExtensionStorageStore((state) => state.isHideSmalValue);
+  const selectedChainFilterId = useExtensionStorageStore((state) => state.selectedChainFilterId);
+
+  const { groupAccountAssets, isLoading: isGroupAssetsLoading } = useGroupAccountAssets();
+
+  const isFirstBalanceLoading = !groupAccountAssets?.singleAccountAssets.length && !groupAccountAssets?.groupAccountAssets.length;
+  const isLoading = isFirstBalanceLoading || isGroupAssetsLoading || isCoinGeckoPriceLoading || isCoinGeckoPriceUSDLoading;
+
+  const chainDefaultCoinsBase = useMemo(
+    () => getDefaultAssetsByChainId(accountAllAssets?.flatAccountAssets, selectedChainFilterId),
+    [accountAllAssets?.flatAccountAssets, selectedChainFilterId],
+  );
+
+  const baseAssets = useMemo(() => {
+    if (!groupAccountAssets) return [];
+
+    const { groupAccountAssets: grouped, singleAccountAssets: singles, groupMap } = groupAccountAssets;
+    const isSearchOrFilterMode = (!!search && debouncedSearch.length > 1) || !!selectedChainFilterId;
+
+    if (isSearchOrFilterMode) {
+      const ungroupedAssets = Object.values(groupMap)
+        .flat()
+        .map((item) => {
+          const balance = 'totalBalance' in item ? item.totalBalance || '0' : item.balance;
+          return {
+            ...item,
+            counts: '1',
+            totalDisplayAmount: toDisplayDenomAmount(balance, item.asset.decimals),
+          };
+        });
+      return [...ungroupedAssets, ...singles];
+    }
+
+    return [...grouped, ...singles];
+  }, [groupAccountAssets, search, debouncedSearch.length, selectedChainFilterId]);
+
+  const assetsWithPrice = useMemo<PortfolioCoinItem[]>(() => {
+    return baseAssets.map((item) => {
+      const priceInfo = applyPriceToAsset(item, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
+      return { ...item, ...priceInfo } as PortfolioCoinItem;
+    });
+  }, [baseAssets, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference]);
+
+  const filteredByValue = useMemo(() => {
+    if (!isHideSmalValue) return assetsWithPrice;
+    return assetsWithPrice.filter((coin) => gte(coin.dollarValue, '1'));
+  }, [assetsWithPrice, isHideSmalValue]);
+
+  const filteredAssets = useMemo(() => {
+    const chainFiltered = getFilteredAssetsByChainId(filteredByValue, selectedChainFilterId || undefined);
+
+    let merged = chainFiltered;
+    if (selectedChainFilterId && chainDefaultCoinsBase) {
+      const chainDefaultCoinsWithPrice = chainDefaultCoinsBase.map((item) => {
+        const balance = 'totalBalance' in item ? item.totalBalance || '0' : item.balance;
+        const totalDisplayAmount = toDisplayDenomAmount(balance, item.asset.decimals) || '0';
+        const priceInfo = applyPriceToAsset({ ...item, totalDisplayAmount }, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference);
+        return {
+          ...item,
+          counts: '1',
+          totalDisplayAmount,
+          ...priceInfo,
+        } as PortfolioCoinItem;
+      });
+
+      merged = removeDuplicates([...chainDefaultCoinsWithPrice, ...chainFiltered], (a, b) => a.asset.id === b.asset.id);
+    }
+
+    return filterBySearch(merged, debouncedSearch);
+  }, [filteredByValue, selectedChainFilterId, chainDefaultCoinsBase, coinGeckoPrice, usdCoinGeckoPrice, userCurrencyPreference, debouncedSearch]);
+
+  const sortedAssets = useMemo(() => sortAssets(filteredAssets, dashboardCoinSortKey), [filteredAssets, dashboardCoinSortKey]);
+
+  const totalValue = useMemo(() => sortedAssets.reduce((acc, cur) => plus(acc, cur.value), '0'), [sortedAssets]);
+
+  const hasAssets = sortedAssets.length > 0;
+
+  const setPortfolioValue = usePortfolioValueStore((state) => state.setPortfolioValue);
+
+  useEffect(() => {
+    setPortfolioValue(totalValue, hasAssets);
+  }, [totalValue, hasAssets, setPortfolioValue]);
+
+  return {
+    filteredAssetsBySearch: sortedAssets,
+    totalValue,
+    hasAssets,
+    isLoading,
+    selectedChainFilterId,
+  };
+}

--- a/src/pages/coin-overview/$coinId/-entry.tsx
+++ b/src/pages/coin-overview/$coinId/-entry.tsx
@@ -11,16 +11,16 @@ import IntersectionObserver from '@/components/common/IntersectionObserver';
 import CoinOverViewBox from '@/components/MainBox/CoinOverviewBox';
 import Search from '@/components/Search';
 import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
+import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
 import { useAutoBalanceRefresh } from '@/hooks/update/useAutoBalanceRefresh';
-import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
+import { useAssetPricing } from '@/hooks/useAssetPricing';
 import { useGroupAccountAssets } from '@/hooks/useGroupAccountAssets';
 import { Route as CoinDetail } from '@/pages/coin-detail/$coinId';
 import type { UniqueChainId } from '@/types/chain';
-import { getFilteredAssetsByChainId, getFilteredChainsByChainId, isStakeableAsset } from '@/utils/asset';
-import { minus, times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, getUniqueChainId, isMatchingUniqueChainId } from '@/utils/queryParamGenerator';
+import { filterAssetsBySearch, getFilteredAssetsByChainId, getFilteredChainsByChainId, isStakeableAsset, sortAssetsByKey } from '@/utils/asset';
+import { toDisplayDenomAmount } from '@/utils/numbers';
+import { getUniqueChainId, isMatchingUniqueChainId } from '@/utils/queryParamGenerator';
 import { shorterAddress } from '@/utils/string';
-import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import { CoinButtonWrapper, Container, FilterContaienr, StickyContentsContainer } from './-styled';
 
@@ -32,12 +32,10 @@ export default function Entry({ coinId }: EntryProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const { data: coinGeckoPrice } = useCoinGeckoPrice();
-  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
-
   const [search, setSearch] = useState('');
   const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
 
+  const isSearchEmpty = useMemo(() => search.length === 0, [search]);
   const isDebouncing = !!search && isPending();
 
   const [viewLimit, setViewLimit] = useState(30);
@@ -47,7 +45,7 @@ export default function Entry({ coinId }: EntryProps) {
   const { groupAccountAssets } = useGroupAccountAssets();
 
   const baseCoinList = useMemo(() => {
-    const selectedCoin = groupAccountAssets?.groupAccountAssets.find((item) => getCoinId(item.asset) === coinId);
+    const selectedCoin = groupAccountAssets?.groupAccountAssets.find(({ uniqueCoinId }) => uniqueCoinId === coinId);
 
     const selectedGroupMap = groupAccountAssets?.groupMap[selectedCoin?.asset.coinGeckoId || ''];
 
@@ -62,39 +60,16 @@ export default function Entry({ coinId }: EntryProps) {
     return resolvedGroupMap;
   }, [coinId, groupAccountAssets?.groupAccountAssets, groupAccountAssets?.groupMap]);
 
+  const chainFilteredList = useMemo(() => getFilteredAssetsByChainId(baseCoinList, currentSelectedChainId), [baseCoinList, currentSelectedChainId]);
+
+  const pricedAssets = useAssetPricing(chainFilteredList);
+
+  const sortedAssets = useMemo(() => sortAssetsByKey(pricedAssets, DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER), [pricedAssets]);
+
   const filteredAssetsBySearch = useMemo(() => {
-    const filteredByChain = getFilteredAssetsByChainId(baseCoinList, currentSelectedChainId);
-
-    const computedAssetValues = filteredByChain?.map((item) => {
-      const displayAmount = toDisplayDenomAmount(item.balance || '0', item.asset.decimals);
-
-      const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-
-      const value = times(displayAmount, coinPrice);
-
-      return {
-        ...item,
-        value,
-      };
-    });
-
-    const sortedAssets = computedAssetValues?.sort((a, b) => {
-      return Number(minus(b.value, a.value));
-    });
-
-    if (!!search && debouncedSearch.length > 1) {
-      return (
-        sortedAssets
-          ?.filter((asset) => {
-            const condition = [asset.asset.symbol, asset.asset.id];
-
-            return condition.some((item) => item.toLowerCase().indexOf(search.toLowerCase()) > -1);
-          })
-          .slice(0, viewLimit) || []
-      );
-    }
-    return sortedAssets?.slice(0, viewLimit) || [];
-  }, [baseCoinList, coinGeckoPrice, userCurrencyPreference, currentSelectedChainId, debouncedSearch.length, search, viewLimit]);
+    const filtered = filterAssetsBySearch(sortedAssets, debouncedSearch, isSearchEmpty);
+    return filtered.slice(0, viewLimit);
+  }, [sortedAssets, debouncedSearch, isSearchEmpty, viewLimit]);
 
   const chainList = useMemo(() => getFilteredChainsByChainId(baseCoinList), [baseCoinList]);
 
@@ -107,7 +82,7 @@ export default function Entry({ coinId }: EntryProps) {
     [chainList, currentSelectedChainId],
   );
 
-  const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
+  const isShowAssetId = useMemo(() => !!currentSelectedChain || (!!debouncedSearch && !isSearchEmpty), [currentSelectedChain, debouncedSearch, isSearchEmpty]);
 
   return (
     <BaseBody>
@@ -155,7 +130,7 @@ export default function Entry({ coinId }: EntryProps) {
 
               return (
                 <CoinWithChainNameButton
-                  key={getCoinId(item.asset)}
+                  key={item.uniqueCoinId}
                   displayAmount={displayAmount || '0'}
                   symbol={item.asset.symbol}
                   chainName={item.chain.name}
@@ -171,7 +146,7 @@ export default function Entry({ coinId }: EntryProps) {
                     navigate({
                       to: CoinDetail.to,
                       params: {
-                        coinId: getCoinId(item.asset),
+                        coinId: item.uniqueCoinId,
                       },
                     });
                   }}

--- a/src/pages/dapp-list/-components/DappDetailBottomSheet/index.tsx
+++ b/src/pages/dapp-list/-components/DappDetailBottomSheet/index.tsx
@@ -63,7 +63,8 @@ type DappDetailBottomSheetProps = Omit<React.ComponentProps<typeof StyledBottomS
 
 export default function DappDetailBottomSheet({ dappInfo, onClose, ...remainder }: DappDetailBottomSheetProps) {
   const { t } = useTranslation();
-  const { pinnedDappIds, updateExtensionStorageStore } = useExtensionStorageStore((state) => state);
+  const pinnedDappIds = useExtensionStorageStore((state) => state.pinnedDappIds);
+  const updateExtensionStorageStore = useExtensionStorageStore((state) => state.updateExtensionStorageStore);
 
   const { flatChainList } = useChainList();
 

--- a/src/pages/manage-assets/visibility/assets/-entry.tsx
+++ b/src/pages/manage-assets/visibility/assets/-entry.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebounce } from 'use-debounce';
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import { useNavigate } from '@tanstack/react-router';
 
 import AllNetworkButton from '@/components/AllNetworkButton';
@@ -17,24 +17,16 @@ import EmptyAsset from '@/components/EmptyAsset';
 import Search from '@/components/Search';
 import SortBottomSheet from '@/components/SortBottomSheet';
 import { useScroll } from '@/components/Wrapper/components/ScrollProvider';
-import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
 import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
-import { useCurrentCustomCW20Tokens } from '@/hooks/useCurrentCustomCW20Tokens';
-import { useCurrentCustomERC20Tokens } from '@/hooks/useCurrentCustomERC20Tokens';
-import { useCurrentHiddenAssetIds } from '@/hooks/useCurrentHiddenAssetIds';
-import { useCurrentVisibleAssetIds } from '@/hooks/useCurrentVisibleAssetIds';
-import { useCustomAssets } from '@/hooks/useCustomAssets';
+import { useAssetVisibilityToggle } from '@/hooks/useAssetVisibilityToggle';
+import { useProcessedAssets } from '@/hooks/useProcessedAssets';
 import { Route as ImportToken } from '@/pages/manage-assets/import/assets';
-import type { FlatAccountAssets } from '@/types/accountAssets';
 import type { UniqueChainId } from '@/types/chain';
 import type { CommonSortKeyType } from '@/types/sortKey';
-import { getFilteredAssetsByChainId, getFilteredChainsByChainId } from '@/utils/asset';
-import { gt, minus, times, toDisplayDenomAmount } from '@/utils/numbers';
-import { getCoinId, getCoinIdWithManual, isMatchingCoinId, isMatchingUniqueChainId, isSameCoin, parseCoinId } from '@/utils/queryParamGenerator';
-import { isEqualsIgnoringCase, shorterAddress } from '@/utils/string';
-import { toastError } from '@/utils/toast';
+import { getFilteredChainsByChainId } from '@/utils/asset';
+import { isMatchingUniqueChainId } from '@/utils/queryParamGenerator';
+import { shorterAddress } from '@/utils/string';
 import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import {
@@ -56,364 +48,53 @@ import AddIcon from '@/assets/images/icons/Add20.svg';
 import PlusIcon from '@/assets/images/icons/Plus12.svg';
 import RemoveIcon from '@/assets/images/icons/Remove20.svg';
 
-type FlatAccountAssetsWithValue = FlatAccountAssets & {
-  value: string;
-};
 
 export default function Entry() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-
   const { scrollToTop } = useScroll();
-  const { data: coinGeckoPrice } = useCoinGeckoPrice();
-  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
+
   const selectedChainFilterId = useExtensionStorageStore((state) => state.selectedChainFilterId);
-
-  const { currentHiddenAssetIds, hideAsset, showAsset } = useCurrentHiddenAssetIds();
-
-  const { currentVisibleAssetIds, removeVisibleAsset, addVisibleAsset } = useCurrentVisibleAssetIds();
-
-  const { customHiddenAssetIds, hideCustomAsset, showCustomAsset } = useCustomAssets();
-
-  const { currentCustomERC20Tokens, removeCustomERC20Token } = useCurrentCustomERC20Tokens();
-  const { currentCustomCW20Tokens, removeCustomCW20Token } = useCurrentCustomCW20Tokens();
-
-  const { data: currentAccountAllAssets } = useAccountAllAssets({
-    filterByPreferAccountType: true,
-  });
-
-  const { customAssets } = useCustomAssets();
-
-  const [tokenToDelete, setTokenToDelete] = useState<FlatAccountAssetsWithValue | undefined>();
 
   const [search, setSearch] = useState('');
   const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
+  const isSearchEmpty = useMemo(() => search.length === 0, [search.length]);
   const isDebouncing = !!search && isPending();
 
   const [isOpenSortBottomSheet, setIsOpenSortBottomSheet] = useState(false);
   const [sortOption, setSortOption] = useState<CommonSortKeyType>(DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER);
 
   const [userSelectedChainId, setUserSelectedChainId] = useState<UniqueChainId | undefined>();
+  const currentSelectedChainId = useMemo(() => selectedChainFilterId || userSelectedChainId, [selectedChainFilterId, userSelectedChainId]);
 
-  const currentSelectedChainId = useMemo(() => {
-    if (selectedChainFilterId) {
-      return selectedChainFilterId;
-    }
-
-    return userSelectedChainId;
-  }, [selectedChainFilterId, userSelectedChainId]);
-
-  const visibleAssetCoinIds = useMemo(() => currentVisibleAssetIds?.map((item) => getCoinIdWithManual(item)), [currentVisibleAssetIds]);
-
-  const [initVisibleAssetCoinIds, setInitVisibleAssetCoinIds] = useState<string[] | undefined>(undefined);
-
-  const hiddenAssetCoinIds = useMemo(() => currentHiddenAssetIds?.map((item) => getCoinIdWithManual(item)), [currentHiddenAssetIds]);
-
-  const [initHiddenAssetCoinIds, setInitHiddenAssetCoinIds] = useState<string[] | undefined>(undefined);
-
-  const hiddenCustomAssetCoinIds = useMemo(() => customHiddenAssetIds?.map((item) => getCoinIdWithManual(item)), [customHiddenAssetIds]);
-
-  const [initHiddenCustomAssetCoinIds, setInitHiddenCustomAssetCoinIds] = useState<string[] | undefined>(undefined);
-
+  const { data: currentAccountAllAssets } = useAccountAllAssets({ filterByPreferAccountType: true });
   const baseCoinList = useMemo(() => currentAccountAllAssets?.flatAccountAssets || [], [currentAccountAllAssets?.flatAccountAssets]);
 
   const chainList = useMemo(() => getFilteredChainsByChainId(baseCoinList), [baseCoinList]);
-
   const currentSelectedChain = useMemo(
     () => chainList.find((item) => isMatchingUniqueChainId(item, currentSelectedChainId)),
     [chainList, currentSelectedChainId],
   );
+  const isShowAssetId = useMemo(() => !!currentSelectedChain || (!!debouncedSearch && !isSearchEmpty), [currentSelectedChain, debouncedSearch, isSearchEmpty]);
 
-  const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
-
-  const computedAssetValues = useMemo<FlatAccountAssetsWithValue[]>(() => {
-    return (
-      baseCoinList?.map((item) => {
-        const displayAmount = toDisplayDenomAmount(item.balance, item.asset.decimals);
-
-        const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-
-        const value = times(displayAmount, coinPrice, 10);
-
-        return {
-          ...item,
-          value,
-        };
-      }) || []
-    );
-  }, [baseCoinList, coinGeckoPrice, userCurrencyPreference]);
-
-  const sortedAssets = useMemo(
-    () =>
-      computedAssetValues.sort((a, b) => {
-        if (sortOption === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {
-          return Number(minus(b.value, a.value));
-        }
-
-        if (sortOption === DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC) {
-          return a.asset.symbol.localeCompare(b.asset.symbol);
-        }
-
-        return 0;
-      }),
-    [computedAssetValues, sortOption],
-  );
-
-  const filteredCoinListWithChain = useMemo(() => getFilteredAssetsByChainId(sortedAssets, currentSelectedChainId), [currentSelectedChainId, sortedAssets]);
-
-  const filteredCoinListBySearch = useMemo(() => {
-    const filteredAssetsByChain = filteredCoinListWithChain;
-
-    const filteredAssetsBySearch = (() => {
-      if (!!search && debouncedSearch.length > 1) {
-        return (
-          filteredAssetsByChain.filter((asset) => {
-            const condition = [asset.asset.symbol, asset.asset.id];
-
-            return condition.some((item) => item.toLowerCase().indexOf(debouncedSearch.toLowerCase()) > -1);
-          }) || []
-        );
-      }
-      return filteredAssetsByChain;
-    })();
-
-    return filteredAssetsBySearch;
-  }, [debouncedSearch, filteredCoinListWithChain, search]);
-
-  const sortedCoinListByHidden = useMemo(() => {
-    const mergedHiddenCoinIds = [...(initHiddenAssetCoinIds || []), ...(initHiddenCustomAssetCoinIds || [])];
-
-    const visibleAssets = filteredCoinListBySearch.filter((item) => {
-      const isCustomERC20Token = currentCustomERC20Tokens.some((token) => isMatchingCoinId(token, getCoinId(item.asset)));
-      const isCustomCW20Token = currentCustomCW20Tokens.some((token) => isMatchingCoinId(token, getCoinId(item.asset)));
-
-      const isVisibleAsset = initVisibleAssetCoinIds?.includes(getCoinId(item.asset));
-
-      if (isCustomERC20Token || isCustomCW20Token || isVisibleAsset) {
-        return true;
-      }
-
-      const isHidden = mergedHiddenCoinIds?.includes(getCoinId(item.asset));
-      const isBalanceZero = item.balance === '0';
-
-      if (isHidden || isBalanceZero) {
-        return false;
-      }
-      return true;
-    });
-
-    const hiddenAssets = filteredCoinListBySearch.filter((item) => !visibleAssets.some((visibleAsset) => isSameCoin(visibleAsset.asset, item.asset)));
-
-    const displayAssets = [...visibleAssets, ...hiddenAssets];
-
-    return currentSelectedChainId
-      ? displayAssets.sort((a, b) => {
-          const denoms = a.chain.chainDefaultCoinDenoms ?? [];
-          const idxA = denoms.findIndex((d) => isEqualsIgnoringCase(d, a.asset.id));
-          const idxB = denoms.findIndex((d) => isEqualsIgnoringCase(d, b.asset.id));
-
-          return (idxA < 0 ? Number.MAX_SAFE_INTEGER : idxA) - (idxB < 0 ? Number.MAX_SAFE_INTEGER : idxB);
-        })
-      : displayAssets;
-  }, [
-    currentCustomCW20Tokens,
-    currentCustomERC20Tokens,
+  const { list: processedCoinList, visibleCount } = useProcessedAssets({
+    baseCoinList,
+    sortOption,
     currentSelectedChainId,
-    filteredCoinListBySearch,
-    initHiddenAssetCoinIds,
-    initHiddenCustomAssetCoinIds,
-    initVisibleAssetCoinIds,
-  ]);
+    search: debouncedSearch,
+    isSearchEmpty,
+  });
 
-  const finalCoinList = useMemo(
-    () =>
-      sortedCoinListByHidden.map((coin) => {
-        const currentCoinId = getCoinId(coin.asset);
+  const { handleToggleVisibility, deleteConfirmState } = useAssetVisibilityToggle({ isLastVisible: visibleCount === 1 });
 
-        const currentCustomTokens = [...currentCustomERC20Tokens, ...currentCustomCW20Tokens];
-        const customToken = currentCustomTokens.find((item) => isMatchingCoinId(item, currentCoinId));
 
-        const isHiddenManagedAsset = hiddenAssetCoinIds?.includes(currentCoinId);
-        const isHiddenCustomAsset = hiddenCustomAssetCoinIds?.includes(currentCoinId);
-
-        const isCustomAsset = customAssets.some((item) => isMatchingCoinId(item, currentCoinId));
-
-        const isHiddenAsset = isCustomAsset ? isHiddenCustomAsset : isHiddenManagedAsset;
-        const isBalanceZero = coin.balance === '0';
-
-        const isVisibleAsset = visibleAssetCoinIds?.includes(currentCoinId);
-
-        const isHiddenState = (() => {
-          if (customToken || isVisibleAsset) {
-            return false;
-          }
-
-          if (isHiddenAsset || isBalanceZero) {
-            return true;
-          }
-          return false;
-        })();
-        const displayAmount = toDisplayDenomAmount(coin.balance, coin.asset.decimals);
-
-        const resolvedAssetId =
-          coin.chain.mainAssetDenom === coin.asset.id || coin.asset.id === NATIVE_EVM_COIN_ADDRESS
-            ? coin.asset.description
-            : coin.asset.id.length > 15
-              ? shorterAddress(coin.asset.id, 16)
-              : coin.asset.id;
-        return {
-          ...coin,
-          isHiddenState,
-          displayAmount,
-          resolvedAssetId,
-          isBalanceZero,
-          isCustomToken: !!customToken,
-        };
-      }),
-    [
-      currentCustomCW20Tokens,
-      currentCustomERC20Tokens,
-      customAssets,
-      hiddenAssetCoinIds,
-      hiddenCustomAssetCoinIds,
-      sortedCoinListByHidden,
-      visibleAssetCoinIds,
-    ],
-  );
-
-  const isLastStanding = useMemo(
-    () =>
-      baseCoinList
-        .filter((item) => {
-          const mergedHiddenCoinIds = [...hiddenAssetCoinIds, ...hiddenCustomAssetCoinIds];
-          return !mergedHiddenCoinIds?.includes(getCoinId(item.asset));
-        })
-        .filter((item) => {
-          const isVisibleState = (() => {
-            const isBalance = gt(item.balance, '0');
-            const isVisble = visibleAssetCoinIds?.includes(getCoinId(item.asset));
-
-            return isBalance || isVisble;
-          })();
-
-          return isVisibleState;
-        }).length === 1,
-    [baseCoinList, hiddenAssetCoinIds, hiddenCustomAssetCoinIds, visibleAssetCoinIds],
-  );
-
-  const handleAssetVisibility = async (assetId: string, isBalanceZero: boolean) => {
-    const isCustomERC20Token = currentCustomERC20Tokens.some((item) => isMatchingCoinId(item, assetId));
-    const isCustomCW20Token = currentCustomCW20Tokens.some((item) => isMatchingCoinId(item, assetId));
-
-    const isCustomAsset = customAssets.some((item) => isMatchingCoinId(item, assetId));
-
-    const isHiddenManagedAsset = hiddenAssetCoinIds?.includes(assetId);
-
-    const isHiddenCustomAsset = hiddenCustomAssetCoinIds?.includes(assetId);
-
-    const isHiddenAsset = isCustomAsset ? isHiddenCustomAsset : isHiddenManagedAsset;
-
-    const isVisibleAsset = visibleAssetCoinIds?.includes(assetId);
-
-    const isHiddenState = (() => {
-      if (isCustomCW20Token || isCustomERC20Token || isVisibleAsset) {
-        return false;
-      }
-
-      if (isHiddenAsset || isBalanceZero) {
-        return true;
-      }
-      return false;
-    })();
-
-    if (isCustomERC20Token) {
-      await removeCustomERC20Token(assetId);
-      return;
-    }
-
-    if (isCustomCW20Token) {
-      await removeCustomCW20Token(assetId);
-      return;
-    }
-
-    if (isCustomAsset) {
-      const isHiddenCustomAsset = hiddenCustomAssetCoinIds?.includes(assetId);
-
-      if (isHiddenState) {
-        if (isHiddenCustomAsset) {
-          await showCustomAsset(parseCoinId(assetId));
-          if (isBalanceZero) {
-            await addVisibleAsset(parseCoinId(assetId));
-          }
-        } else {
-          await addVisibleAsset(parseCoinId(assetId));
-        }
-      } else {
-        if (isLastStanding) {
-          toastError(t('pages.manage-assets.visibility.assets.entry.lastStandingError'));
-          return;
-        }
-
-        if (isVisibleAsset) {
-          await removeVisibleAsset(parseCoinId(assetId));
-        }
-
-        if (!isBalanceZero) {
-          await hideCustomAsset(parseCoinId(assetId));
-        }
-        return;
-      }
-    }
-
-    if (isHiddenState) {
-      if (isHiddenManagedAsset) {
-        await showAsset(parseCoinId(assetId));
-
-        if (isBalanceZero) {
-          await addVisibleAsset(parseCoinId(assetId));
-        }
-      } else {
-        await addVisibleAsset(parseCoinId(assetId));
-      }
-    } else {
-      if (isLastStanding) {
-        toastError(t('pages.manage-assets.visibility.assets.entry.lastStandingError'));
-        return;
-      }
-
-      if (isVisibleAsset) {
-        await removeVisibleAsset(parseCoinId(assetId));
-      }
-
-      if (!isBalanceZero) {
-        await hideAsset(parseCoinId(assetId));
-      }
-    }
-  };
+  const shouldScrollToTop = search.length !== 1;
 
   useEffect(() => {
-    if (initVisibleAssetCoinIds === undefined && currentVisibleAssetIds?.length > 0) {
-      setInitVisibleAssetCoinIds(currentVisibleAssetIds.map((item) => getCoinIdWithManual(item)));
-    }
-  }, [currentVisibleAssetIds, initVisibleAssetCoinIds]);
-
-  useEffect(() => {
-    if (initHiddenAssetCoinIds === undefined && currentHiddenAssetIds?.length > 0) {
-      setInitHiddenAssetCoinIds(currentHiddenAssetIds.map((item) => getCoinIdWithManual(item)));
-    }
-  }, [currentHiddenAssetIds, initHiddenAssetCoinIds]);
-
-  useEffect(() => {
-    if (initHiddenCustomAssetCoinIds === undefined && customHiddenAssetIds?.length > 0) {
-      setInitHiddenCustomAssetCoinIds(customHiddenAssetIds.map((item) => getCoinIdWithManual(item)));
-    }
-  }, [customHiddenAssetIds, initHiddenCustomAssetCoinIds]);
-
-  useEffect(() => {
-    if (search.length > 1 || search.length === 0 || currentSelectedChainId) {
+    if (shouldScrollToTop || currentSelectedChainId) {
       scrollToTop();
     }
-  }, [scrollToTop, search.length, currentSelectedChainId]);
+  }, [scrollToTop, shouldScrollToTop, currentSelectedChainId]);
 
   return (
     <>
@@ -429,14 +110,14 @@ export default function Entry() {
             <StickyContainer>
               <Search
                 value={search}
-                onChange={(event) => {
-                  setSearch(event.currentTarget.value);
-                }}
+                onChange={(e) => setSearch(e.currentTarget.value)}
                 isPending={isDebouncing}
-                disableFilter
                 onClear={() => {
                   setSearch('');
                   cancel();
+                }}
+                onClickFilter={() => {
+                  setIsOpenSortBottomSheet(true);
                 }}
               />
 
@@ -445,17 +126,11 @@ export default function Entry() {
                   currentChainId={currentSelectedChainId}
                   chainList={chainList}
                   disabled={!!selectedChainFilterId}
-                  selectChainOption={(id) => {
-                    setUserSelectedChainId(id);
-                  }}
+                  selectChainOption={(id) => setUserSelectedChainId(id)}
                 />
 
                 <IconTextButton
-                  onClick={() => {
-                    navigate({
-                      to: ImportToken.to,
-                    });
-                  }}
+                  onClick={() => navigate({ to: ImportToken.to })}
                   leadingIcon={
                     <PurpleContainer>
                       <PlusIcon />
@@ -468,49 +143,30 @@ export default function Entry() {
                 </IconTextButton>
               </RowContainer>
             </StickyContainer>
-            {sortedCoinListByHidden && sortedCoinListByHidden.length > 0 ? (
+
+            {processedCoinList.length > 0 ? (
               <CoinButtonWrapper>
                 {!isDebouncing && (
                   <VirtualizedList
-                    items={finalCoinList}
+                    items={processedCoinList}
                     estimateSize={() => 60}
-                    renderItem={(coin) => {
-                      return (
-                        <>
-                          <CoinWithChainNameButton
-                            key={getCoinId(coin.asset).concat(coin.chain.id).concat(String(coin.chain.chainId))}
-                            displayAmount={coin.displayAmount}
-                            symbol={coin.asset.symbol}
-                            chainName={coin.chain.name}
-                            assetId={coin.resolvedAssetId}
-                            coinGeckoId={coin.asset.coinGeckoId}
-                            displayAssetId={isShowAssetId}
-                            coinImageProps={{
-                              imageURL: coin.asset.image,
-                              badgeImageURL: coin.chain.image || '',
-                            }}
-                            rightComponent={
-                              coin.isHiddenState ? (
-                                <IconContainer>
-                                  <AddIcon />
-                                </IconContainer>
-                              ) : (
-                                <IconContainer>
-                                  <RemoveIcon />
-                                </IconContainer>
-                              )
-                            }
-                            onClick={() => {
-                              if (coin.isCustomToken) {
-                                setTokenToDelete(coin);
-                              } else {
-                                handleAssetVisibility(getCoinId(coin.asset), coin.isBalanceZero);
-                              }
-                            }}
-                          />
-                        </>
-                      );
-                    }}
+                    renderItem={(coin) => (
+                      <CoinWithChainNameButton
+                        key={coin.uniqueCoinId}
+                        displayAmount={coin.displayAmount}
+                        symbol={coin.asset.symbol}
+                        chainName={coin.chain.name}
+                        assetId={coin.resolvedAssetId}
+                        coinGeckoId={coin.asset.coinGeckoId}
+                        displayAssetId={isShowAssetId}
+                        coinImageProps={{
+                          imageURL: coin.asset.image,
+                          badgeImageURL: coin.chain.image || '',
+                        }}
+                        rightComponent={<IconContainer>{coin.isHiddenState ? <AddIcon /> : <RemoveIcon />}</IconContainer>}
+                        onClick={() => handleToggleVisibility(coin)}
+                      />
+                    )}
                     overscan={5}
                   />
                 )}
@@ -526,6 +182,7 @@ export default function Entry() {
           </Container>
         </EdgeAligner>
       </BaseBody>
+
       <SortBottomSheet
         optionButtonProps={[
           {
@@ -537,34 +194,30 @@ export default function Entry() {
             children: <Typography variant="b2_M">{t('pages.manage-assets.visibility.assets.entry.alphabeticalAsc')}</Typography>,
           },
         ]}
-        currentSortOption={DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER}
+        currentSortOption={sortOption}
         open={isOpenSortBottomSheet}
         onClose={() => setIsOpenSortBottomSheet(false)}
-        onSelectSortOption={(val) => {
-          setSortOption(val);
-        }}
+        onSelectSortOption={(val: CommonSortKeyType) => setSortOption(val)}
       />
+
       <DeleteConfirmBottomSheet
-        open={!!tokenToDelete?.asset}
-        onClose={() => setTokenToDelete(undefined)}
+        open={deleteConfirmState.isOpen}
+        onClose={deleteConfirmState.onClose}
         contents={
           <CoinContainer>
-            <CoinImage imageURL={tokenToDelete?.asset.image} badgeImageURL={tokenToDelete?.chain.image || undefined} />
+            <CoinImage imageURL={deleteConfirmState.token?.asset.image} badgeImageURL={deleteConfirmState.token?.chain.image || undefined} />
             <CoinSymbolContainer>
-              <Base1300Text variant="b1_B">{tokenToDelete?.asset.symbol}</Base1300Text>
+              <Base1300Text variant="b1_B">{deleteConfirmState.token?.asset.symbol}</Base1300Text>
               <CoinIdContainer>
                 <Base1000Text variant="b4_R">{t('pages.manage-assets.visibility.assets.entry.contract')}</Base1000Text>
                 &nbsp;
-                <Base1000Text variant="b3_M">{shorterAddress(tokenToDelete?.asset.id, 16)}</Base1000Text>
+                <Base1000Text variant="b3_M">{shorterAddress(deleteConfirmState.token?.asset.id, 16)}</Base1000Text>
               </CoinIdContainer>
             </CoinSymbolContainer>
           </CoinContainer>
         }
         descriptionText={t('pages.manage-assets.visibility.assets.entry.deleteDescription')}
-        onClickConfirm={() => {
-          handleAssetVisibility(tokenToDelete?.asset ? getCoinId(tokenToDelete?.asset) : '', tokenToDelete?.balance === '0');
-          setTokenToDelete(undefined);
-        }}
+        onClickConfirm={deleteConfirmState.onConfirm}
       />
     </>
   );

--- a/src/pages/wallet/send/chain/$chainId/-components/CoinSelectWithChainId/index.tsx
+++ b/src/pages/wallet/send/chain/$chainId/-components/CoinSelectWithChainId/index.tsx
@@ -57,7 +57,7 @@ export default function CoinSelectWithChainId({
   const currentSelectedChain = useMemo(() => flatChainList?.find((chain) => isMatchingUniqueChainId(chain, chainId)), [chainId, flatChainList]);
   const baseChainList = currentSelectedChain && [currentSelectedChain];
 
-  const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
+  const isShowAssetId = useMemo(() => !!currentSelectedChain || (!!debouncedSearch && !isSearchEmpty), [currentSelectedChain, debouncedSearch, isSearchEmpty]);
 
   const filteredCoinList = useMemo(() => filterAssetsBySearch(coinList, debouncedSearch, isSearchEmpty), [coinList, debouncedSearch, isSearchEmpty]);
 

--- a/src/pages/wallet/send/chain/$chainId/-components/CoinSelectWithChainId/index.tsx
+++ b/src/pages/wallet/send/chain/$chainId/-components/CoinSelectWithChainId/index.tsx
@@ -49,6 +49,7 @@ export default function CoinSelectWithChainId({
   const [search, setSearch] = useState('');
   const [debouncedSearch, { cancel, isPending }] = useDebounce(search, 300);
 
+  const isSearchEmpty = useMemo(() => search.length === 0, [search.length]);
   const isDebouncing = !!search && isPending();
 
   const [isOpenSortBottomSheet, setIsOpenSortBottomSheet] = useState(false);
@@ -58,7 +59,7 @@ export default function CoinSelectWithChainId({
 
   const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
 
-  const filteredCoinList = useMemo(() => filterAssetsBySearch(coinList, search, debouncedSearch), [coinList, debouncedSearch, search]);
+  const filteredCoinList = useMemo(() => filterAssetsBySearch(coinList, debouncedSearch, isSearchEmpty), [coinList, debouncedSearch, isSearchEmpty]);
 
   useEffect(() => {
     if (search.length > 1 || search.length === 0) {

--- a/src/pages/wallet/send/chain/$chainId/-components/CoinSelectWithChainId/index.tsx
+++ b/src/pages/wallet/send/chain/$chainId/-components/CoinSelectWithChainId/index.tsx
@@ -15,7 +15,7 @@ import { useChainList } from '@/hooks/useChainList';
 import type { FlatAccountAssets } from '@/types/accountAssets';
 import type { UniqueChainId } from '@/types/chain';
 import type { CommonSortKeyType } from '@/types/sortKey';
-import { isStakeableAsset } from '@/utils/asset';
+import { filterAssetsBySearch, isStakeableAsset } from '@/utils/asset';
 import { isTestnetChain } from '@/utils/chain';
 import { toDisplayDenomAmount } from '@/utils/numbers';
 import { getCoinId, isMatchingUniqueChainId } from '@/utils/queryParamGenerator';
@@ -58,18 +58,7 @@ export default function CoinSelectWithChainId({
 
   const isShowAssetId = useMemo(() => !!currentSelectedChain || !!debouncedSearch, [currentSelectedChain, debouncedSearch]);
 
-  const filteredCoinList = useMemo(() => {
-    if (!!search && debouncedSearch.length > 1) {
-      return (
-        coinList.filter((asset) => {
-          const condition = [asset.asset.symbol, asset.asset.id];
-
-          return condition.some((item) => item.toLowerCase().indexOf(debouncedSearch.toLowerCase()) > -1);
-        }) || []
-      );
-    }
-    return coinList;
-  }, [coinList, debouncedSearch, search]);
+  const filteredCoinList = useMemo(() => filterAssetsBySearch(coinList, search, debouncedSearch), [coinList, debouncedSearch, search]);
 
   useEffect(() => {
     if (search.length > 1 || search.length === 0) {

--- a/src/pages/wallet/send/chain/$chainId/-entry.tsx
+++ b/src/pages/wallet/send/chain/$chainId/-entry.tsx
@@ -7,22 +7,16 @@ import EthermintSendBottomSheet from '@/components/EthermintSendBottomSheet';
 import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
 import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
 import { useAccountAllAssets } from '@/hooks/useAccountAllAssets';
-import { useCoinGeckoPrice } from '@/hooks/useCoinGeckoPrice';
+import { useAssetPricing } from '@/hooks/useAssetPricing';
 import { Route as Send } from '@/pages/wallet/send/$coinId';
-import type { FlatAccountAssets } from '@/types/accountAssets';
 import type { UniqueChainId } from '@/types/chain';
 import type { CommonSortKeyType } from '@/types/sortKey';
-import { getDefaultAssets, getFilteredAssetsByChainId, isStakeableAsset } from '@/utils/asset';
-import { minus, times, toDisplayDenomAmount } from '@/utils/numbers';
+import { removeDuplicates, sortByReference } from '@/utils/array';
+import { getDefaultAssetsByChainId, getFilteredAssetsByChainId, getStakeableBalance, sortAssetsByKey } from '@/utils/asset';
 import { getCoinId, isMatchingCoinId } from '@/utils/queryParamGenerator';
 import { isEqualsIgnoringCase } from '@/utils/string';
-import { useExtensionStorageStore } from '@/zustand/hooks/useExtensionStorageStore';
 
 import CoinSelectWithChainId from './-components/CoinSelectWithChainId';
-
-type CoinSelectItem = FlatAccountAssets & {
-  value: string;
-};
 
 type EntryProps = {
   chainId: UniqueChainId;
@@ -44,8 +38,6 @@ export default function Entry({ chainId }: EntryProps) {
     disableDupeEthermint: true,
   });
 
-  const { data: coinGeckoPrice } = useCoinGeckoPrice();
-  const userCurrencyPreference = useExtensionStorageStore((state) => state.userCurrencyPreference);
   const [isOpenBottomSheet, setIsOpenBottomSheet] = useState(false);
 
   const [selectedEVMCoinId, setSelectedEVMCoinId] = useState('');
@@ -54,85 +46,38 @@ export default function Entry({ chainId }: EntryProps) {
   const [selectedCoinAccountPrefix, setSelectedCoinAccountPrefix] = useState('');
   const [sortOption, setSortOption] = useState<CommonSortKeyType>(DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER);
 
-  const chainFilteredAllCoins = getFilteredAssetsByChainId(filteredAccountAssets?.flatAccountAssets, chainId);
+  const chainFilteredAllCoins = useMemo(
+    () => getFilteredAssetsByChainId(filteredAccountAssets?.flatAccountAssets, chainId),
+    [chainId, filteredAccountAssets?.flatAccountAssets],
+  );
+  const chainDefaultCoins = useMemo(
+    () => getDefaultAssetsByChainId(filterOnlyDupeEthermintAccountAssets?.flatAccountAssets, chainId),
+    [chainId, filterOnlyDupeEthermintAccountAssets?.flatAccountAssets],
+  );
 
-  const chainDefaultCoins = useMemo<CoinSelectItem[] | undefined>(() => {
-    const chainFilteredCoins = getFilteredAssetsByChainId(filterOnlyDupeEthermintAccountAssets?.flatAccountAssets, chainId);
+  const pricedChainAssets = useAssetPricing(chainFilteredAllCoins, {
+    getBalance: getStakeableBalance,
+  });
 
-    const chainDefaultCoins = getDefaultAssets(chainFilteredCoins)
-      ?.slice()
-      .sort((a, b) => {
-        const denoms = a.chain.chainDefaultCoinDenoms ?? [];
-        const idxA = denoms.findIndex((d) => isEqualsIgnoringCase(d, a.asset.id));
-        const idxB = denoms.findIndex((d) => isEqualsIgnoringCase(d, b.asset.id));
+  const sortedAssets = useMemo(() => sortAssetsByKey(pricedChainAssets, sortOption), [pricedChainAssets, sortOption]);
 
-        return (idxA < 0 ? Number.MAX_SAFE_INTEGER : idxA) - (idxB < 0 ? Number.MAX_SAFE_INTEGER : idxB);
-      });
+  const pricedDefaultCoins = useAssetPricing(chainDefaultCoins, {
+    getBalance: getStakeableBalance,
+  });
 
-    if (!chainDefaultCoins || chainDefaultCoins?.length === 0) return undefined;
-
-    return chainDefaultCoins.map((item) => {
-      const balance = isStakeableAsset(item) ? item.totalBalance || '0' : item.balance;
-      const totalDisplayAmount = toDisplayDenomAmount(balance, item.asset.decimals) || '0';
-
-      const coinPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-
-      const value = times(totalDisplayAmount, coinPrice);
-      return {
-        ...item,
-        totalDisplayAmount,
-        value,
-      };
-    });
-  }, [filterOnlyDupeEthermintAccountAssets?.flatAccountAssets, chainId, coinGeckoPrice, userCurrencyPreference]);
-
-  const computedAssetValues = useMemo<CoinSelectItem[]>(() => {
-    return (
-      chainFilteredAllCoins?.map((item) => {
-        const balance = isStakeableAsset(item) ? item.totalBalance || item.balance || '0' : item.balance;
-
-        const displayAmount = toDisplayDenomAmount(balance, item.asset.decimals);
-
-        const chainPrice = (item.asset.coinGeckoId && coinGeckoPrice?.[item.asset.coinGeckoId]?.[userCurrencyPreference]) || 0;
-
-        const value = times(displayAmount, chainPrice);
-
-        return {
-          ...item,
-          value,
-        };
-      }) || []
-    );
-  }, [chainFilteredAllCoins, coinGeckoPrice, userCurrencyPreference]);
-
-  const sortedAssets = useMemo(() => {
-    const sortedValues = [...computedAssetValues].sort((a, b) => {
-      if (sortOption === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {
-        return Number(minus(b.value, a.value));
-      }
-
-      if (sortOption === DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC) {
-        return a.asset.symbol.localeCompare(b.asset.symbol);
-      }
-
-      return 0;
-    });
-
-    return sortedValues;
-  }, [computedAssetValues, sortOption]);
-
-  const filteredAssetsBySearch = useMemo(() => {
-    return [...(chainDefaultCoins || []), ...sortedAssets].reduce((acc: CoinSelectItem[], item) => {
-      if (!acc.some((existing) => isEqualsIgnoringCase(existing.asset.id, item.asset.id))) {
-        acc.push(item as CoinSelectItem);
-      }
-      return acc;
-    }, []);
-  }, [chainDefaultCoins, sortedAssets]);
+  const mergedCoinList = useMemo(
+    () =>
+      sortByReference(
+        removeDuplicates([...pricedDefaultCoins, ...sortedAssets], (a, b) => isEqualsIgnoringCase(a.asset.id, b.asset.id)),
+        pricedDefaultCoins,
+        (a, b) => isEqualsIgnoringCase(a.asset.id, b.asset.id),
+      ),
+    [pricedDefaultCoins, sortedAssets],
+  );
 
   const handleOnClickCoin = useCallback(
     (coinId: string) => {
-      const currentCoin = filteredAssetsBySearch.find(({ asset }) => isMatchingCoinId(asset, coinId));
+      const currentCoin = mergedCoinList.find(({ asset }) => isMatchingCoinId(asset, coinId));
 
       const cosmosStyleEthermintCoin = (() => {
         const isEthermint = currentCoin?.chain.chainType === 'evm' && currentCoin.chain.isCosmos;
@@ -168,7 +113,7 @@ export default function Entry({ chainId }: EntryProps) {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [notFilteredAccountAssets?.cosmosAccountAssets, filteredAssetsBySearch],
+    [notFilteredAccountAssets?.cosmosAccountAssets, mergedCoinList],
   );
 
   const hanldeOnEthermintSend = useCallback(
@@ -195,7 +140,7 @@ export default function Entry({ chainId }: EntryProps) {
       <EdgeAligner>
         <CoinSelectWithChainId
           chainId={chainId}
-          coinList={filteredAssetsBySearch}
+          coinList={mergedCoinList}
           sortOption={sortOption}
           onSelectCoin={handleOnClickCoin}
           onSelectSortOption={(newSortOption) => {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -18,6 +18,7 @@ import type {
   SolanaAsset,
   SolanaSpltokenAsset,
   SuiAsset,
+  UniqueCoinId,
 } from './asset';
 import type { BitcoinBalance } from './bitcoin/balance';
 import type {
@@ -34,6 +35,7 @@ import type {
   IotaChain,
   SolanaChain,
   SuiChain,
+  UniqueChainId,
 } from './chain';
 import type { AuthAccountsPayload } from './cosmos/account';
 import type { CosmosBalance } from './cosmos/api';
@@ -284,7 +286,11 @@ export interface AccountAddressBalanceGrc20 {
   balances: Grc20Balance[];
 }
 
-export interface AccountCosmosAsset {
+export interface AssetIdentifiers {
+  uniqueCoinId: UniqueCoinId;
+  uniqueChainId: UniqueChainId;
+}
+export interface AccountCosmosAsset extends AssetIdentifiers {
   chain: CosmosChain;
   asset: CosmosAsset;
   address: AccountAddress;
@@ -299,7 +305,7 @@ export interface AccountCosmosAsset {
   lastUpdatedAtMs?: number | null;
   fetchStatus?: AccountCosmosAssetFetchStatus;
 }
-export interface AccountCustomCosmosAsset {
+export interface AccountCustomCosmosAsset extends AssetIdentifiers {
   chain: CustomCosmosChain;
   asset: CustomCosmosAsset;
   address: AccountAddress;
@@ -308,7 +314,7 @@ export interface AccountCustomCosmosAsset {
   fetchStatus?: AccountCosmosAssetFetchStatus;
 }
 
-export interface AccountCw20Asset {
+export interface AccountCw20Asset extends AssetIdentifiers {
   chain: CosmosChain;
   asset: CosmosCw20Asset;
   address: AccountAddress;
@@ -324,7 +330,7 @@ export interface AccountEVMAssetFetchStatus extends AssetFetchStatus {
   commission?: RequestStatus;
 }
 
-export interface AccountEvmAsset {
+export interface AccountEvmAsset extends AssetIdentifiers {
   chain: EvmChain;
   asset: EvmAsset;
   address: AccountAddress;
@@ -338,7 +344,7 @@ export interface AccountEvmAsset {
   fetchStatus?: AccountEVMAssetFetchStatus;
 }
 
-export interface AccountCustomEvmAsset {
+export interface AccountCustomEvmAsset extends AssetIdentifiers {
   chain: CustomEvmChain;
   asset: EvmAsset;
   address: AccountAddress;
@@ -347,7 +353,7 @@ export interface AccountCustomEvmAsset {
   fetchStatus?: AssetFetchStatus;
 }
 
-export interface AccountErc20Asset {
+export interface AccountErc20Asset extends AssetIdentifiers {
   chain: EvmChain;
   asset: EvmErc20Asset;
   address: AccountAddress;
@@ -355,7 +361,7 @@ export interface AccountErc20Asset {
   lastUpdatedAtMs?: number | null;
   fetchStatus?: AssetFetchStatus;
 }
-export interface AccountAptosAsset {
+export interface AccountAptosAsset extends AssetIdentifiers {
   chain: AptosChain;
   asset: AptosAsset;
   address: AccountAddress;
@@ -369,7 +375,7 @@ export interface AccountSuiAssetFetchStatus extends AssetFetchStatus {
   reward?: RequestStatus;
 }
 
-export interface AccountSuiAsset {
+export interface AccountSuiAsset extends AssetIdentifiers {
   chain: SuiChain;
   asset: SuiAsset;
   address: AccountAddress;
@@ -380,7 +386,7 @@ export interface AccountSuiAsset {
   lastUpdatedAtMs?: number | null;
   fetchStatus?: AccountSuiAssetFetchStatus;
 }
-export interface AccountBitcoinAsset {
+export interface AccountBitcoinAsset extends AssetIdentifiers {
   chain: BitcoinChain;
   asset: BitcoinAsset;
   address: AccountAddress;
@@ -390,7 +396,7 @@ export interface AccountBitcoinAsset {
 }
 
 export interface AccountIotaAssetFetchStatus extends AccountSuiAssetFetchStatus {}
-export interface AccountGnoAsset {
+export interface AccountGnoAsset extends AssetIdentifiers {
   chain: GnoChain;
   asset: GnoAsset;
   address: AccountAddress;
@@ -399,7 +405,7 @@ export interface AccountGnoAsset {
   fetchStatus?: AssetFetchStatus;
 }
 
-export interface AccountGrc20Asset {
+export interface AccountGrc20Asset extends AssetIdentifiers {
   chain: GnoChain;
   asset: GnoGrc20Asset;
   address: AccountAddress;
@@ -407,7 +413,7 @@ export interface AccountGrc20Asset {
   lastUpdatedAtMs?: number | null;
   fetchStatus?: AssetFetchStatus;
 }
-export interface AccountIotaAsset {
+export interface AccountIotaAsset extends AssetIdentifiers {
   chain: IotaChain;
   asset: IotaAsset;
   address: AccountAddress;
@@ -419,7 +425,7 @@ export interface AccountIotaAsset {
   fetchStatus?: AccountIotaAssetFetchStatus;
 }
 
-export interface AccountSolanaAsset {
+export interface AccountSolanaAsset extends AssetIdentifiers {
   chain: SolanaChain;
   asset: SolanaAsset;
   address: AccountAddress;
@@ -428,7 +434,7 @@ export interface AccountSolanaAsset {
   fetchStatus?: AssetFetchStatus;
 }
 
-export interface AccountSpltokenAsset {
+export interface AccountSpltokenAsset extends AssetIdentifiers {
   chain: SolanaChain;
   asset: SolanaSpltokenAsset;
   address: AccountAddress;

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -6,6 +6,8 @@ export interface AssetId {
   chainType: ChainType;
 }
 
+export type UniqueCoinId = `${AssetId['id']}__${AssetId['chainId']}__${AssetId['chainType']}`;
+
 export interface AssetBase extends AssetId {
   name: string;
   symbol: string;

--- a/src/types/cosmos/fee.ts
+++ b/src/types/cosmos/fee.ts
@@ -1,8 +1,8 @@
-import type { AccountAddress } from '../account';
+import type { AccountAddress, AssetIdentifiers } from '../account';
 import type { CosmosAsset, CustomCosmosAsset } from '../asset';
 import type { CosmosChain, CustomCosmosChain } from '../chain';
 
-export interface CosmosFeeAsset {
+export interface CosmosFeeAsset extends AssetIdentifiers {
   gasRate: string[];
   chain: CosmosChain;
   asset: CosmosAsset | CustomCosmosAsset;

--- a/src/types/gno/fee.ts
+++ b/src/types/gno/fee.ts
@@ -1,8 +1,8 @@
-import type { AccountAddress } from '../account';
+import type { AccountAddress, AssetIdentifiers } from '../account';
 import type { GnoAsset } from '../asset';
 import type { GnoChain } from '../chain';
 
-export interface GnoFeeAsset {
+export interface GnoFeeAsset extends AssetIdentifiers {
   gasRate: string[];
   chain: GnoChain;
   asset: GnoAsset;

--- a/src/types/store/portfolioValue.ts
+++ b/src/types/store/portfolioValue.ts
@@ -1,0 +1,10 @@
+export interface PortfolioValueState {
+  totalValue: string;
+  hasAssets: boolean;
+}
+
+export type PortfolioValueActions = {
+  setPortfolioValue: (totalValue: string, hasAssets: boolean) => void;
+};
+
+export type PortfolioValueStore = PortfolioValueState & PortfolioValueActions;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -11,3 +11,15 @@ export function removeDuplicates<T>(list: T[], isDuplicate: (a: T, b: T) => bool
     return acc;
   }, []);
 }
+
+export function sortByReference<T, K>(target: T[], reference: K[], isEqual: (a: T, b: K) => boolean): T[] {
+  return [...target].sort((a, b) => {
+    const idxA = reference.findIndex((ref) => isEqual(a, ref));
+    const idxB = reference.findIndex((ref) => isEqual(b, ref));
+
+    const weightA = idxA < 0 ? Number.MAX_SAFE_INTEGER : idxA;
+    const weightB = idxB < 0 ? Number.MAX_SAFE_INTEGER : idxB;
+
+    return weightA - weightB;
+  });
+}

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -1,9 +1,13 @@
 import { NATIVE_EVM_COIN_ADDRESS } from '@/constants/evm';
+import { DASHBOARD_COIN_SORT_KEY } from '@/constants/sortKey';
 import type { AccountCosmosAsset, AccountEvmAsset, AccountIotaAsset, AccountSuiAsset } from '@/types/account';
 import type { FlatAccountAssets } from '@/types/accountAssets';
 import type { Chain, CustomChain, UniqueChainId } from '@/types/chain';
+import type { CommonSortKeyType } from '@/types/sortKey';
 
-import { getUniqueChainId, getUniqueChainIdWithManual, isMatchingUniqueChainId, isSameChain, parseUniqueChainId } from './queryParamGenerator';
+import { sortByReference } from './array';
+import { minus } from './numbers';
+import { getUniqueChainIdWithManual, isSameChain, parseUniqueChainId } from './queryParamGenerator';
 import { isEqualsIgnoringCase } from './string';
 
 export function filterChainsByChainId<T extends Chain>(chains: T[]): T[] {
@@ -27,8 +31,8 @@ export function getFilteredChainsByChainId<T extends FlatAccountAssets>(accountA
   const shouldCheckEthermint = !option?.disableDupeEthermint;
 
   for (const asset of accountAssets) {
-    const { chain, address } = asset;
-    const chainKey = getUniqueChainId(chain);
+    const { chain, address, uniqueChainId } = asset;
+    const chainKey = uniqueChainId;
 
     if (chainMap.has(chainKey)) continue;
 
@@ -73,7 +77,7 @@ export function getFilteredAssetsByChainId<T extends FlatAccountAssets>(
   const result: T[] = [];
 
   for (const asset of accountAssets) {
-    const { chain, address } = asset;
+    const { chain, address, uniqueChainId: assetUniqueChainId } = asset;
 
     if (shouldCheckEthermint && address.accountType.pubkeyStyle === 'keccak256' && chain.chainType === 'cosmos' && chain.isEvm) {
       if (chain.id === targetChainId) {
@@ -82,7 +86,7 @@ export function getFilteredAssetsByChainId<T extends FlatAccountAssets>(
       continue;
     }
 
-    if (isMatchingUniqueChainId(chain, uniqueChainId)) {
+    if (assetUniqueChainId === uniqueChainId) {
       result.push(asset);
     }
   }
@@ -110,7 +114,7 @@ export function getMainAssetByChainId<T extends FlatAccountAssets>(
 
     return (
       item.chain.mainAssetDenom &&
-      getUniqueChainId(item.chain) === uniqueChainId &&
+      item.uniqueChainId === uniqueChainId &&
       isEqualsIgnoringCase(item.asset.id, XRPL_CHAINS_ID.includes(item.chain.id) ? NATIVE_EVM_COIN_ADDRESS : item.chain.mainAssetDenom)
     );
   });
@@ -150,12 +154,7 @@ export function getDefaultAssetsByChainId<T extends FlatAccountAssets>(accountAs
 
   if (!defaultCoins?.length) return undefined;
 
-  return defaultCoins.toSorted((a, b) => {
-    const denoms = a.chain.chainDefaultCoinDenoms ?? [];
-    const idxA = denoms.findIndex((d) => isEqualsIgnoringCase(d, a.asset.id));
-    const idxB = denoms.findIndex((d) => isEqualsIgnoringCase(d, b.asset.id));
-    return (idxA < 0 ? Number.MAX_SAFE_INTEGER : idxA) - (idxB < 0 ? Number.MAX_SAFE_INTEGER : idxB);
-  });
+  return sortByReference(defaultCoins, defaultCoins[0]?.chain.chainDefaultCoinDenoms ?? [], (coin, denom) => isEqualsIgnoringCase(coin.asset.id, denom));
 }
 
 export function isAccountCosmosStakableAsset(asset: FlatAccountAssets): asset is AccountCosmosAsset {
@@ -176,4 +175,23 @@ export function isAccountIotaStakableAsset(asset: FlatAccountAssets): asset is A
 
 export function isStakeableAsset(asset: FlatAccountAssets): asset is AccountCosmosAsset | AccountEvmAsset | AccountSuiAsset | AccountIotaAsset {
   return isAccountCosmosStakableAsset(asset) || isAccountEVMStakableAsset(asset) || isAccountSuiStakableAsset(asset) || isAccountIotaStakableAsset(asset);
+}
+
+export function sortAssetsByKey<T extends { value: string; asset: { symbol: string } }>(assets: T[], sortKey: CommonSortKeyType): T[] {
+  return [...assets].sort((a, b) => {
+    if (sortKey === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {
+      return Number(minus(b.value, a.value));
+    }
+    if (sortKey === DASHBOARD_COIN_SORT_KEY.ALPHABETICAL_ASC) {
+      return a.asset.symbol.localeCompare(b.asset.symbol);
+    }
+    return 0;
+  });
+}
+
+export function filterAssetsBySearch<T extends { asset: { symbol: string; id: string } }>(assets: T[], search: string, debouncedSearch: string): T[] {
+  if (!search || debouncedSearch.length <= 1) return assets;
+
+  const lowerSearch = debouncedSearch.toLowerCase();
+  return assets.filter((asset) => [asset.asset.symbol, asset.asset.id].some((target) => target.toLowerCase().includes(lowerSearch)));
 }

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -143,6 +143,21 @@ export function getDefaultAssets<T extends FlatAccountAssets>(
   });
 }
 
+export function getDefaultAssetsByChainId<T extends FlatAccountAssets>(accountAssets?: T[], uniqueChainId?: UniqueChainId | null): T[] | undefined {
+  if (!uniqueChainId || !accountAssets || accountAssets.length === 0) return undefined;
+
+  const defaultCoins = getDefaultAssets(getFilteredAssetsByChainId(accountAssets, uniqueChainId));
+
+  if (!defaultCoins?.length) return undefined;
+
+  return defaultCoins.toSorted((a, b) => {
+    const denoms = a.chain.chainDefaultCoinDenoms ?? [];
+    const idxA = denoms.findIndex((d) => isEqualsIgnoringCase(d, a.asset.id));
+    const idxB = denoms.findIndex((d) => isEqualsIgnoringCase(d, b.asset.id));
+    return (idxA < 0 ? Number.MAX_SAFE_INTEGER : idxA) - (idxB < 0 ? Number.MAX_SAFE_INTEGER : idxB);
+  });
+}
+
 export function isAccountCosmosStakableAsset(asset: FlatAccountAssets): asset is AccountCosmosAsset {
   return asset.chain.chainType === 'cosmos' && asset.asset.type === 'native' && 'delegation' in asset;
 }

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -177,6 +177,10 @@ export function isStakeableAsset(asset: FlatAccountAssets): asset is AccountCosm
   return isAccountCosmosStakableAsset(asset) || isAccountEVMStakableAsset(asset) || isAccountSuiStakableAsset(asset) || isAccountIotaStakableAsset(asset);
 }
 
+export function getStakeableBalance(item: FlatAccountAssets) {
+  return isStakeableAsset(item) ? item.totalBalance || item.balance || '0' : item.balance;
+}
+
 export function sortAssetsByKey<T extends { value: string; asset: { symbol: string } }>(assets: T[], sortKey: CommonSortKeyType): T[] {
   return [...assets].sort((a, b) => {
     if (sortKey === DASHBOARD_COIN_SORT_KEY.VALUE_HIGH_ORDER) {

--- a/src/utils/asset.ts
+++ b/src/utils/asset.ts
@@ -193,9 +193,9 @@ export function sortAssetsByKey<T extends { value: string; asset: { symbol: stri
   });
 }
 
-export function filterAssetsBySearch<T extends { asset: { symbol: string; id: string } }>(assets: T[], search: string, debouncedSearch: string): T[] {
-  if (!search || debouncedSearch.length <= 1) return assets;
+export function filterAssetsBySearch<T extends { asset: { symbol: string; id: string } }>(assets: T[], search: string, isSearchEmpty: boolean): T[] {
+  if (isSearchEmpty || search.length <= 1) return assets;
 
-  const lowerSearch = debouncedSearch.toLowerCase();
+  const lowerSearch = search.toLowerCase();
   return assets.filter((asset) => [asset.asset.symbol, asset.asset.id].some((target) => target.toLowerCase().includes(lowerSearch)));
 }

--- a/src/utils/queryParamGenerator.ts
+++ b/src/utils/queryParamGenerator.ts
@@ -32,7 +32,7 @@ export function isMatchingCoinId(baseCoin: AssetId, targetCoinId: string) {
   return getCoinId(baseCoin) === targetCoinId;
 }
 
-export function getMatchinCoinFromCoinId<T extends FlatAccountAssets>(assets?: T[], targetCoinId?: UniqueCoinId | string): T | undefined {
+export function getMatchingCoinFromCoinId<T extends FlatAccountAssets>(assets?: T[], targetCoinId?: UniqueCoinId | string): T | undefined {
   return assets?.find(({ uniqueCoinId }) => uniqueCoinId === targetCoinId);
 }
 

--- a/src/utils/queryParamGenerator.ts
+++ b/src/utils/queryParamGenerator.ts
@@ -1,5 +1,6 @@
 import type { Account, MnemonicAccount } from '@/types/account';
-import type { AssetId } from '@/types/asset';
+import type { FlatAccountAssets } from '@/types/accountAssets';
+import type { AssetId, UniqueCoinId } from '@/types/asset';
 import type { ChainId, ChainType, UniqueChainId } from '@/types/chain';
 
 export function getMnemonicId(account: Account): account is MnemonicAccount {
@@ -7,6 +8,10 @@ export function getMnemonicId(account: Account): account is MnemonicAccount {
 }
 
 export function getCoinId(coinAsset: AssetId) {
+  return `${coinAsset.id}__${coinAsset.chainId}__${coinAsset.chainType}`;
+}
+
+export function getUniqueCoinId(coinAsset: AssetId): UniqueCoinId {
   return `${coinAsset.id}__${coinAsset.chainId}__${coinAsset.chainType}`;
 }
 
@@ -25,6 +30,10 @@ export function parseCoinId(coinId: string) {
 
 export function isMatchingCoinId(baseCoin: AssetId, targetCoinId: string) {
   return getCoinId(baseCoin) === targetCoinId;
+}
+
+export function getMatchinCoinFromCoinId<T extends FlatAccountAssets>(assets?: T[], targetCoinId?: UniqueCoinId | string): T | undefined {
+  return assets?.find(({ uniqueCoinId }) => uniqueCoinId === targetCoinId);
 }
 
 export function isSameCoin(baseCoin: AssetId, targetCoin: AssetId) {

--- a/src/zustand/hooks/usePortfolioValueStore.ts
+++ b/src/zustand/hooks/usePortfolioValueStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+import type { PortfolioValueState, PortfolioValueStore } from '@/types/store/portfolioValue';
+
+const initialState: PortfolioValueState = {
+  totalValue: '0',
+  hasAssets: false,
+};
+
+export const usePortfolioValueStore = create<PortfolioValueStore>()((set) => ({
+  ...initialState,
+  setPortfolioValue: (totalValue, hasAssets) => {
+    set({ totalValue, hasAssets });
+  },
+}));


### PR DESCRIPTION

- PorFolio페이지 리팩토링
  - 내부 컴포넌트 분리

- asset 필터링 로직 개선
  - visible / hidden 필터링로직에 set/map도입
  - AccountAsset  랩핑 시 `uniqueCoinId`필드를 생성하여 사용처에서 coinId를 계산하지 않도록 변경
