### PR TITLE
[APIS-740] fix cosmos pagination limit and URL encoding

### DIFF
--- a/src/hooks/cosmos/useValidators.ts
+++ b/src/hooks/cosmos/useValidators.ts
@@ -56,7 +56,7 @@ export function useValidators({ coinId, config }: UseValidatorsProps) {
       let nextCursor = response?.pagination.next_key;
 
       while (nextCursor) {
-        const nextCursorRequestURL = `${requestURLs[index]}?pagination.key=${nextCursor}`;
+        const nextCursorRequestURL = `${requestURLs[index]}&pagination.key=${encodeURIComponent(nextCursor)}`;
 
         const nextResponse = await get<GetValidatorsResponse>(nextCursorRequestURL, {
           timeout: DEFAULT_FETCH_TIME_OUT_MS * 5,
@@ -125,7 +125,7 @@ export function useValidators({ coinId, config }: UseValidatorsProps) {
   };
 
   const { data, isLoading, error, refetch } = useFetch({
-    queryKey: ['cosmosValidaotrsInfo', coinId],
+    queryKey: ['cosmosValidatorsInfo', coinId],
     fetchFunction: () => fetcher(),
     config: {
       retry: false,

--- a/src/utils/cosmos/fetch/balance.ts
+++ b/src/utils/cosmos/fetch/balance.ts
@@ -18,7 +18,7 @@ export const fetchCosmosBalances = async (
     const urlPath = option?.path || `/cosmos/bank/v1beta1/balances/${address}`;
 
     const requestUrl = buildRequestUrl(lcdUrl, urlPath, {
-      'pagination.limit': '10000',
+      'pagination.limit': '2000',
     });
 
     const response = await getWithFullResponse<CosmosBalanceResponse>(requestUrl, {
@@ -32,7 +32,7 @@ export const fetchCosmosBalances = async (
 
     while (nextKey) {
       try {
-        const paginatedRequestUrl = `${requestUrl}&pagination.key=${nextKey}`;
+        const paginatedRequestUrl = `${requestUrl}&pagination.key=${encodeURIComponent(nextKey)}`;
 
         const paginatedResponse = await getWithFullResponse<CosmosBalanceResponse>(paginatedRequestUrl, {
           timeout: BALANCE_FETCH_TIME_OUT_MS,

--- a/src/utils/crypto/cosmos.ts
+++ b/src/utils/crypto/cosmos.ts
@@ -6,7 +6,7 @@ import { toBase64 } from '../string';
 export function cosmosURL(lcdURL: string, chainId: string) {
   return {
     getNodeInfo: () => buildRequestUrl(lcdURL, `/cosmos/base/tendermint/v1beta1/node_info`),
-    getBalance: (address: string) => buildRequestUrl(lcdURL, `/cosmos/bank/v1beta1/balances/${address}?pagination.limit=10000`),
+    getBalance: (address: string) => buildRequestUrl(lcdURL, `/cosmos/bank/v1beta1/balances/${address}?pagination.limit=2000`),
     getDelegations: (address: string) => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/delegations/${address}`),
     getRewards: (address: string) => buildRequestUrl(lcdURL, `/cosmos/distribution/v1beta1/delegators/${address}/rewards`),
     getUndelegations: (address: string) => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/delegators/${address}/unbonding_delegations`),
@@ -37,7 +37,7 @@ export function cosmosURL(lcdURL: string, chainId: string) {
     getBlockLatest: () => buildRequestUrl(lcdURL, `/cosmos/base/tendermint/v1beta1/blocks/latest`),
     getCommission: (validatorAddress: string) => buildRequestUrl(lcdURL, `/cosmos/distribution/v1beta1/validators/${validatorAddress}/commission`),
     getFeemarket: (denom?: string) => buildRequestUrl(lcdURL, `/feemarket/v1/gas_prices${denom ? `/${denom}` : ''}`),
-    getValidators: () => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/validators?pagination.limit=10000`),
+    getValidators: () => buildRequestUrl(lcdURL, `/cosmos/staking/v1beta1/validators?pagination.limit=2000`),
     getNTRNRewards: (contractAddress: string, address: string) =>
       buildRequestUrl(lcdURL, `/cosmwasm/wasm/v1/contract/${contractAddress}/smart/${encodeURIComponent(toBase64(`{"rewards":{"user":"${address}"}}`))}`),
   };


### PR DESCRIPTION
- Reduce pagination.limit from 10000 to 2000 for better node compatibility
- Fix URL parameter separator (? → &) in useValidators pagination
- Add encodeURIComponent for pagination.key to handle base64 special characters
- Fix typo in query key (cosmosValidaotrsInfo → cosmosValidatorsInfo)